### PR TITLE
Fix error `Model not defined`

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -444,10 +444,10 @@ function build_output(model_info)
     @gensym(evaluator, generator)
     generator_kw_form = isempty(args) ? () : (:($generator(;$(args...)) = $generator($(arg_syms...))),)
     model_gen_constructor = :(DynamicPPL.ModelGen{$(Tuple(arg_syms))}($generator, $defaults_nt))
-    
+
     ex = quote
         function $evaluator(
-            $model::Model,
+            $model::DynamicPPL.Model,
             $vi::DynamicPPL.VarInfo,
             $sampler::DynamicPPL.AbstractSampler,
             $ctx::DynamicPPL.AbstractContext,
@@ -456,11 +456,10 @@ function build_output(model_info)
             DynamicPPL.resetlogp!($vi)
             $main_body
         end
-        
 
         $generator($(args...)) = DynamicPPL.Model($evaluator, $args_nt, $model_gen_constructor)
         $(generator_kw_form...)
-        
+
         $model_gen = $model_gen_constructor
     end
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -216,7 +216,7 @@ function replace_logpdf!(model_info)
     vi = model_info[:main_body_names][:vi]
     ex = MacroTools.postwalk(ex) do x
         if @capture(x, @logpdf())
-            :(getlogp($vi))
+            :($(DynamicPPL.getlogp)($vi))
         else
             x
         end

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -27,43 +27,42 @@ function wrong_dist_errormsg(l)
 end
 
 """
-    @isassumption(model, expr)
+    isassumption(model, expr)
 
-Let `expr` be `x[1]`. `vn` is an assumption in the following cases:
-    1. `x` was not among the input data to the model,
-    2. `x` was among the input data to the model but with a value `missing`, or
-    3. `x` was among the input data to the model with a value other than missing, 
+Return an expression that can be evaluated to check if `expr` is an assumption in the
+`model`.
+
+Let `expr` be `:(x[1])`. It is an assumption in the following cases:
+    1. `x` is not among the input data to the `model`,
+    2. `x` is among the input data to the `model` but with a value `missing`, or
+    3. `x` is among the input data to the `model` with a value other than missing,
        but `x[1] === missing`.
+
 When `expr` is not an expression or symbol (i.e., a literal), this expands to `false`.
 """
-macro isassumption(model, expr::Union{Symbol, Expr})
-    # Note: never put a return in this... don't forget it's a macro!
+function isassumption(model, expr::Union{Symbol, Expr})
     vn = gensym(:vn)
-    
+
     return quote
-        $vn = @varname($expr)
-        
-        # This branch should compile nicely in all cases except for partial missing data
-        # For example, when `expr` is `x[i]` and `x isa Vector{Union{Missing, Float64}}`
-        if !$DynamicPPL.inargnames($vn, $model) || $DynamicPPL.inmissings($vn, $model)
-            true
-        else
-            if $DynamicPPL.inargnames($vn, $model)
-                # Evaluate the lhs
-                $expr === missing
+        let $vn = $(varname(expr))
+            # This branch should compile nicely in all cases except for partial missing data
+            # For example, when `expr` is `:(x[i])` and `x isa Vector{Union{Missing, Float64}}`
+            if !$(DynamicPPL.inargnames)($vn, $model) || $(DynamicPPL.inmissings)($vn, $model)
+                true
             else
-                throw("This point should not be reached. Please report this error.")
+                if $(DynamicPPL.inargnames)($vn, $model)
+                    # Evaluate the lhs
+                    $expr === missing
+                else
+                    throw("This point should not be reached. Please report this error.")
+                end
             end
         end
-    end |> esc
+    end
 end
 
-macro isassumption(model, expr)
-    # failsafe: a literal is never an assumption
-    false
-end
-
-
+# failsafe: a literal is never an assumption
+isassumption(model, expr) = :(false)
 
 #################
 # Main Compiler #
@@ -128,7 +127,7 @@ function build_model_info(input_expr)
             Expr(:tuple, QuoteNode.(arg_syms)...), 
             Expr(:curly, :Tuple, [:(Core.Typeof($x)) for x in arg_syms]...)
         )
