### PR TITLE
Refactor VarName

### DIFF
--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -44,6 +44,7 @@ export  AbstractVarInfo,
 #VarName
         VarName,
         inspace,
+        subsumes,
 # Compiler
         ModelGen,
         @model,

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -5,11 +5,9 @@ using Distributions
 using Bijectors
 using MacroTools
 
-import Base: string,
-             Symbol,
+import Base: Symbol,
              ==,
              hash,
-             in,
              getindex,
              setindex!,
              push!,
@@ -22,8 +20,7 @@ import Base: string,
              haskey
 
 # VarInfo
-export  VarName,
-        AbstractVarInfo,
+export  AbstractVarInfo,
         VarInfo,
         UntypedVarInfo,
         getlogp,
@@ -44,6 +41,9 @@ export  VarName,
         link!,
         invlink!,
         tonamedtuple,
+#VarName
+        VarName,
+        inspace,
 # Compiler
         ModelGen,
         @model,

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -70,7 +70,7 @@ end
 To generate a `Model`, call `model_generator(x_value)`.
 """
 macro model(input_expr)
-    build_model_info(input_expr) |> replace_tilde! |> replace_vi! |> 
+    Base.replace_ref_end!(input_expr) |> build_model_info |> replace_tilde! |> replace_vi! |> 
         replace_logpdf! |> replace_sampler! |> build_output
 end
 

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -184,7 +184,7 @@ function get_vns_and_dist(
     var::AbstractArray, 
     vn::VarName
 )
-    getvn = ind -> VarName(vn, (vn.indexing..., ind))
+    getvn = ind -> VarName(vn, (vn.indexing..., Tuple(ind)))
     return getvn.(CartesianIndices(var)), dist
 end
 

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -40,15 +40,6 @@ function _tilde(sampler, right, vn::VarName, vi)
 end
 function _tilde(sampler, right::NamedDist, vn::VarName, vi)
     name = right.name
-    if name isa String
-        vn = parse(VarName, name)
-    elseif name isa Symbol
-        vn = VarName{name}(())
-    elseif name isa VarName
-        vn = name
-    else
-        throw("Unsupported variable name. Please use either a string, symbol or VarName.")
-    end
     return _tilde(sampler, right.dist, vn, vi)
 end
 
@@ -163,15 +154,6 @@ end
 
 function get_vns_and_dist(dist::NamedDist, var, vn::VarName)
     name = dist.name
-    if name isa String
-        vn = parse(VarName, name)
-    elseif name isa Symbol
-        vn = VarName{name}(())
-    elseif name isa VarName
-        vn = name
-    else
-        throw("Unsupported variable name. Please use either a string, symbol or VarName.")
-    end
     return get_vns_and_dist(dist.dist, var, vn)
 end
 function get_vns_and_dist(dist::MultivariateDistribution, var::AbstractMatrix, vn::VarName)

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -39,8 +39,7 @@ function _tilde(sampler, right, vn::VarName, vi)
     return assume(sampler, right, vn, vi)
 end
 function _tilde(sampler, right::NamedDist, vn::VarName, vi)
-    name = right.name
-    return _tilde(sampler, right.dist, vn, vi)
+    return _tilde(sampler, right.dist, right.name, vi)
 end
 
 # observe
@@ -153,8 +152,7 @@ function dot_tilde(
 end
 
 function get_vns_and_dist(dist::NamedDist, var, vn::VarName)
-    name = dist.name
-    return get_vns_and_dist(dist.dist, var, vn)
+    return get_vns_and_dist(dist.dist, var, dist.name)
 end
 function get_vns_and_dist(dist::MultivariateDistribution, var::AbstractMatrix, vn::VarName)
     getvn = i -> VarName(vn, (vn.indexing..., (Colon(), i)))

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -41,11 +41,9 @@ end
 function _tilde(sampler, right::NamedDist, vn::VarName, vi)
     name = right.name
     if name isa String
-        sym_str, inds = split_var_str(name, String)
-        sym = Symbol(sym_str)
-        vn = VarName{sym}(inds)
+        vn = parse(VarName, name)
     elseif name isa Symbol
-        vn = VarName{name}("")
+        vn = VarName{name}(())
     elseif name isa VarName
         vn = name
     else
@@ -166,11 +164,9 @@ end
 function get_vns_and_dist(dist::NamedDist, var, vn::VarName)
     name = dist.name
     if name isa String
-        sym_str, inds = split_var_str(name, String)
-        sym = Symbol(sym_str)
-        vn = VarName{sym}(inds)
+        vn = parse(VarName, name)
     elseif name isa Symbol
-        vn = VarName{name}("")
+        vn = VarName{name}(())
     elseif name isa VarName
         vn = name
     else
@@ -179,15 +175,16 @@ function get_vns_and_dist(dist::NamedDist, var, vn::VarName)
     return get_vns_and_dist(dist.dist, var, vn)
 end
 function get_vns_and_dist(dist::MultivariateDistribution, var::AbstractMatrix, vn::VarName)
-    getvn = i -> VarName(vn, vn.indexing * "[Colon(),$i]")
+    getvn = i -> VarName(vn, (vn.indexing..., (Colon(), i)))
     return getvn.(1:size(var, 2)), dist
+    
 end
 function get_vns_and_dist(
     dist::Union{Distribution, AbstractArray{<:Distribution}}, 
     var::AbstractArray, 
     vn::VarName
 )
-    getvn = ind -> VarName(vn, vn.indexing * "[" * join(Tuple(ind), ",") * "]")
+    getvn = ind -> VarName(vn, (vn.indexing..., ind))
     return getvn.(CartesianIndices(var)), dist
 end
 

--- a/src/distribution_wrappers.jl
+++ b/src/distribution_wrappers.jl
@@ -21,7 +21,7 @@ struct NamedDist{
         new{variate, support, typeof(dist), name}(dist, vn)
 end
 
-NamedDist(dist::Distribution, name::Symbol) = NamedDist(dist, VarName{name}())
+NamedDist(dist::Distribution, name::Symbol) = NamedDist(dist, VarName(name))
 
 
 struct NoDist{

--- a/src/distribution_wrappers.jl
+++ b/src/distribution_wrappers.jl
@@ -16,11 +16,10 @@ struct NamedDist{
 } <: Distribution{variate, support}
     dist::Td
     name::VarName{name}
-
-    NamedDist(dist::Distribution{variate, support}, vn::VarName{name}) where {variate, support, name} =
-        new{variate, support, typeof(dist), name}(dist, vn)
 end
 
+NamedDist(dist::Distribution{variate, support}, vn::VarName{name}) where {variate, support, name} =
+    NamedDist{variate, support, typeof(dist), name}(dist, vn)
 NamedDist(dist::Distribution, name::Symbol) = NamedDist(dist, VarName(name))
 
 

--- a/src/distribution_wrappers.jl
+++ b/src/distribution_wrappers.jl
@@ -11,12 +11,17 @@ A named distribution that carries the name of the random variable with it.
 struct NamedDist{
     variate, 
     support, 
-    Td <: Distribution{variate, support}, 
-    Tn
+    Td <: Distribution{variate, support},
+    name
 } <: Distribution{variate, support}
     dist::Td
-    name::Tn
+    name::VarName{name}
+
+    NamedDist(dist::Distribution{variate, support}, vn::VarName{name}) where {variate, support, name} =
+        new{variate, support, typeof(dist), name}(dist, vn)
 end
+
+NamedDist(dist::Distribution, name::Symbol) = NamedDist(dist, VarName{name}())
 
 
 struct NoDist{

--- a/src/distribution_wrappers.jl
+++ b/src/distribution_wrappers.jl
@@ -12,10 +12,10 @@ struct NamedDist{
     variate, 
     support, 
     Td <: Distribution{variate, support},
-    name
+    Tv <: VarName
 } <: Distribution{variate, support}
     dist::Td
-    name::VarName{name}
+    name::Tv
 end
 
 NamedDist(dist::Distribution, name::Symbol) = NamedDist(dist, VarName(name))

--- a/src/distribution_wrappers.jl
+++ b/src/distribution_wrappers.jl
@@ -18,8 +18,6 @@ struct NamedDist{
     name::VarName{name}
 end
 
-NamedDist(dist::Distribution{variate, support}, vn::VarName{name}) where {variate, support, name} =
-    NamedDist{variate, support, typeof(dist), name}(dist, vn)
 NamedDist(dist::Distribution, name::Symbol) = NamedDist(dist, VarName(name))
 
 

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -333,13 +333,6 @@ setall!(vi::TypedVarInfo, val) = _setall!(vi.metadata, val)
 end
 
 """
