### PR TITLE
Refactor ModelGen and nested closures

### DIFF
--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -62,7 +62,11 @@ export  VarName,
         set_resume!,
 # Model
         Model,
-        getmissing,
+        getmissings,
+        getargnames,
+        getdefaults,
+        getgenerator,
+        getmodeltype,
         runmodel!,
 # Samplers
         Sampler,

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -61,12 +61,12 @@ export  VarName,
         vectorize,
         set_resume!,
 # Model
+        ModelGen,
         Model,
         getmissings,
         getargnames,
         getdefaults,
         getgenerator,
-        getmodeltype,
         runmodel!,
 # Samplers
         Sampler,
@@ -94,6 +94,11 @@ const DEBUG = Bool(parse(Int, get(ENV, "DEBUG_DYNAMICPPL", "0")))
 
 # Used here and overloaded in Turing
 function getspace end
+
+# Necessary forward declarations
+abstract type AbstractVarInfo end
+abstract type AbstractContext end
+
 
 include("utils.jl")
 include("selector.jl")

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -475,7 +475,7 @@ function build_output(model_info)
         end
         
         DynamicPPL.getdefaults(::typeof($model_gen)) = $defaults_nt
-        DynamicPPL.getargtypes(::typeof($model_gen)) = $(Tuple(arg_syms))
+        DynamicPPL.getargnames(::typeof($model_gen)) = $(Tuple(arg_syms))
         DynamicPPL.getmodeltype(::typeof($model_gen)) = DynamicPPL.Model{typeof($model_gen)}
         DynamicPPL.getgenerator(::DynamicPPL.Model{typeof($model_gen)}) = $model_gen
     end

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -188,18 +188,6 @@ function build_model_info(input_expr)
     return model_info
 end
 
-function to_namedtuple_expr(syms::Vector, vals = syms)
-    if length(syms) == 0
-        nt = :(NamedTuple())
-    else
-        nt_type = Expr(:curly, :NamedTuple, 
-            Expr(:tuple, QuoteNode.(syms)...), 
-            Expr(:curly, :Tuple, [:(Core.Typeof($x)) for x in vals]...)
-        )
-        nt = Expr(:call, :(DynamicPPL.namedtuple), nt_type, Expr(:tuple, vals...))
-    end
-    return nt
-end
 
 """
     replace_vi!(model_info)

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -1,5 +1,3 @@
-abstract type AbstractContext end
-
 """
     struct DefaultContext <: AbstractContext end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,33 +1,55 @@
 """
-    struct Model{S, Targs<:NamedTuple, Tmissings <: Val}
+    struct Model{G, Targs<:NamedTuple, Tmissings <: Val}
         args::Targs
         missings::Tmissings
     end
 
-A `Model` struct with arguments `args`, model generator `modelgen` and
+A `Model` struct with arguments `args`, model generator type `G` and
 missing data `missings`. `missings` is a `Val` instance, e.g. `Val{(:a, :b)}()`. An
 argument in `args` with a value `missing` will be in `missings` by default. However, in
 non-traditional use-cases `missings` can be defined differently. All variables in
 `missings` are treated as random variables rather than observations.
 """
-struct Model{S, Targs<:NamedTuple, Tmissings<:Val} <: AbstractModel
+struct Model{G, Targs<:NamedTuple, Tmissings<:Val} <: AbstractModel
     args::Targs
     missings::Tmissings
 end
+
+Model{G}(args::Targs, missings::Tmissings) where {G, Targs, Tmissings} =
+    Model{G, Targs, Tmissings}(args, missings)
 
 (model::Model)(vi) = model(vi, SampleFromPrior())
 (model::Model)(vi, spl) = model(vi, spl, DefaultContext())
 
 
 """
-    getdefaults(model)
+    getgenerator(model::Model)
 
-Get a named tuple of the default argument values defined in a `Model` type.
+Get the generator (the function defined by the `@model` macro) of a certain model instance.
 """
-getdefaults(model::Model) = getdefaults(typeof(model))
+function getgenerator end
 