-        args_nt = Expr(:call, :($DynamicPPL.namedtuple), nt_type, Expr(:tuple, arg_syms...))
+        args_nt = Expr(:call, :($namedtuple), nt_type, Expr(:tuple, arg_syms...))
     end
     args = map(modeldef[:args]) do arg
         if (arg isa Symbol)
@@ -217,7 +216,7 @@ function replace_logpdf!(model_info)
     vi = model_info[:main_body_names][:vi]
     ex = MacroTools.postwalk(ex) do x
         if @capture(x, @logpdf())
-            :($vi.logp[])
+            :(getlogp($vi))
         else
             x
         end
@@ -294,45 +293,58 @@ function generate_tilde(left, right, model_info)
     vi = model_info[:main_body_names][:vi]
     ctx = model_info[:main_body_names][:ctx]
     sampler = model_info[:main_body_names][:sampler]
-    temp_right = gensym(:temp_right)
-    out = gensym(:out)
-    lp = gensym(:lp)
-    vn = gensym(:vn)
-    inds = gensym(:inds)
-    isassumption = gensym(:isassumption)
-    assert_ex = :($DynamicPPL.assert_dist($temp_right, msg = $(wrong_dist_errormsg(@__LINE__))))
+
+    @gensym tmpright
+    expr = quote
+        $tmpright = $right
+        $(DynamicPPL.assert_dist)($tmpright, msg = $(wrong_dist_errormsg(@__LINE__)))
+    end
 
     if left isa Symbol || left isa Expr
-        ex = quote
-            $temp_right = $right
-            $assert_ex
+        @gensym out vn inds
+        push!(expr.args,
+              :($vn = $(varname(left))),
+              :($inds = $(vinds(left))))
 
-            $vn, $inds = $(varname(left)), $(vinds(left))
-            $isassumption = $DynamicPPL.@isassumption($model, $left)
-            if $isassumption
-                $out = $DynamicPPL.tilde_assume($ctx, $sampler, $temp_right, $vn, $inds, $vi)
-                $left = $out[1]
-                $DynamicPPL.acclogp!($vi, $out[2])
-            else
-                $DynamicPPL.acclogp!(
-                    $vi,
-                    $DynamicPPL.tilde_observe($ctx, $sampler, $temp_right, $left, $vn, $inds, $vi),
-                )
+        assumption = quote
+            $out = $(DynamicPPL.tilde_assume)($ctx, $sampler, $tmpright, $vn, $inds,
+                                              $vi)
+            $left = $out[1]
+            $(DynamicPPL.acclogp!)($vi, $out[2])
+        end
+
+        # It can only be an observation if the LHS is an argument of the model
+        if vsym(left) in model_info[:args]
+            @gensym isassumption
+            return quote
+                $expr
+                $isassumption = $(DynamicPPL.isassumption(model, left))
+                if $isassumption
+                    $assumption
+                else
+                    $(DynamicPPL.acclogp!)(
+                        $vi,
+                        $(DynamicPPL.tilde_observe)($ctx, $sampler, $tmpright, $left, $vn,
+                                                    $inds, $vi)
+                    )
+                end
             end
         end
-    else
-        # we have a literal, which is automatically an observation
-        ex = quote
-            $temp_right = $right
-            $assert_ex
 
-            $DynamicPPL.acclogp!(
-                $vi,
-                $DynamicPPL.tilde_observe($ctx, $sampler, $temp_right, $left, $vi),
-            )
+        return quote
+            $expr
+            $assumption
         end
     end