-    getsym(vn::VarName)
-
-Return the symbol of the Julia variable used to generate `vn`.
-"""
-getsym(vn::VarName{sym}) where sym = sym
-
-"""
     getgid(vi::VarInfo, vn::VarName)
 
 Return the set of sampler selectors associated with `vn` in `vi`.
@@ -490,69 +483,6 @@ end
 #### APIs for typed and untyped VarInfo
 ####
 
-# VarName
-
-"""
-    VarName(sym, indexing)
-    VarName{sym}(indexing::String)
-
-Construct a new instance of `VarName{sym}`
-"""
-VarName(sym, indexing) = VarName{sym}(indexing)
-
-"""
-    VarName(vn::VarName, indexing::String)
-
-Return a copy of `vn` with a new index `indexing`.
-"""
-function VarName(vn::VarName, indexing::String)
-    return VarName{getsym(vn)}(indexing)
-end
-
-"""
-    uid(vn::VarName)
-
-Return a unique tuple identifier for `vn`.
-"""
-uid(vn::VarName) = (getsym(vn), vn.indexing)
-
-hash(vn::VarName) = hash(uid(vn))
-
-==(x::VarName, y::VarName) = hash(uid(x)) == hash(uid(y))
-
-function string(vn::VarName)
-    return "$(getsym(vn))$(vn.indexing)"
-end
-function string(vns::Vector{<:VarName})
-    return replace(string(map(string, vns)), "String" => "")
-end
-
-"""
-    Symbol(vn::VarName)
-
-Return a `Symbol` represenation of the variable identifier `VarName`.
-"""
-Symbol(vn::VarName) = Symbol(string(vn))  # simplified symbol
-
-"""
-    in(vn::VarName, space::Set)
-
-Check whether `vn`'s symbol is in `space`.
-"""
-in(::VarName, ::Tuple{}) = true
-in(vn::VarName, space::Tuple)::Bool = getsym(vn) in space || _in(string(vn), space)
-
-_in(::String, ::Tuple{}) = false
-_in(vn_str::String, space::Tuple)::Bool = _in(vn_str, Base.tail(space))
-function _in(vn_str::String, space::Tuple{Expr,Vararg})::Bool
-    # Collect expressions from space
-    expr = first(space)
-    # Filter `(` and `)` out and get a string representation of `exprs`
-    expr_str = replace(string(expr), r"\(|\)" => "")
-    # Check if `vn_str` is in `expr_strs`
-    valid = occursin(expr_str, vn_str)
-    return valid || _in(vn_str, Base.tail(space))
-end
 
 # VarInfo
 

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -413,7 +413,7 @@ end
     # Get all the idcs of the vns in `space` and that belong to the selector `s`
     return filter((i) ->
         (s in f_meta.gids[i] || isempty(f_meta.gids[i])) &&
-        (isempty(space) || in(f_meta.vns[i], space)), 1:length(f_meta.gids))
+        (isempty(space) || inspace(f_meta.vns[i], space)), 1:length(f_meta.gids))
 end
 @inline function findinds(f_meta)
     # Get all the idcs of the vns

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -127,7 +127,7 @@ end
     offset = :(0)
     for f in names
         mdf = :(metadata.$f)