+"""
+    getmodeltype(::typeof(modelgen))
 
-getargtype(::Type{<:Model{S, Targs}}) where {S, Targs} = Targs
+Get the associated model type for a model generating function.
+"""
+function getmodeltype end
+
+"""
+    getdefaults(::typeof(modelgen))
+
+Get a named tuple of the default argument values defined for a model defined by a generating function.
+"""
+function getdefaults end
+
+"""
+    getargtypes(::typeof(modelgen))
+
+Get a named tuple of the argument
+"""
+function getargtypes end
+
 
 getmissing(model::Model) = model.missings
 @generated function getmissing(args::NamedTuple{names, ttuple}) where {names, ttuple}

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,31 +1,41 @@
-"""Tagged type for implementation of inner model functions that allow dispatch on their type."""
-struct ModelFunction{S} end
-
-
 """
-    struct Model{S, Targs <: NamedTuple, Tmodelgen, Tmissings <: Val}
+    struct Model{S, Targs<:NamedTuple, Tdefaults<:NamedTuple, Tmissings <: Val}
         f::ModelFunction{S}
         args::Targs
-        modelgen::Tmodelgen
+        defaults::Tmodelgen
         missings::Tmissings
     end
 
-A `Model` struct with arguments `args`, inner function `f`, model generator `modelgen` and
+A `Model` struct with arguments `args`, model generator `modelgen` and
 missing data `missings`. `missings` is a `Val` instance, e.g. `Val{(:a, :b)}()`. An
 argument in `args` with a value `missing` will be in `missings` by default. However, in
 non-traditional use-cases `missings` can be defined differently. All variables in
 `missings` are treated as random variables rather than observations.
 """
-struct Model{S, Targs <: NamedTuple, Tmodelgen, Tmissings <: Val} <: AbstractModel
-    f::ModelFunction{S}
+struct Model{S, Targs<:NamedTuple, Tdefaults<:NamedTuple, Tmissings<:Val} <: AbstractModel
     args::Targs
-    modelgen::Tmodelgen
+    defaults::Tdefaults
     missings::Tmissings
 end
-Model(f::ModelFunction, args::NamedTuple, modelgen) = Model(f, args, modelgen, getmissing(args))
+
+function Model{S}(args::NamedTuple, defaults::NamedTuple) where {S}
+    missings = getmissing(args)
+    Model{S, typeof(args), typeof(defaults), typeof(missings)}(args, defaults, missings)
+end
+
 (model::Model)(vi) = model(vi, SampleFromPrior())
 (model::Model)(vi, spl) = model(vi, spl, DefaultContext())
-(model::Model)(args...; kwargs...) = model.f(args..., model; kwargs...)
+
+
+"""
+    getdefaults(::Type{<:Model})
+
+Get a named tuple of the default argument values defined in a `Model` type.
+"""
+function getdefaults end
+
+
+getargtype(::Type{<:Model{S, Targs}}) where {S, Targs} = Targs
 
 getmissing(model::Model) = model.missings
 @generated function getmissing(args::NamedTuple{names, ttuple}) where {names, ttuple}

--- a/src/model.jl
+++ b/src/model.jl
@@ -44,11 +44,11 @@ Get a named tuple of the default argument values defined for a model defined by 
 function getdefaults end
 
 """
-    getargtypes(::typeof(modelgen))
+    getargnames(::typeof(modelgen))
 
-Get a named tuple of the argument
+Get a tuple of the argument names of the model defined by a generating function.
 """
-function getargtypes end
+function getargnames end
 
 
 getmissing(model::Model) = model.missings

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,6 +1,10 @@
+"""Tagged type for implementation of inner model functions that allow dispatch on their type."""
+struct ModelFunction{S} end
+
+
 """
-    struct Model{F, Targs <: NamedTuple, Tmodelgen, Tmissings <: Val}
-        f::F
+    struct Model{S, Targs <: NamedTuple, Tmodelgen, Tmissings <: Val}
+        f::ModelFunction{S}
         args::Targs
         modelgen::Tmodelgen
         missings::Tmissings
@@ -12,13 +16,13 @@ argument in `args` with a value `missing` will be in `missings` by default. Howe
 non-traditional use-cases `missings` can be defined differently. All variables in
 `missings` are treated as random variables rather than observations.
 """
-struct Model{F, Targs <: NamedTuple, Tmodelgen, Tmissings <: Val} <: AbstractModel
-    f::F
+struct Model{S, Targs <: NamedTuple, Tmodelgen, Tmissings <: Val} <: AbstractModel
+    f::ModelFunction{S}
     args::Targs
     modelgen::Tmodelgen
     missings::Tmissings
 end