-    return ex
+
+    # If the LHS is a literal, it is always an observation
+    return quote
+        $expr
+        $(DynamicPPL.acclogp!)(
+            $vi,
+            $(DynamicPPL.tilde_observe)($ctx, $sampler, $tmpright, $left, $vi)
+        )
+    end
 end
 
 """
@@ -347,46 +359,58 @@ function generate_dot_tilde(left, right, model_info)
     vi = model_info[:main_body_names][:vi]
     ctx = model_info[:main_body_names][:ctx]
     sampler = model_info[:main_body_names][:sampler]
-    out = gensym(:out)
-    temp_right = gensym(:temp_right)
-    isassumption = gensym(:isassumption)
-    lp = gensym(:lp)
-    vn = gensym(:vn)
-    inds = gensym(:inds)
-    assert_ex = :($DynamicPPL.assert_dist($temp_right, msg = $(wrong_dist_errormsg(@__LINE__))))
+
+    @gensym tmpright
+    expr = quote
+        $tmpright = $right
+        $(DynamicPPL.assert_dist)($tmpright, msg = $(wrong_dist_errormsg(@__LINE__)))
+    end
 
     if left isa Symbol || left isa Expr
-        ex = quote
-            $temp_right = $right
-            $assert_ex
+        @gensym out vn inds
+        push!(expr.args,
+              :($vn = $(varname(left))),
+              :($inds = $(vinds(left))))
 
-            $vn, $inds = $(varname(left)), $(vinds(left))
-            $isassumption = $DynamicPPL.@isassumption($model, $left)
+        assumption = quote
+            $out = $(DynamicPPL.dot_tilde_assume)($ctx, $sampler, $tmpright, $left,
+                                                  $vn, $inds, $vi)
+            $left .= $out[1]
+            $(DynamicPPL.acclogp!)($vi, $out[2])
+        end
 
-            if $isassumption
-                $out = $DynamicPPL.dot_tilde_assume($ctx, $sampler, $temp_right, $left, $vn, $inds, $vi)
-                $left .= $out[1]
-                $DynamicPPL.acclogp!($vi, $out[2])
-            else
-                $DynamicPPL.acclogp!(
-                    $vi,
-                    $DynamicPPL.dot_tilde_observe($ctx, $sampler, $temp_right, $left, $vn, $inds, $vi),
-                )
+        # It can only be an observation if the LHS is an argument of the model
+        if vsym(left) in model_info[:args]
+            @gensym isassumption
+            return quote
+                $expr
+                $isassumption = $(DynamicPPL.isassumption(model, left))
+                if $isassumption
+                    $assumption
+                else
+                    $(DynamicPPL.acclogp!)(
+                        $vi,
+                        $(DynamicPPL.dot_tilde_observe)($ctx, $sampler, $tmpright, $left,
+                                                        $vn, $inds, $vi)
+                    )
+                end
             end
         end
-    else
-        # we have a literal, which is automatically an observation
-        ex = quote
-            $temp_right = $right
-            $assert_ex
 
-            $DynamicPPL.acclogp!(
-                $vi,
-                $DynamicPPL.dot_tilde_observe($ctx, $sampler, $temp_right, $left, $vi),
-            )
+        return quote
+            $expr
+            $assumption
         end
     end
-    return ex
+
+    # If the LHS is a literal, it is always an observation
+    return quote
+        $expr
+        $(DynamicPPL.acclogp!)(
+            $vi,
+            $(DynamicPPL.dot_tilde_observe)($ctx, $sampler, $tmpright, $left, $vi)
+        )
+    end
 end
 
 const FloatOrArrayType = Type{<:Union{AbstractFloat, AbstractArray}}
@@ -425,39 +449,27 @@ function build_output(model_info)
 
     unwrap_data_expr = Expr(:block)
     for var in arg_syms
-        temp_var = gensym(:temp_var)
-        varT = gensym(:varT)
-        push!(unwrap_data_expr.args, quote
-            local $var
-            $temp_var = $model.args.$var
-            $varT = typeof($temp_var)
-            if $temp_var isa $DynamicPPL.FloatOrArrayType
-                $var = $DynamicPPL.get_matching_type($sampler, $vi, $temp_var)
-            elseif $DynamicPPL.hasmissing($varT)
-                $var = $DynamicPPL.get_matching_type($sampler, $vi, $varT)($temp_var)
-            else
-                $var = $temp_var
-            end
-        end)
+        push!(unwrap_data_expr.args,
+              :($var = $(DynamicPPL.matchingvalue)($sampler, $vi, $(model).args.$var)))
     end
 
     @gensym(evaluator, generator)
     generator_kw_form = isempty(args) ? () : (:($generator(;$(args...)) = $generator($(arg_syms...))),)
-    model_gen_constructor = :($DynamicPPL.ModelGen{$(Tuple(arg_syms))}($generator, $defaults_nt))
+    model_gen_constructor = :($(DynamicPPL.ModelGen){$(Tuple(arg_syms))}($generator, $defaults_nt))
 
     ex = quote
         function $evaluator(
-            $model::$DynamicPPL.Model,
-            $vi::$DynamicPPL.VarInfo,
-            $sampler::$DynamicPPL.AbstractSampler,
-            $ctx::$DynamicPPL.AbstractContext,
+            $model::$(DynamicPPL.Model),
+            $vi::$(DynamicPPL.VarInfo),
+            $sampler::$(DynamicPPL.AbstractSampler),
+            $ctx::$(DynamicPPL.AbstractContext),
         )
             $unwrap_data_expr
-            $DynamicPPL.resetlogp!($vi)
+            $(DynamicPPL.resetlogp!)($vi)
             $main_body
         end
 
-        $generator($(args...)) = $DynamicPPL.Model($evaluator, $args_nt, $model_gen_constructor)
+        $generator($(args...)) = $(DynamicPPL.Model)($evaluator, $args_nt, $model_gen_constructor)
         $(generator_kw_form...)
 
         $model_gen = $model_gen_constructor
@@ -473,6 +485,21 @@ function warn_empty(body)
     end
     return
 end
+
+"""
+    matchingvalue(sampler, vi, value)
+
+Convert the `value` to the correct type for the `sampler` and the `vi` object.
+"""
+function matchingvalue(sampler, vi, value)
+    T = typeof(value)
+    if hasmissing(T)
+        return get_matching_type(sampler, vi, T)(value)
+    else
+        return value
+    end
+end
+matchingvalue(sampler, vi, value::FloatOrArrayType) = get_matching_type(sampler, vi, value)
 
 """
     get_matching_type(spl, vi, ::Type{T}) where {T}

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -200,7 +200,7 @@ function replace_logpdf!(model_info)
     vi = model_info[:main_body_names][:vi]
     ex = MacroTools.postwalk(ex) do x
         if @capture(x, @logpdf())
