### PR TITLE
Add shorter non-display printing of VarInfo

### DIFF
--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -924,7 +924,7 @@ function haskey(vi::TypedVarInfo, vn::VarName)
     return getsym(vn) in fieldnames(Tmeta) && haskey(getmetadata(vi, vn).idcs, vn)
 end
 
-function show(io::IO, vi::UntypedVarInfo)
+function Base.show(io::IO, ::MIME"text/plain", vi::UntypedVarInfo)
     vi_str = """
     /=======================================================================
     | VarInfo
@@ -941,6 +941,8 @@ function show(io::IO, vi::UntypedVarInfo)
     """
     print(io, vi_str)
 end
+
+Base.show(io::IO, vi::UntypedVarInfo) = print(io, "VarInfo of ", vi.metadata.vns)
 
 # Add a new entry to VarInfo
 """

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -942,10 +942,29 @@ function Base.show(io::IO, ::MIME"text/plain", vi::UntypedVarInfo)
     print(io, vi_str)
 end
 
+
+const _MAX_VARS_SHOWN = 4
+
+function _show_varnames(io::IO, vi)
+    md = vi.metadata
+    vns = md.vns
+
+    groups = Dict{Symbol, Vector{VarName}}()
+    for vn in vns
+        group = get!(() -> Vector{VarName}(), groups, getsym(vn))
+        push!(group, vn)
+    end
+
+    print(io, length(groups), " variables (")
+    join(io, Iterators.take(keys(groups), _MAX_VARS_SHOWN), ", ")
+    length(groups) > _MAX_VARS_SHOWN && print(io, ", ...")
+    print(io, "), dimension ", sum(prod(size(md.vals[md.ranges[md.idcs[vn]]])) for vn in vns))
+end
+
 function Base.show(io::IO, vi::UntypedVarInfo)
     print(io, "VarInfo (")
-    print(io, length(vi.metadata.vns), " variables, ")
-    print(io, "logp = ", round(getlogp(vi), digits=3))
+    _show_varnames(io, vi)
+    print(io, "; logp: ", round(getlogp(vi), digits=3))
     print(io, ")")
 end
 

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -942,7 +942,12 @@ function Base.show(io::IO, ::MIME"text/plain", vi::UntypedVarInfo)
     print(io, vi_str)
 end
 
-Base.show(io::IO, vi::UntypedVarInfo) = print(io, "VarInfo of ", vi.metadata.vns)
+function Base.show(io::IO, vi::UntypedVarInfo)
+    print(io, "VarInfo (")
+    print(io, length(vi.metadata.vns), " variables, ")
+    print(io, "logp = ", round(getlogp(vi), digits=3))
+    print(io, ")")
+end
 
 # Add a new entry to VarInfo
 """

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -955,7 +955,7 @@ function _show_varnames(io::IO, vi)
         push!(group, vn)
     end
 
-    print(io, length(groups), " variables (")
+    print(io, length(groups), length(groups) == 1 ? " variable " : " variables ", "(")
     join(io, Iterators.take(keys(groups), _MAX_VARS_SHOWN), ", ")
     length(groups) > _MAX_VARS_SHOWN && print(io, ", ...")
     print(io, "), dimension ", sum(prod(size(md.vals[md.ranges[md.idcs[vn]]])) for vn in vns))
@@ -968,7 +968,7 @@ function Base.show(io::IO, vi::UntypedVarInfo)
     print(io, ")")
 end
 
-# Add a new entry to VarInfo
+
 """
     push!(vi::VarInfo, vn::VarName, r, dist::Distribution)
 


### PR DESCRIPTION
Currently, a `VarInfo` prints to a huge blob showing all kinds of stuff.  Which is useful on its own in the REPL, but not as part of another printed structure.

I moved that version to `show(::IO, ::MIME"text/plain", ::UntypedVarInfo)`, and added a dummy replacement

```julia
Base.show(io::IO, vi::UntypedVarInfo) = print(io, "VarInfo of ", vi.metadata.vns)
```

Please suggest what things should actually printed in the short version.