### PR TITLE
Less surprising model return values

### DIFF
--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -68,7 +68,6 @@ export  VarName,
         getargnames,
         getdefaults,
         getgenerator,
-        runmodel!,
 # Samplers
         Sampler,
         SampleFromPrior,

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -443,7 +443,6 @@ function build_output(model_info)
             $ctx::$(DynamicPPL.AbstractContext),
         )
             $unwrap_data_expr
-            $(DynamicPPL.resetlogp!)($vi)
             $main_body
             return
         end

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -445,6 +445,7 @@ function build_output(model_info)
             $unwrap_data_expr
             $(DynamicPPL.resetlogp!)($vi)
             $main_body
+            return
         end
 
         $generator($(args...)) = $(DynamicPPL.Model)($evaluator, $args_nt, $model_gen_constructor)

--- a/src/model.jl
+++ b/src/model.jl
@@ -131,7 +131,7 @@ function runmodel!(
     spl::AbstractSampler=SampleFromPrior(),
     ctx::AbstractContext=DefaultContext()
 )
-    setlogp!(vi, 0)
+    resetlogp!(vi)
     if has_eval_num(spl)
         spl.state.eval_num += 1
     end

--- a/src/model.jl
+++ b/src/model.jl
@@ -109,24 +109,25 @@ function Model{missings}(
     return Model{missings}(model.f, args, modelgen)
 end
 
+"""
+    (model::Model)([spl = SampleFromPrior(), ctx = DefaultContext()])
 
+Sample from `model` using the sampler `spl`.
+"""
 function (model::Model)(
-    vi::AbstractVarInfo=VarInfo(),
     spl::AbstractSampler=SampleFromPrior(),
     ctx::AbstractContext=DefaultContext()
 )
-    return model.f(model, vi, spl, ctx)
+    return model(VarInfo(), spl, ctx)
 end
 
-
 """
-    runmodel!(model::Model, vi::AbstractVarInfo[, spl::AbstractSampler, ctx::AbstractContext])
+    (model::Model)(vi::AbstractVarInfo[, spl = SampleFromPrior(), ctx = DefaultContext()])
 
 Sample from `model` using the sampler `spl` storing the sample and log joint probability in `vi`.
 Resets the `vi` and increases `spl`s `state.eval_num`.
 """
-function runmodel!(
-    model::Model,
+function (model::Model)(
     vi::AbstractVarInfo,
     spl::AbstractSampler=SampleFromPrior(),
     ctx::AbstractContext=DefaultContext()
@@ -135,8 +136,7 @@ function runmodel!(
     if has_eval_num(spl)
         spl.state.eval_num += 1
     end
-    model(vi, spl, ctx)
-    return vi
+    return model.f(model, vi, spl, ctx)
 end
 
 

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -107,7 +107,7 @@ const TypedVarInfo = VarInfo{<:NamedTuple}
 
 function VarInfo(model::Model, ctx = DefaultContext())
     vi = VarInfo()
-    runmodel!(model, vi, SampleFromPrior(), ctx)
+    model(vi, SampleFromPrior(), ctx)
     return TypedVarInfo(vi)
 end
 

--- a/test/Turing/Turing.jl
+++ b/test/Turing/Turing.jl
@@ -16,7 +16,7 @@ using Markdown, Libtask, MacroTools
 using Tracker: Tracker
 
 import Base: ~, ==, convert, hash, promote_rule, rand, getindex, setindex!
-import DynamicPPL: getspace, runmodel!
+import DynamicPPL: getspace
 
 const PROGRESS = Ref(true)
 function turnprogress(switch::Bool)

--- a/test/Turing/contrib/inference/dynamichmc.jl
+++ b/test/Turing/contrib/inference/dynamichmc.jl
@@ -60,11 +60,11 @@ function AbstractMCMC.sample_init!(
         gradient_logp(x, spl.state.vi, model, spl)
     end
 
-    runmodel!(model, spl.state.vi, SampleFromUniform())
+    model(spl.state.vi, SampleFromUniform())
 
     if spl.selector.tag == :default
         link!(spl.state.vi, spl)
-        runmodel!(model, spl.state.vi, spl)
+        model(spl.state.vi, spl)
     end
 
     # Set the parameters to a starting value.

--- a/test/Turing/contrib/inference/sghmc.jl
+++ b/test/Turing/contrib/inference/sghmc.jl
@@ -85,7 +85,7 @@ function step(
     Turing.DEBUG && @debug "X-> R..."
     if spl.selector.tag != :default
         link!(vi, spl)
-        runmodel!(model, vi, spl)
+        model(vi, spl)
     end
 
     Turing.DEBUG && @debug "recording old variables..."
@@ -198,7 +198,7 @@ function step(
     Turing.DEBUG && @debug "X-> R..."
     if spl.selector.tag != :default
         link!(vi, spl)
-        runmodel!(model, vi, spl)
+        model(vi, spl)
     end
 
     Turing.DEBUG && @debug "recording old variables..."

--- a/test/Turing/core/Core.jl
+++ b/test/Turing/core/Core.jl
@@ -6,7 +6,7 @@ using Distributions, LinearAlgebra
 using ..Utilities, Reexport
 using Tracker: Tracker
 using ..Turing: Turing
-using DynamicPPL: Model, runmodel!,
+using DynamicPPL: Model,
     AbstractSampler, Sampler, SampleFromPrior
 using LinearAlgebra: copytri!
 using Bijectors: PDMatDistribution

--- a/test/Turing/core/ad.jl
+++ b/test/Turing/core/ad.jl
@@ -92,7 +92,8 @@ function gradient_logp(
     logp_old = getlogp(vi)
     function f(θ)
         new_vi = VarInfo(vi, sampler, θ)
-        logp = getlogp(runmodel!(model, new_vi, sampler))
+        model(new_vi, sampler)
+        logp = getlogp(new_vi)
         setlogp!(vi, ForwardDiff.value(logp))
         return logp
     end
@@ -119,7 +120,8 @@ function gradient_logp(
     # Specify objective function.
     function f(θ)
         new_vi = VarInfo(vi, sampler, θ)
-        return getlogp(runmodel!(model, new_vi, sampler))
+        model(new_vi, sampler)
+        return getlogp(new_vi)
     end
 
     # Compute forward and reverse passes.

--- a/test/Turing/core/compat/zygote.jl
+++ b/test/Turing/core/compat/zygote.jl
@@ -16,7 +16,8 @@ function gradient_logp(
     # Specify objective function.
     function f(θ)
         new_vi = VarInfo(vi, sampler, θ)
-        return getlogp(runmodel!(model, new_vi, sampler))
+        model(new_vi, sampler)
+        return getlogp(new_vi)
     end
 
     # Compute forward and reverse passes.

--- a/test/Turing/inference/Inference.jl
+++ b/test/Turing/inference/Inference.jl
@@ -4,7 +4,7 @@ using ..Core, ..Utilities
 using DynamicPPL: Metadata, _tail, VarInfo, TypedVarInfo, 
     islinked, invlink!, getlogp, tonamedtuple, VarName, getsym, vectorize, 
     settrans!, _getvns, getdist, split_var_str, CACHERESET, AbstractSampler,
-    Model, runmodel!, Sampler, SampleFromPrior, SampleFromUniform,
+    Model, Sampler, SampleFromPrior, SampleFromUniform,
     Selector, AbstractSamplerState, DefaultContext, PriorContext,
     LikelihoodContext, MiniBatchContext, set_flag!, unset_flag!, NamedDist, NoDist
 using Distributions, Libtask, Bijectors

--- a/test/Turing/inference/Inference.jl
+++ b/test/Turing/inference/Inference.jl
@@ -4,7 +4,7 @@ using ..Core, ..Utilities
 using DynamicPPL: Metadata, _tail, VarInfo, TypedVarInfo, 
     islinked, invlink!, getlogp, tonamedtuple, VarName, getsym, vectorize, 
     settrans!, _getvns, getdist, CACHERESET, AbstractSampler,
-    Model, runmodel!, Sampler, SampleFromPrior, SampleFromUniform,
+    Model, Sampler, SampleFromPrior, SampleFromUniform,
     Selector, AbstractSamplerState, DefaultContext, PriorContext,
     LikelihoodContext, MiniBatchContext, set_flag!, unset_flag!, NamedDist, NoDist
 using Distributions, Libtask, Bijectors

--- a/test/Turing/inference/ess.jl
+++ b/test/Turing/inference/ess.jl
@@ -76,7 +76,7 @@ function AbstractMCMC.step!(
 
     # recompute log-likelihood in logp
     if spl.selector.tag !== :default
-        runmodel!(model, vi, spl)
+        model(vi, spl)
     end
 
     # define previous sampler state
@@ -117,7 +117,7 @@ function EllipticalSliceSampling.sample_prior(rng::Random.AbstractRNG, model::ES
     vi = spl.state.vi
     vns = _getvns(vi, spl)
     set_flag!(vi, vns[1][1], "del")
-    runmodel!(model.model, vi, spl)
+    model.model(vi, spl)
     return vi[spl]
 end
 
@@ -140,7 +140,7 @@ function Distributions.loglikelihood(model::ESSModel, f)
     spl = model.spl
     vi = spl.state.vi
     vi[spl] = f
-    runmodel!(model.model, vi, spl)
+    model.model(vi, spl)
     getlogp(vi)
 end
 

--- a/test/Turing/inference/hmc.jl
+++ b/test/Turing/inference/hmc.jl
@@ -137,7 +137,7 @@ function AbstractMCMC.sample_init!(
     # non-Gibbs sampling.
     if !islinked(spl.state.vi, spl) && spl.selector.tag == :default
         link!(spl.state.vi, spl)
-        runmodel!(model, spl.state.vi, spl)
+        model(spl.state.vi, spl)
     end
 end
 
@@ -343,7 +343,7 @@ function AbstractMCMC.step!(
         # Transform the space
         Turing.DEBUG && @debug "X-> R..."
         link!(spl.state.vi, spl)
-        runmodel!(model, spl.state.vi, spl)
+        model(spl.state.vi, spl)
         # Update Hamiltonian
         metric = gen_metric(length(spl.state.vi[spl]), spl)
         ∂logπ∂θ = gen_∂logπ∂θ(spl.state.vi, spl, model)
@@ -413,7 +413,7 @@ function gen_logπ(vi::VarInfo, spl::Sampler, model)
     function logπ(x)::Float64
         x_old, lj_old = vi[spl], getlogp(vi)
         vi[spl] = x
-        runmodel!(model, vi, spl)
+        model(vi, spl)
         lj = getlogp(vi)
         vi[spl] = x_old
         setlogp!(vi, lj_old)

--- a/test/Turing/inference/mh.jl
+++ b/test/Turing/inference/mh.jl
@@ -105,7 +105,7 @@ function gen_logπ_mh(spl::Sampler, model)
         x_old, lj_old = vi[spl], getlogp(vi)
         # vi[spl] = x
         set_namedtuple!(vi, x)
-        runmodel!(model, vi)
+        model(vi)
         lj = getlogp(vi)
         vi[spl] = x_old
         setlogp!(vi, lj_old)
@@ -231,7 +231,7 @@ function AbstractMCMC.step!(
     kwargs...
 )
     if spl.selector.rerun # Recompute joint in logp
-        runmodel!(model, spl.state.vi)
+        model(spl.state.vi)
     end
 
     # Retrieve distribution and value NamedTuples.

--- a/test/independence.jl
+++ b/test/independence.jl
@@ -7,8 +7,5 @@
         end
     end
     model = coinflip([1,1,0])
-
-    vi = VarInfo()
-
-    runmodel!(model, vi, SampleFromPrior(), LikelihoodContext())
+    model(SampleFromPrior(), LikelihoodContext())
 end

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -1,7 +1,7 @@
 using .Turing, Random
 using AbstractMCMC: step!
 using DynamicPPL: Selector, reconstruct, invlink, CACHERESET,
-    SampleFromPrior, Sampler, SampleFromUniform, uid, 
+    SampleFromPrior, Sampler, SampleFromUniform,
     _getidcs, set_retained_vns_del_by_spl!, is_flagged,
     set_flag!, unset_flag!, VarInfo, TypedVarInfo,
     getlogp, setlogp!, resetlogp!, acclogp!, vectorize,

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -1,7 +1,7 @@
 using .Turing, Random
 using AbstractMCMC: step!
 using DynamicPPL: Selector, reconstruct, invlink, CACHERESET,
-    SampleFromPrior, Sampler, runmodel!, SampleFromUniform, uid, 
+    SampleFromPrior, Sampler, SampleFromUniform, uid, 
     _getidcs, set_retained_vns_del_by_spl!, is_flagged,
     set_flag!, unset_flag!, VarInfo, TypedVarInfo,
     getlogp, setlogp!, resetlogp!, acclogp!, vectorize,

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -1,7 +1,7 @@
 using .Turing, Random
 using AbstractMCMC: step!
 using DynamicPPL: Selector, reconstruct, invlink, CACHERESET,
-    SampleFromPrior, Sampler, runmodel!, SampleFromUniform, uid, 
+    SampleFromPrior, Sampler, SampleFromUniform, uid, 
     _getidcs, set_retained_vns_del_by_spl!, is_flagged,
     set_flag!, unset_flag!, VarInfo, TypedVarInfo,
     getlogp, setlogp!, resetlogp!, acclogp!, vectorize,
@@ -117,19 +117,18 @@ include(dir*"/test/test_utils/AllUtils.jl")
         test_base!(vi)
         test_base!(empty!(TypedVarInfo(vi)))
     end
-    @testset "runmodel!" begin
-        # Test that eval_num is incremented when calling runmodel!
+    @testset "in-place" begin
+        # Test that eval_num is incremented when running the model
         @model testmodel() = begin
             x ~ Normal()
         end
         alg = HMC(0.1, 5)
         spl = Sampler(alg, testmodel())
-        vi = VarInfo()
         m = testmodel()
-        m(vi)
-        runmodel!(m, vi, spl)
+        vi = VarInfo(m)
+        m(vi, spl)
         @test spl.state.eval_num == 1
-        runmodel!(m, vi, spl)
+        m(vi, spl)
         @test spl.state.eval_num == 2
     end
     @testset "flags" begin


### PR DESCRIPTION
As can be seen in https://github.com/TuringLang/DynamicPPL.jl/pull/50#issuecomment-611088486, the output of `model()` can be quite surprising if no return statements are specified in the model definition. One possible solution to the problem that is implemented in this PR is to always return `nothing` as a fallback. An alternative would be to return the `VarInfo` object as a fallback but that might be not completely user-friendly since it might not be clear how to handle or analyse it.

Additionally, currently `logp` is reset both in the default evaluation function and in `runmodel!`, so basically `model(vi)` and `runmodel!(vi)` are doing the same thing currently apart from adjusting `eval_num`. I removed the `resetlogp!` statement in the evaluation function to allow for greater flexibility and removed the `runmodel!` function. Instead now one can call `model()` and `model(vi)` - without `vi` a new `VarInfo` object is created but otherwise they are doing exactly the same thing.