-            :($(DynamicPPL.getlogp)($vi))
+            :($(vi).logp[])
         else
             x
         end

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -38,12 +38,8 @@ function isassumption(model, expr::Union{Symbol, Expr})
             if !$(DynamicPPL.inargnames)($vn, $model) || $(DynamicPPL.inmissings)($vn, $model)
                 true
             else
-                if $(DynamicPPL.inargnames)($vn, $model)
-                    # Evaluate the lhs
-                    $expr === missing
-                else
-                    throw("This point should not be reached. Please report this error.")
-                end
+                # Evaluate the LHS
+                $expr === missing
             end
         end
     end

--- a/src/prob_macro.jl
+++ b/src/prob_macro.jl
@@ -1,10 +1,10 @@
 macro logprob_str(str)
     expr1, expr2 = get_exprs(str)
-    return :($DynamicPPL.logprob($expr1, $expr2)) |> esc
+    return :(logprob($(esc(expr1)), $(esc(expr2))))
 end
 macro prob_str(str)
     expr1, expr2 = get_exprs(str)
-    return :(exp.($DynamicPPL.logprob($expr1, $expr2))) |> esc
+    return :(exp.(logprob($(esc(expr1)), $(esc(expr2)))))
 end
 
 function get_exprs(str::String)
@@ -169,7 +169,7 @@ end
     # `missings` is splatted into a tuple at compile time and inserted as literal
     return quote
         $(warnings...)
