### PR TITLE
Run CI tests on Julia 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ julia:
   - 1.1
   - 1.2
   - 1.3
+  - 1.4
   - nightly
 matrix:
   allow_failures:
@@ -19,6 +20,6 @@ matrix:
 notifications:
   email: false
 after_success:
-  - if [[ $TRAVIS_JULIA_VERSION = 1.3 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
+  - if [[ $TRAVIS_JULIA_VERSION = 1.4 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
       julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.3
   - 1
   - nightly
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.1
-  - 1.2
   - 1.3
-  - 1.4
+  - 1
   - nightly
 matrix:
   allow_failures:
@@ -20,6 +18,6 @@ matrix:
 notifications:
   email: false
 after_success:
-  - if [[ $TRAVIS_JULIA_VERSION = 1.4 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
+  - if [[ $TRAVIS_JULIA_VERSION = 1 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
       julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';
     fi


### PR DESCRIPTION
Should we drop, e.g., Julia 1.1?