### PR TITLE
Updated AbstractMCMC compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
-AbstractMCMC = "~0.1"
+AbstractMCMC = "0.1. 0.2, 0.3"
 AdvancedHMC = "0.2.20"
 Bijectors = "0.5.2"
 Distributions = "0.22"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
-AbstractMCMC = "0"
+AbstractMCMC = "0.1, 0.2, 0.3"
 AdvancedHMC = "0.2.20"
 Bijectors = "0.5.2"
 Distributions = "0.22"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
-AbstractMCMC = "0.1. 0.2, 0.3"
+AbstractMCMC = "0"
 AdvancedHMC = "0.2.20"
 Bijectors = "0.5.2"
 Distributions = "0.22"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
 authors = ["mohamed82008 <mohamed82008@gmail.com>"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"


### PR DESCRIPTION
Updates DynamicPPL to have significantly less restrictive compatibility with AbstractMCMC, since the things that DynamicPPL uses are very core to AbstractMCMC and are unlikely to change pre-`AbstractMCMC@1.0`.