-        $DynamicPPL.Model{$(Tuple(missings))}(modelgen, $(to_namedtuple_expr(argnames, argvals)))
+        Model{$(Tuple(missings))}(modelgen, $(to_namedtuple_expr(argnames, argvals)))
     end
 end
 
@@ -225,7 +225,7 @@ end
 
     # `args` is inserted as properly typed NamedTuple expression; 
     # `missings` is splatted into a tuple at compile time and inserted as literal
-    return :($DynamicPPL.Model{$(Tuple(missings))}(modelgen, $(to_namedtuple_expr(argnames, argvals))))
+    return :(Model{$(Tuple(missings))}(modelgen, $(to_namedtuple_expr(argnames, argvals))))
 end
 
 _setval!(vi::TypedVarInfo, c::AbstractChains) = _setval!(vi.metadata, vi, c)

--- a/src/prob_macro.jl
+++ b/src/prob_macro.jl
@@ -1,10 +1,10 @@
 macro logprob_str(str)
     expr1, expr2 = get_exprs(str)
-    return :(DynamicPPL.logprob($expr1, $expr2)) |> esc
+    return :($DynamicPPL.logprob($expr1, $expr2)) |> esc
 end
 macro prob_str(str)
     expr1, expr2 = get_exprs(str)
-    return :(exp.(DynamicPPL.logprob($expr1, $expr2))) |> esc
+    return :(exp.($DynamicPPL.logprob($expr1, $expr2))) |> esc
 end
 
 function get_exprs(str::String)
@@ -169,7 +169,7 @@ end
     # `missings` is splatted into a tuple at compile time and inserted as literal
     return quote
         $(warnings...)
-        DynamicPPL.Model{$(Tuple(missings))}(modelgen, $(to_namedtuple_expr(argnames, argvals)))
+        $DynamicPPL.Model{$(Tuple(missings))}(modelgen, $(to_namedtuple_expr(argnames, argvals)))
     end
 end
 
@@ -225,7 +225,7 @@ end
 
     # `args` is inserted as properly typed NamedTuple expression; 
     # `missings` is splatted into a tuple at compile time and inserted as literal
-    return :(DynamicPPL.Model{$(Tuple(missings))}(modelgen, $(to_namedtuple_expr(argnames, argvals))))
+    return :($DynamicPPL.Model{$(Tuple(missings))}(modelgen, $(to_namedtuple_expr(argnames, argvals))))
 end
 
 _setval!(vi::TypedVarInfo, c::AbstractChains) = _setval!(vi.metadata, vi, c)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,7 +59,7 @@ function to_namedtuple_expr(syms, vals=syms)
             Expr(:tuple, QuoteNode.(syms)...), 
             Expr(:curly, :Tuple, [:(Core.Typeof($x)) for x in vals]...)
         )
-        nt = Expr(:call, :(DynamicPPL.namedtuple), nt_type, Expr(:tuple, vals...))
+        nt = Expr(:call, :($DynamicPPL.namedtuple), nt_type, Expr(:tuple, vals...))
     end
     return nt
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,7 +59,7 @@ function to_namedtuple_expr(syms, vals=syms)
             Expr(:tuple, QuoteNode.(syms)...), 
             Expr(:curly, :Tuple, [:(Core.Typeof($x)) for x in vals]...)
         )
-        nt = Expr(:call, :($DynamicPPL.namedtuple), nt_type, Expr(:tuple, vals...))
+        nt = Expr(:call, :($(DynamicPPL.namedtuple)), nt_type, Expr(:tuple, vals...))
     end
     return nt
 end

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -35,7 +35,7 @@ end
 function varname(expr)
     ex = deepcopy(expr)
     (ex isa Symbol) && return quote
-        DynamicPPL.VarName{$(QuoteNode(ex))}("")
+        $DynamicPPL.VarName{$(QuoteNode(ex))}("")
     end
     (ex.head == :ref) || throw("VarName: Mis-formed variable name $(expr)!")
     inds = :(())