-        if f in space || length(space) == 0
+        if inspace(f, space) || length(space) == 0
             len = :(length($mdf.vals))
             push!(exprs, :($f = Metadata($mdf.idcs,
                                         $mdf.vns,
@@ -402,7 +402,7 @@ end
         # If the varname is in the sampler space
         # or the sample space is empty (all variables)
         # then return the indices for that variable.
-        if f in space || length(space) == 0
+        if inspace(f, space) || length(space) == 0
             push!(exprs, :($f = findinds(metadata.$f, s, Val($space))))
         end
     end
@@ -554,8 +554,7 @@ function TypedVarInfo(vi::UntypedVarInfo)
         sym_vals = foldl(vcat, _vals)
 
         push!(new_metas, Metadata(sym_idcs, sym_vns, sym_ranges, sym_vals,
-                                    sym_dists, sym_gids, sym_orders, sym_flags)
-            )
+                                  sym_dists, sym_gids, sym_orders, sym_flags))
     end
     logp = getlogp(vi)
     num_produce = get_num_produce(vi)
@@ -716,7 +715,7 @@ end
 @generated function _link!(metadata::NamedTuple{names}, vi, vns, ::Val{space}) where {names, space}
     expr = Expr(:block)
     for f in names
-        if f in space || length(space) == 0
+        if inspace(f, space) || length(space) == 0
             push!(expr.args, quote
                 f_vns = vi.metadata.$f.vns
                 if ~istrans(vi, f_vns[1])
@@ -762,7 +761,7 @@ end
 @generated function _invlink!(metadata::NamedTuple{names}, vi, vns, ::Val{space}) where {names, space}
     expr = Expr(:block)
     for f in names
-        if f in space || length(space) == 0
+        if inspace(f, space) || length(space) == 0
             push!(expr.args, quote
                 f_vns = vi.metadata.$f.vns
                 if istrans(vi, f_vns[1])
@@ -1125,7 +1124,7 @@ Set `vn`'s `gid` to `Set([spl.selector])`, if `vn` does not have a sampler selec
 and `vn`'s symbol is in the space of `spl`.
 """
 function updategid!(vi::AbstractVarInfo, vn::VarName, spl::Sampler)
-    if vn in getspace(spl)
+    if inspace(vn, getspace(spl))
         setgid!(vi, spl.selector, vn)
     end
 end

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -27,6 +27,7 @@ struct VarName{sym, T<:Tuple}
 end
 
 VarName{sym}(indexing::T) where {sym, T<:Tuple} = VarName{sym, T}(indexing)
+VarName{sym}() where {sym} = VarName{sym}(())
 VarName(sym, indexing) = VarName{sym}(indexing)
 
 """
@@ -67,8 +68,6 @@ function show(io::IO, vn::VarName)
     end
 end
 
-parse(::Type{VarName}, name::AbstractString) = varname(Meta.parse(name))
-
 
 """
     Symbol(vn::VarName)
@@ -97,7 +96,6 @@ function _in(vn_str::String, space::Tuple{Expr,Vararg})::Bool
     valid = occursin(expr_str, vn_str)
     return valid || _in(vn_str, Base.tail(space))
 end
-
 
 
 """

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -58,7 +58,7 @@ function Base.show(io::IO, vn::VarName)
     print(io, getsym(vn))
     for indices in getindexing(vn)
         print(io, "[")
-        join(io, indices, ", ")
+        join(io, indices, ",")
         print(io, "]")
     end
 end

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -87,9 +87,11 @@ _isprefix(::Tuple{}, ::Tuple) = true
 _isprefix(::Tuple, ::Tuple{}) = false
 _isprefix(t::Tuple, u::Tuple) = _subsumes(first(t), first(u)) && _isprefix(Base.tail(t), Base.tail(u))
 
-_subsumes(i::Union{Int, UnitRange{Int}}, j::Union{Int, UnitRange{Int}}) = issubset(i, j)
-_subsumes(i::Union{Int, UnitRange{Int}, Colon}, j::Colon) = true
-_subsumes(i::Colon, ::Union{Int, UnitRange{Int}}) = false
+const ConcreteIndex = Union{Int, AbstractVector{Int}} # this include all kinds of ranges
+"""Determine whether `i` is a valid if `j` is."""
+_subsumes(i::ConcreteIndex, j::ConcreteIndex) = issubset(i, j)
+_subsumes(i::Union{ConcreteIndex, Colon}, j::Colon) = true
+_subsumes(i::Colon, j::ConcreteIndex) = false
 
 _name(vn::Symbol) = vn
 _name(vn::VarName) = getsym(vn)

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -82,6 +82,12 @@ inspace(vn, space::Tuple) = vn in space
 inspace(vn::VarName, space::Tuple{}) = true
 inspace(vn::VarName, space::Tuple) = any(_in(vn, s) for s in space)
 
+@noinline function Base.in(vn::VarName, space::Tuple)
+    Base.depwarn("`Base.in(vn::VarName, space::Tuple)` is deprecated, use `inspace(vn, space)` instead.",
+                 nameof(Base.in))
+    return inspace(vn, space)
+end
+
 _in(vn::VarName, s::Symbol) = getsym(vn) == s
 _in(vn::VarName, s::VarName) = subsumes(s, vn)
 

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -86,6 +86,7 @@ _inspace(vn::VarName{s}, space::Tuple{Symbol, Vararg}) where {s} =
     s == first(space) || _inspace(vn, Base.tail(space))
 function _inspace(vn::VarName{s}, space::Tuple{Expr, Vararg}) where {s}
     expr = first(space)
+    Meta.isexpr(expr, :ref) || throw("VarName: Mis-formed variable name $(expr)!")
     ip = expr.args[1] == s && isprefix(tuple(expr.args[2:end]), vn.indexing)
     return ip || _inspace(vn, Base.tail(space))
 end

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -1,5 +1,4 @@
-import Base: hash, parse, show, Symbol
-import Base: ==
+import Base: ==, hash, show, Symbol
 
 """
 ```
@@ -54,10 +53,10 @@ Return the indexing tuple of the Julia variable used to generate `vn`.
 getindexing(vn::VarName) = vn.indexing
 
 
-hash(vn::VarName, h::UInt) = hash((getsym(vn), getindexing(vn)), h)
-==(x::VarName{S}, y::VarName{T}) where {S, T} = S == T && getindexing(x) == getindexing(y)
+Base.hash(vn::VarName, h::UInt) = hash((getsym(vn), getindexing(vn)), h)
+Base.:(==)(x::VarName{S}, y::VarName{T}) where {S, T} = S == T && getindexing(x) == getindexing(y)
 
-function show(io::IO, vn::VarName)
+function Base.show(io::IO, vn::VarName)
     print(io, getsym(vn))
     for indices in getindexing(vn)
         print(io, "[")
@@ -72,7 +71,7 @@ end
 
 Return a `Symbol` represenation of the variable identifier `VarName`.
 """
-Symbol(vn::VarName) = Symbol(string(vn))  # simplified symbol
+Base.Symbol(vn::VarName) = Symbol(string(vn))  # simplified symbol
 
 
 """

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -38,12 +38,14 @@ function VarName(vn::VarName, indexing)
     return VarName{getsym(vn)}(indexing)
 end
 
+
 """
     getsym(vn::VarName)
 
 Return the symbol of the Julia variable used to generate `vn`.
 """
 getsym(vn::VarName{sym}) where sym = sym
+
 
 """
     getindexing(vn::VarName)
@@ -53,14 +55,8 @@ Return the indexing tuple of the Julia variable used to generate `vn`.
 getindexing(vn::VarName) = vn.indexing
 
 
-"""
-    uid(vn::VarName)
-
-Return a unique tuple identifier for `vn`.
-"""
-uid(vn::VarName) = (getsym(vn), vn.indexing)
-hash(vn::VarName) = hash(uid(vn))
-==(x::VarName, y::VarName) = hash(uid(x)) == hash(uid(y))
+hash(vn::VarName, h::UInt) = hash((getsym(vn), getindexing(vn)), h)
+==(x::VarName{S}, y::VarName{T}) where {S, T} = S == T && getindexing(x) == getindexing(y)
 
 function show(io::IO, vn::VarName)
     print(io, getsym(vn))
@@ -73,13 +69,14 @@ end
 
 parse(::Type{VarName}, name::AbstractString) = varname(Meta.parse(name))
 
-    
+
 """
     Symbol(vn::VarName)
 
 Return a `Symbol` represenation of the variable identifier `VarName`.
 """
 Symbol(vn::VarName) = Symbol(string(vn))  # simplified symbol
+
 
 """
     in(vn::VarName, space::Set)

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -23,15 +23,15 @@ struct VarName{sym, T<:Tuple}
     indexing::T
 end
 
-VarName(sym::Symbol, indexing::T = ()) where {T} = VarName{sym, T}(indexing)
+VarName(sym::Symbol, indexing::Tuple = ()) = VarName{sym, typeof(indexing)}(indexing)
 
 """
     VarName(vn::VarName, indexing)
 
 Return a copy of `vn` with a new index `indexing`.
 """
-function VarName(vn::VarName{sym}, indexing::T = ()) where {sym, T}
-    return VarName{sym, T}(indexing)
+function VarName(vn::VarName, indexing::Tuple = ())
+    return VarName{getsym(vn), typeof(indexing)}(indexing)
 end
 
 
@@ -52,7 +52,7 @@ getindexing(vn::VarName) = vn.indexing
 
 
 Base.hash(vn::VarName, h::UInt) = hash((getsym(vn), getindexing(vn)), h)
-Base.:(==)(x::VarName{S}, y::VarName{T}) where {S, T} = S == T && getindexing(x) == getindexing(y)
+Base.:(==)(x::VarName, y::VarName) = getsym(x) == getsym(y) && getindexing(x) == getindexing(y)
 
 function Base.show(io::IO, vn::VarName)
     print(io, getsym(vn))

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -26,17 +26,15 @@ struct VarName{sym, T<:Tuple}
     indexing::T
 end
 
-VarName{sym}(indexing::T) where {sym, T<:Tuple} = VarName{sym, T}(indexing)
-VarName{sym}() where {sym} = VarName{sym}(())
-VarName(sym, indexing) = VarName{sym}(indexing)
+VarName(sym::Symbol, indexing::T = ()) where {T} = VarName{sym, T}(indexing)
 
 """
     VarName(vn::VarName, indexing)
 
 Return a copy of `vn` with a new index `indexing`.
 """
-function VarName(vn::VarName, indexing)
-    return VarName{getsym(vn)}(indexing)
+function VarName(vn::VarName{sym}, indexing::T = ()) where {sym, T}
+    return VarName{sym, T}(indexing)
 end
 
 
@@ -108,11 +106,11 @@ macro varname(expr::Union{Expr, Symbol})
     expr |> varname |> esc
 end
 
-varname(expr::Symbol) = DynamicPPL.VarName{expr}(())
+varname(expr::Symbol) = VarName(expr)
 function varname(expr::Expr)
     if Meta.isexpr(expr, :ref)
         sym, inds = vsym(expr), vinds(expr)
-        return :(DynamicPPL.VarName{$sym}($inds))
+        return :(DynamicPPL.VarName($sym, $inds))
     else
         throw("VarName: Mis-formed variable name $(expr)!")
     end

--- a/test/Turing/inference/AdvancedSMC.jl
+++ b/test/Turing/inference/AdvancedSMC.jl
@@ -262,7 +262,7 @@ end
 
 function DynamicPPL.assume(spl::Sampler{<:Union{PG,SMC}}, dist::Distribution, vn::VarName, ::VarInfo)
     vi = current_trace().vi
-    if vn in getspace(spl)
+    if DynamicPPL.inspace(vn, getspace(spl))
         if ~haskey(vi, vn)
             r = rand(dist)
             push!(vi, vn, r, dist, spl)

--- a/test/Turing/inference/Inference.jl
+++ b/test/Turing/inference/Inference.jl
@@ -3,7 +3,7 @@ module Inference
 using ..Core, ..Utilities
 using DynamicPPL: Metadata, _tail, VarInfo, TypedVarInfo, 
     islinked, invlink!, getlogp, tonamedtuple, VarName, getsym, vectorize, 
-    settrans!, _getvns, getdist, split_var_str, CACHERESET, AbstractSampler,
+    settrans!, _getvns, getdist, CACHERESET, AbstractSampler,
     Model, runmodel!, Sampler, SampleFromPrior, SampleFromUniform,
     Selector, AbstractSamplerState, DefaultContext, PriorContext,
     LikelihoodContext, MiniBatchContext, set_flag!, unset_flag!, NamedDist, NoDist

--- a/test/Turing/inference/ess.jl
+++ b/test/Turing/inference/ess.jl
@@ -145,7 +145,7 @@ function Distributions.loglikelihood(model::ESSModel, f)
 end
 
 function DynamicPPL.tilde(ctx::DefaultContext, sampler::Sampler{<:ESS}, right, vn::VarName, inds, vi)
-    if vn in getspace(sampler)
+    if DynamicPPL.inspace(vn, getspace(sampler))
         return DynamicPPL.tilde(LikelihoodContext(), SampleFromPrior(), right, vn, inds, vi)
     else
         return DynamicPPL.tilde(ctx, SampleFromPrior(), right, vn, inds, vi)
@@ -157,7 +157,7 @@ function DynamicPPL.tilde(ctx::DefaultContext, sampler::Sampler{<:ESS}, right, l
 end
 
 function DynamicPPL.dot_tilde(ctx::DefaultContext, sampler::Sampler{<:ESS}, right, left, vn::VarName, inds, vi)
-    if vn in getspace(sampler)
+    if DynamicPPL.inspace(vn, getspace(sampler))
         return DynamicPPL.dot_tilde(LikelihoodContext(), SampleFromPrior(), right, left, vn, inds, vi)
     else
         return DynamicPPL.dot_tilde(ctx, SampleFromPrior(), right, left, vn, inds, vi)

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -498,29 +498,24 @@ priors = 0 # See "new grammar" test.
     end
     @testset "var name splitting" begin
         var_expr = :(x)
-        sym, inds = vsym(var_expr), vinds(var_expr)
-        @test sym == :(:x)
-        @test inds == :(())
+        @test vsym(var_expr) == :(:x)
+        @test vinds(var_expr) == :(())
 
         var_expr = :(x[1,1][2,3])
-        sym, inds = vsym(var_expr), vinds(var_expr)
-        @test sym == :(:x)
-        @test inds == :(((1, 1), (2, 3)))
+        @test vsym(var_expr) == :(:x)
+        @test vinds(var_expr) == :(((1, 1), (2, 3)))
 
         var_expr = :(x[:,1][2,:])
-        sym, inds = vsym(var_expr), vinds(var_expr)
-        @test sym == :(:x)
-        @test inds == :(((:, 1), (2, :)))
+        @test vsym(var_expr) == :(:x)
+        @test vinds(var_expr) == :(((:, 1), (2, :)))
 
         var_expr = :(x[2:3,1][2,1:2])
-        sym, inds = vsym(var_expr), vinds(var_expr)
-        @test sym == :(:x)
-        @test inds == :(((2:3, 1), (2, 1:2)))
+        @test vsym(var_expr) == :(:x)
+        @test vinds(var_expr) == :(((2:3, 1), (2, 1:2)))
 
         var_expr = :(x[2:3,2:3][[1,2],[1,2]])
-        sym, inds = vsym(var_expr), vinds(var_expr)
-        @test sym == :(:x)
-        @test inds == :(((2:3, 2:3), ([1, 2], [1, 2])))
+        @test vsym(var_expr) == :(:x)
+        @test vinds(var_expr) == :(((2:3, 2:3), ([1, 2], [1, 2])))
     end
     @testset "user-defined variable name" begin
         @model f1() = begin
@@ -529,8 +524,8 @@ priors = 0 # See "new grammar" test.
         @model f2() = begin
             x ~ NamedDist(Normal(), @varname(y[2][:,1]))
         end
-        @model f3() = begin 
-            x ~ NamedDist(Normal(), @varname(y[1])) 
+        @model f3() = begin
+            x ~ NamedDist(Normal(), @varname(y[1]))
         end
         vi1 = VarInfo(f1())
         vi2 = VarInfo(f2())

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -524,10 +524,10 @@ priors = 0 # See "new grammar" test.
         vi2 = VarInfo(f2())
         vi3 = VarInfo(f3())
         @test haskey(vi1.metadata, :y)
-        @test vi1.metadata.y.vns[1] == VarName{:y}()
+        @test vi1.metadata.y.vns[1] == VarName(:y)
         @test haskey(vi2.metadata, :y)
-        @test vi2.metadata.y.vns[1] == VarName{:y}(((2,), (Colon(), 1)))
+        @test vi2.metadata.y.vns[1] == VarName(:y, ((2,), (Colon(), 1)))
         @test haskey(vi3.metadata, :y)
-        @test vi2.metadata.y.vns[1] == VarName{:y}(((1,),))
+        @test vi3.metadata.y.vns[1] == VarName(:y, ((1,),))
     end
 end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -1,5 +1,5 @@
 using .Turing, Random, MacroTools, Distributions, Test
-using DynamicPPL: DynamicPPL, split_var_str, @varname, VarInfo, VarName
+using DynamicPPL: DynamicPPL, @vsym, @vinds, @varname, VarInfo, VarName
 
 dir = splitdir(splitdir(pathof(DynamicPPL))[1])[1]
 include(dir*"/test/test_utils/AllUtils.jl")
@@ -480,35 +480,35 @@ priors = 0 # See "new grammar" test.
         sample(vdemo3(Vector{Float64}), alg, 250)
         sample(vdemo3(TV=Vector{Float64}), alg, 250)
     end
-    @testset "split var string" begin
-        var_str = "x"
-        sym, inds = split_var_str(var_str)
-        @test sym == "x"
-        @test inds == Vector{String}[]
+    @testset "var name splitting" begin
+        var_expr = :(x)
+        sym, inds = @eval @vsym($var_expr), @vinds($var_expr)
+        @test sym == :x
+        @test inds == ()
 
-        var_str = "x[1,1][2,3]"
-        sym, inds = split_var_str(var_str)
-        @test sym == "x"
-        @test inds[1] == ["1", "1"]
-        @test inds[2] == ["2", "3"]
+        var_expr = :(x[1,1][2,3])
+        sym, inds = @eval @vsym($var_expr), @vinds($var_expr)
+        @test sym == :x
+        @test inds[1] == (1, 1)
+        @test inds[2] == (2, 3)
 
-        var_str = "x[Colon(),1][2,Colon()]"
-        sym, inds = split_var_str(var_str)
-        @test sym == "x"
-        @test inds[1] == ["Colon()", "1"]
-        @test inds[2] == ["2", "Colon()"]
+        var_expr = :(x[Colon(),1][2,Colon()])
+        sym, inds = @eval @vsym($var_expr), @vinds($var_expr)
+        @test sym == :x
+        @test inds[1] == (Colon(), 1)
+        @test inds[2] == (2, Colon())
 
-        var_str = "x[2:3,1][2,1:2]"
-        sym, inds = split_var_str(var_str)
-        @test sym == "x"
-        @test inds[1] == ["2:3", "1"]
-        @test inds[2] == ["2", "1:2"]
+        var_expr = :(x[2:3,1][2,1:2])
+        sym, inds = @eval @vsym($var_expr), @vinds($var_expr)
+        @test sym == :x
+        @test inds[1] == (2:3, 1)
+        @test inds[2] == (2, 1:2)
 
-        var_str = "x[2:3,2:3][[1,2],[1,2]]"
-        sym, inds = split_var_str(var_str)
-        @test sym == "x"
-        @test inds[1] == ["2:3", "2:3"]
-        @test inds[2] == ["[1,2]", "[1,2]"]
+        var_expr = :(x[2:3,2:3][[1,2],[1,2]])
+        sym, inds = @eval @vsym($var_expr), @vinds($var_expr)
+        @test sym == :x
+        @test inds[1] == (2:3, 2:3)
+        @test inds[2] == ([1, 2], [1, 2])
     end
     @testset "user-defined variable name" begin
         @model f1() = begin
@@ -517,17 +517,17 @@ priors = 0 # See "new grammar" test.
         @model f2() = begin
             x ~ NamedDist(Normal(), @varname(y[2][:,1]))
         end
-        @model f3() = begin
-            x ~ NamedDist(Normal(), "y[1]")
+        @model f3() = begin 
+            x ~ NamedDist(Normal(), @varname(y[1])) 
         end
         vi1 = VarInfo(f1())
         vi2 = VarInfo(f2())
         vi3 = VarInfo(f3())
         @test haskey(vi1.metadata, :y)
-        @test vi1.metadata.y.vns[1] == VarName{:y}("")
+        @test vi1.metadata.y.vns[1] == VarName{:y}()
         @test haskey(vi2.metadata, :y)
-        @test vi2.metadata.y.vns[1] == VarName{:y}("[2][Colon(),1]")
+        @test vi2.metadata.y.vns[1] == VarName{:y}(((2,), (Colon(), 1)))
         @test haskey(vi3.metadata, :y)
-        @test vi3.metadata.y.vns[1] == VarName{:y}("[1]")
+        @test vi2.metadata.y.vns[1] == VarName{:y}(((1,),))
     end
 end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -1,5 +1,5 @@
 using .Turing, Random, MacroTools, Distributions, Test
-using DynamicPPL: DynamicPPL, @vsym, @vinds, @varname, VarInfo, VarName
+using DynamicPPL: DynamicPPL, vsym, vinds, @varname, VarInfo, VarName
 
 dir = splitdir(splitdir(pathof(DynamicPPL))[1])[1]
 include(dir*"/test/test_utils/AllUtils.jl")
@@ -498,33 +498,29 @@ priors = 0 # See "new grammar" test.
     end
     @testset "var name splitting" begin
         var_expr = :(x)
-        sym, inds = @eval @vsym($var_expr), @vinds($var_expr)
-        @test sym == :x
-        @test inds == ()
+        sym, inds = vsym(var_expr), vinds(var_expr)
+        @test sym == :(:x)
+        @test inds == :(())
 
         var_expr = :(x[1,1][2,3])
-        sym, inds = @eval @vsym($var_expr), @vinds($var_expr)
-        @test sym == :x
-        @test inds[1] == (1, 1)
-        @test inds[2] == (2, 3)
+        sym, inds = vsym(var_expr), vinds(var_expr)
+        @test sym == :(:x)
+        @test inds == :(((1, 1), (2, 3)))
 
-        var_expr = :(x[Colon(),1][2,Colon()])
-        sym, inds = @eval @vsym($var_expr), @vinds($var_expr)
-        @test sym == :x
-        @test inds[1] == (Colon(), 1)
-        @test inds[2] == (2, Colon())
+        var_expr = :(x[:,1][2,:])
+        sym, inds = vsym(var_expr), vinds(var_expr)
+        @test sym == :(:x)
+        @test inds == :(((:, 1), (2, :)))
 
         var_expr = :(x[2:3,1][2,1:2])
-        sym, inds = @eval @vsym($var_expr), @vinds($var_expr)
-        @test sym == :x
-        @test inds[1] == (2:3, 1)
-        @test inds[2] == (2, 1:2)
+        sym, inds = vsym(var_expr), vinds(var_expr)
+        @test sym == :(:x)
+        @test inds == :(((2:3, 1), (2, 1:2)))
 
         var_expr = :(x[2:3,2:3][[1,2],[1,2]])
-        sym, inds = @eval @vsym($var_expr), @vinds($var_expr)
-        @test sym == :x
-        @test inds[1] == (2:3, 2:3)
-        @test inds[2] == ([1, 2], [1, 2])
+        sym, inds = vsym(var_expr), vinds(var_expr)
+        @test sym == :(:x)
+        @test inds == :(((2:3, 2:3), ([1, 2], [1, 2])))
     end
     @testset "user-defined variable name" begin
         @model f1() = begin

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -212,6 +212,15 @@ priors = 0 # See "new grammar" test.
         model(varinfo)
         @test getlogp(varinfo) == lp
         @test varinfo === _varinfo
+
+        # test DPPL#61
+        @model testmodel(z) = begin
+            m ~ Normal()
+            z[1:end] ~ MvNormal(fill(m, length(z)), 1.0)
+            return m
+        end
+        model = testmodel(rand(10))
+        @test all(z -> isapprox(z, 0; atol = 0.2), mean(model() for _ in 1:1000))
     end
     @testset "nested model" begin
         function makemodel(p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ turnprogress(false)
 
 @testset "DynamicPPL.jl" begin
     include("compiler.jl")
-    # include("varinfo.jl")
-    # include("prob_macro.jl")
-    # include("independence.jl")
+    include("varinfo.jl")
+    include("prob_macro.jl")
+    include("independence.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ turnprogress(false)
 
 @testset "DynamicPPL.jl" begin
     include("compiler.jl")
-    include("varinfo.jl")
-    include("prob_macro.jl")
-    include("independence.jl")
+    # include("varinfo.jl")
+    # include("prob_macro.jl")
+    # include("independence.jl")
 end

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -11,8 +11,6 @@ using Distributions
 using ForwardDiff: Dual
 using Test
 
-i, j, k = 1, 2, 3
-
 dir = splitdir(splitdir(pathof(DynamicPPL))[1])[1]
 include(dir*"/test/test_utils/AllUtils.jl")
 
@@ -341,6 +339,8 @@ include(dir*"/test/test_utils/AllUtils.jl")
         chain = sample(priorsinarray(xs), HMC(0.01, 10), 10)
     end
     @testset "varname" begin
+        i, j, k = 1, 2, 3
+
         vn1 = @varname x[1]
         @test vn1 == VarName(:x, ((1,),))
 

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -61,7 +61,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
         vn2 = @varname x[1][2]
         @test vn2 == vn1
         @test hash(vn2) == hash(vn1)
-        @test in(vn1, (:x,))
+        @test inspace(vn1, (:x,))
 
         function test_base!(vi)
             empty!(vi)
@@ -104,12 +104,12 @@ include(dir*"/test/test_utils/AllUtils.jl")
                 vn5 = @varname z[2]
                 vn6 = @varname z
 
-                @test in(vn1, space)
-                @test in(vn2, space)
-                @test in(vn3, space)
-                @test in(vn4, space)
-                @test ~in(vn5, space)
-                @test ~in(vn6, space)
+                @test inspace(vn1, space)
+                @test inspace(vn2, space)
+                @test inspace(vn3, space)
+                @test inspace(vn4, space)
+                @test ~inspace(vn5, space)
+                @test ~inspace(vn6, space)
             end
             test_in()
         end

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -95,23 +95,22 @@ include(dir*"/test/test_utils/AllUtils.jl")
             @test isempty(vi)
             push!(vi, vn, r, dist, gid)
 
-            function test_in()
-                space = (:x, :y, :(z[1]))
-                vn1 = @varname x
-                vn2 = @varname y
-                vn3 = @varname x[1]
-                vn4 = @varname z[1][1]
-                vn5 = @varname z[2]
-                vn6 = @varname z
+            function test_inspace()
+                space = (:x, :y, @varname(z[1]), @varname(M[1:10, :]))
 
-                @test inspace(vn1, space)
-                @test inspace(vn2, space)
-                @test inspace(vn3, space)
-                @test inspace(vn4, space)
-                @test ~inspace(vn5, space)
-                @test ~inspace(vn6, space)
+                @test inspace(@varname(x), space)
+                @test inspace(@varname(y), space)
+                @test inspace(@varname(x[1]), space)
+                @test inspace(@varname(z[1][1]), space)
+                @test inspace(@varname(z[1][:]), space)
+                @test inspace(@varname(z[1][2:3:10]), space)
+                @test inspace(@varname(M[[2,3], 1]), space)
+                @test inspace(@varname(M[:, 1:4]), space)
+                @test inspace(@varname(M[1, [2, 4, 6]]), space)
+                @test !inspace(@varname(z[2]), space)
+                @test !inspace(@varname(z), space)
             end
-            test_in()
+            test_inspace()
         end
         vi = VarInfo()
         test_base!(vi)

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -1,7 +1,7 @@
 using .Turing, Random
 using AbstractMCMC: step!
 using DynamicPPL: Selector, reconstruct, invlink, CACHERESET,
-    SampleFromPrior, Sampler, runmodel!, SampleFromUniform, uid, 
+    SampleFromPrior, Sampler, runmodel!, SampleFromUniform,
     _getidcs, set_retained_vns_del_by_spl!, is_flagged,
     set_flag!, unset_flag!, VarInfo, TypedVarInfo,
     getlogp, setlogp!, resetlogp!, acclogp!, vectorize,
@@ -343,7 +343,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
     end
     @testset "varname" begin
         vn1 = @varname x[1]
-        @test vn1 == VarName{:x}("[1]")
+        @test vn1 == VarName(:x, ((1,),))
 
         # Symbol
         v_sym = string(:x)
@@ -351,17 +351,17 @@ include(dir*"/test/test_utils/AllUtils.jl")
 
         # Array
         v_arr = @varname x[i]
-        @test v_arr.indexing == "[1]"
+        @test v_arr.indexing == ((1,),)
 
         # Matrix
         v_mat = @varname x[i,j]
-        @test v_mat.indexing == "[1,2]"
+        @test v_mat.indexing == ((1, 2),)
 
         v_mat = @varname x[i,j,k]
-        @test v_mat.indexing == "[1,2,3]"
+        @test v_mat.indexing == ((1,2,3),)
 
         v_mat = @varname x[1,2][1+5][45][3][i]
-        @test v_mat.indexing == "[1,2][6][45][3][1]"
+        @test v_mat.indexing == ((1,2), (6,), (45,), (3,), (1,))
 
         @model mat_name_test() = begin
             p = Array{Any}(undef, 2, 2)
@@ -375,7 +375,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
 
         # Multi array
         v_arrarr = @varname x[i][j]
-        @test v_arrarr.indexing == "[1][2]"
+        @test v_arrarr.indexing == ((1,), (2,))
 
         @model marr_name_test() = begin
             p = Array{Array{Any}}(undef, 2)


### PR DESCRIPTION
Implements the changes discussed in #49: make `VarName` use a tuple of tuples instead of a string for the indexing value.  For that, I mostly reused the existing implementations of `@vinds` and `@vsym`.

While at that, I also refactored the methods realing to `VarName` a bit and moved some leftovers to their right place in `varname.jl`.

Updating all the rest of the code base and the tests is still to be done.