-Model(f, args::NamedTuple, modelgen) = Model(f, args, modelgen, getmissing(args))
+Model(f::ModelFunction, args::NamedTuple, modelgen) = Model(f, args, modelgen, getmissing(args))
 (model::Model)(vi) = model(vi, SampleFromPrior())
 (model::Model)(vi, spl) = model(vi, spl, DefaultContext())
 (model::Model)(args...; kwargs...) = model.f(args..., model; kwargs...)

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,7 +1,6 @@
 """
-    struct Model{S, Targs<:NamedTuple, Tdefaults<:NamedTuple, Tmissings <: Val}
+    struct Model{S, Targs<:NamedTuple, Tmissings <: Val}
         args::Targs
-        defaults::Tdefaults
         missings::Tmissings
     end
 
@@ -11,15 +10,14 @@ argument in `args` with a value `missing` will be in `missings` by default. Howe
 non-traditional use-cases `missings` can be defined differently. All variables in
 `missings` are treated as random variables rather than observations.
 """
-struct Model{S, Targs<:NamedTuple, Tdefaults<:NamedTuple, Tmissings<:Val} <: AbstractModel
+struct Model{S, Targs<:NamedTuple, Tmissings<:Val} <: AbstractModel
     args::Targs
-    defaults::Tdefaults
     missings::Tmissings
 end
 
-function Model{S}(args::NamedTuple, defaults::NamedTuple) where {S}
+function Model{S}(args::NamedTuple) where {S}
     missings = getmissing(args)
-    Model{S, typeof(args), typeof(defaults), typeof(missings)}(args, defaults, missings)
+    Model{S, typeof(args), typeof(missings)}(args, missings)
 end
 
 (model::Model)(vi) = model(vi, SampleFromPrior())
@@ -27,11 +25,11 @@ end
 
 
 """
-    getdefaults(::Type{<:Model})
+    getdefaults(model)
 
 Get a named tuple of the default argument values defined in a `Model` type.
 """
-function getdefaults end
+getdefaults(model::Model) = getdefaults(typeof(model))
 
 
 getargtype(::Type{<:Model{S, Targs}}) where {S, Targs} = Targs

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,8 +1,7 @@
 """
     struct Model{S, Targs<:NamedTuple, Tdefaults<:NamedTuple, Tmissings <: Val}
-        f::ModelFunction{S}
         args::Targs
-        defaults::Tmodelgen
+        defaults::Tdefaults
         missings::Tmissings
     end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -15,11 +15,6 @@ struct Model{S, Targs<:NamedTuple, Tmissings<:Val} <: AbstractModel
     missings::Tmissings
 end
 
-function Model{S}(args::NamedTuple) where {S}
-    missings = getmissing(args)
-    Model{S, typeof(args), typeof(missings)}(args, missings)
-end
-
 (model::Model)(vi) = model(vi, SampleFromPrior())
 (model::Model)(vi, spl) = model(vi, spl, DefaultContext())
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -44,6 +44,10 @@ Get a tuple of the argument names of the `model`.
 getargnames(model::Model) = getargnames(typeof(model))
 getargnames(::Type{<:Model{_G, argnames} where {_G}}) where {argnames} = argnames
 
+@generated function inargnames(::Val{s}, ::Model{_G, argnames}) where {s, _G, argnames}
+    return s in argnames
+end
+
 
 """
     getmissings(model::Model)
@@ -54,6 +58,10 @@ getmissings(model::Model{_G, _a, missings}) where {missings, _G, _a} = missings
 
 getmissing(model::Model) = getmissings(model)
 @deprecate getmissing(model) getmissings(model)