@@ -46,7 +46,7 @@ function varname(expr)
         end
         ex = ex.args[1]
         isa(ex, Symbol) && return quote
-            DynamicPPL.VarName{$(QuoteNode(ex))}(foldl(*, $inds, init = ""))
+            $DynamicPPL.VarName{$(QuoteNode(ex))}(foldl(*, $inds, init = ""))
         end
     end
     throw("VarName: Mis-formed variable name $(expr)!")

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -34,10 +34,8 @@ macro varname(expr::Union{Expr, Symbol})
 end
 function varname(expr)
     ex = deepcopy(expr)
-    (ex isa Symbol) && return quote
-        $DynamicPPL.VarName{$(QuoteNode(ex))}("")
-    end
-    (ex.head == :ref) || throw("VarName: Mis-formed variable name $(expr)!")
+    ex isa Symbol && return :($(DynamicPPL.VarName){$(QuoteNode(ex))}(""))
+    ex.head == :ref || throw("VarName: Mis-formed variable name $(expr)!")
     inds = :(())
     while ex.head == :ref
         if length(ex.args) >= 2
@@ -45,15 +43,13 @@ function varname(expr)
             pushfirst!(inds.args, :("[" * join($(Expr(:vect, strs...)), ",") * "]"))
         end
         ex = ex.args[1]
-        isa(ex, Symbol) && return quote
-            $DynamicPPL.VarName{$(QuoteNode(ex))}(foldl(*, $inds, init = ""))
-        end
+        ex isa Symbol && return :($(DynamicPPL.VarName){$(QuoteNode(ex))}(foldl(*, $inds, init = "")))
     end
     throw("VarName: Mis-formed variable name $(expr)!")
 end
 
 macro vsym(expr::Union{Expr, Symbol})
-    expr |> vsym
+    return :(QuoteNode($(vsym(expr))))
 end
 
 """
@@ -61,16 +57,11 @@ end
 
 Returns the variable symbol given the input variable expression `expr`. For example, if the input `expr = :(x[1])`, the output is `:x`.
 """
-function vsym(expr::Union{Expr, Symbol})
-    ex = deepcopy(expr)
-    (ex isa Symbol) && return QuoteNode(ex)
-    (ex.head == :ref) || throw("VarName: Mis-formed variable name $(expr)!")
-    while ex.head == :ref
-        ex = ex.args[1]
-        isa(ex, Symbol) && return QuoteNode(ex)
-    end
-    throw("VarName: Mis-formed variable name $(expr)!")
+function vsym(expr::Expr)
+    (expr.head == :ref && !isempty(expr.args)) || throw("VarName: Mis-formed variable name $(expr)!")
+    vsym(expr.args[1])
 end
+vsym(sym::Symbol) = sym
 
 """
     @vinds(expr)


### PR DESCRIPTION
Fixes the error
```julia
ERROR: LoadError: LoadError: LoadError: UndefVarError: Model not defined
Stacktrace:
 [1] top-level scope at /home/david/.julia/packages/DynamicPPL/e9MX7/src/compiler.jl:449
 [2] include(::String) at ./client.jl:439
 [3] top-level scope at /home/david/.julia/dev/Turing/test/test_utils/AllUtils.jl:7
 [4] include(::String) at ./client.jl:439
 [5] top-level scope at /home/david/.julia/dev/Turing/test/runtests.jl:9
 [6] include(::String) at ./client.jl:439
 [7] top-level scope at none:6
in expression starting at /home/david/.julia/dev/Turing/test/test_utils/models.jl:2
in expression starting at /home/david/.julia/dev/Turing/test/test_utils/AllUtils.jl:7
in expression starting at /home/david/.julia/dev/Turing/test/runtests.jl:9
ERROR: Package Turing errored during testing
```
when trying to use Turing with the master branch of DynamicPPL. I'm not sure if there's a good and reliable way to catch this error in the CI tests - I guess Model is always defined since we load DynamicPPL explicitly, isn't it?