### PR TITLE
Fixed _setval! to work with vector-indices

### DIFF
--- a/src/prob_macro.jl
+++ b/src/prob_macro.jl
@@ -233,7 +233,7 @@ _setval!(vi::TypedVarInfo, c::AbstractChains) = _setval!(vi.metadata, vi, c)
     return Expr(:block, map(names) do n
         quote
             for vn in md.$n.vns
-                val = copy.(vec(c[string(vn)].value))
+                val = copy.(vec(c[Symbol(string(vn))].value))
                 setval!(vi, val, vn)
                 settrans!(vi, false, vn)
             end


### PR DESCRIPTION
At the moment `_setval!(varinfo, chain)` will fail because `chain` does not support element-wise string-indexing, e.g. `"y[1]"`, but `chain` does support `Symbol("y[1]")`. Therefore I've just changed it to use symbol- instead of string-indexing.