+
+@generated function inmissings(::Val{s}, ::Model{_G, _a, missings}) where {s, missings, _G, _a}
+    return s in missings
+end
 
 
 """

--- a/src/prob_macro.jl
+++ b/src/prob_macro.jl
@@ -8,11 +8,9 @@ macro prob_str(str)
 end
 
 function get_exprs(str::String)
-    ind = findfirst(isequal('|'), str)
-    ind === nothing && throw("Invalid expression.")
-
-    str1 = str[1:(ind - 1)]
-    str2 = str[(ind + 1):end]
+    substrings = split(str, '|'; limit = 2)
+    length(substrings) == 2 || error("Invalid expression.")
+    str1, str2 = substrings
 
     expr1 = Meta.parse("($str1,)")
     expr1 = Expr(:tuple, expr1.args...)
@@ -57,7 +55,7 @@ function probtype(ntl::NamedTuple{namesl}, ntr::NamedTuple{namesr}) where {names
         defaults = getdefaults(modelgen)
         valid_arg(arg) = isdefined(ntl, arg) || isdefined(ntr, arg) || 
             isdefined(defaults, arg) && getfield(defaults, arg) !== missing
-        @assert all(valid_arg.(getargtypes(modelgen)))
+        @assert all(valid_arg, getargtypes(modelgen))
         return Val(:likelihood), modelgen, vi
     else
         @assert isdefined(ntr, :model)
@@ -96,7 +94,7 @@ function probtype(
         a = get_arg(arg)
         return a !== nothing && a !== missing
     end
-    valid_args = all(valid_arg.(args))
+    valid_args = all(valid_arg, args)
 
     # Uses the default values for model arguments not provided.
     # If no default value exists, use `nothing`.

--- a/src/prob_macro.jl
+++ b/src/prob_macro.jl
@@ -170,7 +170,7 @@ end
     # `missings` is splatted into a tuple at compile time and inserted as literal
     return quote
         $(warnings...)
-        DynamicPPL.Model{G, $((missings...,))}($(to_namedtuple_expr(argnames, argvals)))
+        DynamicPPL.Model{G, $(Tuple(missings))}($(to_namedtuple_expr(argnames, argvals)))
     end
 end
 
@@ -227,7 +227,7 @@ end
 
     # `args` is inserted as properly typed NamedTuple expression; 
     # `missings` is splatted into a tuple at compile time and inserted as literal
-    return :(DynamicPPL.Model{G, $((missings...,))}($(to_namedtuple_expr(argnames, argvals))))
+    return :(DynamicPPL.Model{G, $(Tuple(missings))}($(to_namedtuple_expr(argnames, argvals))))
 end
 
 _setval!(vi::TypedVarInfo, c::AbstractChains) = _setval!(vi.metadata, vi, c)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,20 @@
 ############################################
 # Julia 1.2 temporary fix - Julia PR 33303 #
 ############################################
+function to_namedtuple_expr(syms, vals=syms)
+    if length(syms) == 0
+        nt = :(NamedTuple())
+    else
+        nt_type = Expr(:curly, :NamedTuple, 
+            Expr(:tuple, QuoteNode.(syms)...), 
+            Expr(:curly, :Tuple, [:(Core.Typeof($x)) for x in vals]...)
+        )
+        nt = Expr(:call, :(DynamicPPL.namedtuple), nt_type, Expr(:tuple, vals...))
+    end
+    return nt
+end
+
+
 if VERSION == v"1.2"
     @eval function namedtuple(::Type{NamedTuple{names, T}}, args::Tuple) where {names, T <: Tuple}
         if length(args) != length(names)

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -8,7 +8,6 @@ const CACHERANGES = 0b01
 ####
 
 
-abstract type AbstractVarInfo end
 
 ####################
 # VarInfo metadata #
@@ -108,10 +107,9 @@ const TypedVarInfo = VarInfo{<:NamedTuple}
 
 function VarInfo(model::Model, ctx = DefaultContext())
     vi = VarInfo()
-    model(vi, SampleFromPrior(), ctx)
+    runmodel!(model, vi, SampleFromPrior(), ctx)
     return TypedVarInfo(vi)
 end
-(model::Model)() = model(VarInfo(), SampleFromPrior())
 
 function VarInfo(old_vi::UntypedVarInfo, spl, x::AbstractVector)
     new_vi = deepcopy(old_vi)
@@ -555,26 +553,6 @@ function _in(vn_str::String, space::Tuple{Expr,Vararg})::Bool
 end
 
 # VarInfo
-
-"""
-    runmodel!(model::Model, vi::AbstractVarInfo, spl::AbstractSampler, ctx::AbstractContext)
-
-Sample from `model` using the sampler `spl` storing the sample and log joint
-probability in `vi`.
-"""
-function runmodel!(
-    model::Model,
-    vi::AbstractVarInfo,
-    spl::AbstractSampler = SampleFromPrior(),
-    ctx::AbstractContext = DefaultContext()
-)
-    setlogp!(vi, 0)
-    if has_eval_num(spl)
-        spl.state.eval_num += 1
-    end
-    model(vi, spl, ctx)
-    return vi
-end
 
 VarInfo(meta=Metadata()) = VarInfo(meta, Ref{Real}(0.0), Ref(0))
 

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -213,6 +213,22 @@ priors = 0 # See "new grammar" test.
         @test getlogp(varinfo) == lp
         @test varinfo === _varinfo
     end
+    @testset "nested model" begin
+        function nest(α_0, θ_0)
+            @model gdemo(x) = begin
+                λ ~ Gamma(α_0, θ_0)
+                m ~ Normal(0, √(1 / λ))
+                x .~ Normal(m, √(1 / λ))
+                global lp = @logpdf()
+            end
+
+            return gdemo
+        end
+        model = nest(2.0, inv(3.0))([1.5, 2.0])
+        varinfo = DynamicPPL.VarInfo(model)
+        model(varinfo)
+        @test getlogp(varinfo) = lp
+    end
     @testset "new grammar" begin
         x = Float64[1 2]
 

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -214,20 +214,20 @@ priors = 0 # See "new grammar" test.
         @test varinfo === _varinfo
     end
     @testset "nested model" begin
-        function nest(α_0, θ_0)
-            @model gdemo(x) = begin
-                λ ~ Gamma(α_0, θ_0)
-                m ~ Normal(0, √(1 / λ))
-                x .~ Normal(m, √(1 / λ))
-                global lp = @logpdf()
-            end
+        # function nest(α_0, θ_0)
+        #     @model gdemo(x) = begin
+        #         λ ~ Gamma(α_0, θ_0)
+        #         m ~ Normal(0, √(1 / λ))
+        #         x .~ Normal(m, √(1 / λ))
+        #         global lp = @logpdf()
+        #     end
 
-            return gdemo
-        end
-        model = nest(2.0, inv(3.0))([1.5, 2.0])
-        varinfo = DynamicPPL.VarInfo(model)
-        model(varinfo)
-        @test getlogp(varinfo) = lp
+        #     return gdemo
+        # end
+        # model = nest(2.0, inv(3.0))([1.5, 2.0])
+        # varinfo = DynamicPPL.VarInfo(model)
+        # model(varinfo)
+        # @test getlogp(varinfo) = lp
     end
     @testset "new grammar" begin
         x = Float64[1 2]


### PR DESCRIPTION
Implements what I proposed in #45.  Surprisingly, I couldn't find any problems yet.

The main change is that

```julia
ex = quote
    function $outer_function($(args...))
        function $inner_function(
            $vi::DynamicPPL.VarInfo,
            $sampler::DynamicPPL.AbstractSampler,
            $ctx::DynamicPPL.AbstractContext,
            $model
        )
            $unwrap_data_expr
            DynamicPPL.resetlogp!($vi)
            $main_body
        end
        return DynamicPPL.Model($inner_function, $args_nt, $model_gen_constructor)
    end
    $model_gen = $model_gen_constructor
end
```

becomes 

```julia
model_type = :(DynamicPPL.Model{$(QuoteNode(model_function))})
defaults = gensym(:defaults)

ex = quote
    function ($model::$model_type)(
        $vi::DynamicPPL.VarInfo,
        $sampler::DynamicPPL.AbstractSampler,
        $ctx::DynamicPPL.AbstractContext,
    )
        $unwrap_data_expr
        DynamicPPL.resetlogp!($vi)
        $main_body
    end

    $defaults = $defaults_nt
    getdefaults(::$model_type) = $defaults
    $model_gen($(args...)) = $model_type($args_nt, $defaults)
end
```

and `Model` and `ModelGen` are merged into

```julia
struct Model{S, Targs<:NamedTuple, Tdefaults<:NamedTuple, Tmissings<:Val} <: AbstractModel
    args::Targs
    defaults::Tdefaults
    missings::Tmissings
end

function Model{S}(args::NamedTuple, defaults::NamedTuple) where {S}
    missings = getmissing(args)
    Model{S, typeof(args), typeof(defaults), typeof(missings)}(args, defaults, missings)
end
```

with `S` begin `gensym(modelname)`, which is used to dispatch on the type of the concrete model.

The alternative would have been to define an abstract base type and a custom subtype for each model, but I think this is even cleaner.

Tests pass so far, except for the prob macro, which I still have to update to work on the new `Model` instead of `ModelGen`.