### PR TITLE
Make tilde_{assume,observe} functions behave more uniformly

### DIFF
--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -36,13 +36,12 @@ function tilde(ctx::MiniBatchContext, sampler, right, left::VarName, inds, vi)
 end
 
 """
-    tilde_assume(ctx, sampler, right, vn, inds, vi) -> sampled value
+    tilde_assume(ctx, sampler, right, vn, inds, vi)
 
-This method is applied in the generated code for assumed variables, e.g., `x ~ Normal()` where
-`x` does not occur in the model inputs.
+Handles assumed variables, e.g., `x ~ Normal()` (where `x` does occur in the model inputs),
+accumulates the log probability, and returns the sampled value.
 
-Falls back to `tilde(ctx, sampler, right, vn, inds, vi)`, but automatically accumulates the
-log-probability and returns only the sampled value.
+Falls back to `tilde(ctx, sampler, right, vn, inds, vi)`.
 """
 function tilde_assume(ctx, sampler, right, vn, inds, vi)
     value, logp = tilde(ctx, sampler, right, vn, inds, vi)
@@ -73,14 +72,13 @@ function tilde(ctx::MiniBatchContext, sampler, right, left, vi)
 end
 
 """
-    tilde_observe(ctx, sampler, right, left, vname, vinds, vi) -> observed value
+    tilde_observe(ctx, sampler, right, left, vname, vinds, vi)
 
-This method is applied in the generated code for observed variables, e.g., `x ~ Normal()` where
-`x` does occur in the model inputs.
+Handles observed variables, e.g., `x ~ Normal()` (where `x` does occur in the model inputs),
+accumulates the log probability, and returns the observed value.
 
 Falls back to `tilde(ctx, sampler, right, left, vi)` ignoring the information about variable name
-and indices; if needed, these can be accessed through this function, though.  Automatically
-accumulates the log-probability and returns only the observed value.
+and indices; if needed, these can be accessed through this function, though.
 """
 function tilde_observe(ctx, sampler, right, left, vname, vinds, vi)
     logp = tilde(ctx, sampler, right, left, vi)
@@ -89,11 +87,12 @@ function tilde_observe(ctx, sampler, right, left, vname, vinds, vi)
 end
 
 """
-    tilde_observe(ctx, sampler, right, left, vi) -> observed value
+    tilde_observe(ctx, sampler, right, left, vi)
 
-This method is applied in the generated code for observed constants, e.g., `1.0 ~ Normal()`.
-Falls back to `tilde(ctx, sampler, right, left, vi)`.  Automatically accumulates the log-probability
-and returns only the observed value.
+Handles observed constants, e.g., `1.0 ~ Normal()`, accumulates the log probability, and returns the
+observed value.
+
+Falls back to `tilde(ctx, sampler, right, left, vi)`.
 """
 function tilde_observe(ctx, sampler, right, left, vi)
     logp = tilde(ctx, sampler, right, left, vi)
@@ -198,13 +197,12 @@ function dot_tilde(
 end
 
 """
-    dot_tilde_assume(ctx, sampler, right, left, vn, inds, vi) -> sampled value
+    dot_tilde_assume(ctx, sampler, right, left, vn, inds, vi)
 
-This method is applied in the generated code for assumed vectorized variables, e.g., `x .~
-MvNormal()` where `x` does not occur in the model inputs.
+Handles broadcasted assumed variables, e.g., `x .~ MvNormal()` (where `x` does not occur in the
+model inputs), accumulates the log probability, and returns the sampled value.
 
-Falls back to `dot_tilde(ctx, sampler, right, left, vn, inds, vi)`, but automatically accumulates
-the log-probability and returns only the sampled value.
+Falls back to `dot_tilde(ctx, sampler, right, left, vn, inds, vi)`.
 """
 function dot_tilde_assume(ctx, sampler, right, left, vn, inds, vi)
     value, logp = dot_tilde(ctx, sampler, right, left, vn, inds, vi)
@@ -377,14 +375,13 @@ function dot_tilde(ctx::MiniBatchContext, sampler, right, left, vi)
 end
 
 """
-    dot_tilde_observe(ctx, sampler, right, left, vname, vinds, vi) -> observed value
+    dot_tilde_observe(ctx, sampler, right, left, vname, vinds, vi)
 
-This method is applied in the generated code for vectorized observed variables, e.g., `x .~
-MvNormal()` where `x` does occur the model inputs.
+Handles broadcasted observed values, e.g., `x .~ MvNormal()` (where `x` does occur the model inputs),
+accumulates the log probability, and returns the observed value.
 
 Falls back to `dot_tilde(ctx, sampler, right, left, vi)` ignoring the information about variable
-name and indices; if needed, these can be accessed through this function, though.  Automatically
-accumulates the log-probability and returns only the observed value.
+name and indices; if needed, these can be accessed through this function, though.
 """
 function dot_tilde_observe(ctx, sampler, right, left, vn, inds, vi)
     logp = dot_tilde(ctx, sampler, right, left, vi)
@@ -393,11 +390,12 @@ function dot_tilde_observe(ctx, sampler, right, left, vn, inds, vi)
 end
 
 """
-    dot_tilde_observe(ctx, sampler, right, left, vi) -> observed value
+    dot_tilde_observe(ctx, sampler, right, left, vi)
 
-This method is applied in the generated code for vectorized observed constants, e.g., `[1.0] .~
-MvNormal()`.  Falls back to `dot_tilde(ctx, sampler, right, left, vi)`.  Automatically
-accumulates the log-probability and returns only the observed value.
+Handles broadcasted observed constants, e.g., `[1.0] .~ MvNormal()`, accumulates the log
+probability, and returns the observed value.
+
+Falls back to `dot_tilde(ctx, sampler, right, left, vi)`.
 """
 function dot_tilde_observe(ctx, sampler, right, left, vi)
     logp = dot_tilde(ctx, sampler, right, left, vi)

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -36,12 +36,13 @@ function tilde(ctx::MiniBatchContext, sampler, right, left::VarName, inds, vi)
 end
 
 """
-    tilde_assume(ctx, sampler, right, vn, inds, vi)
+    tilde_assume(ctx, sampler, right, vn, inds, vi) -> sampled value
 
 This method is applied in the generated code for assumed variables, e.g., `x ~ Normal()` where
 `x` does not occur in the model inputs.
 
-Falls back to `tilde(ctx, sampler, right, vn, inds, vi)`.
+Falls back to `tilde(ctx, sampler, right, vn, inds, vi)`, but automatically accumulates the
+log-probability and returns only the sampled value.
 """
 function tilde_assume(ctx, sampler, right, vn, inds, vi)
     value, logp = tilde(ctx, sampler, right, vn, inds, vi)
@@ -72,13 +73,14 @@ function tilde(ctx::MiniBatchContext, sampler, right, left, vi)
 end
 
 """
-    tilde_observe(ctx, sampler, right, left, vname, vinds, vi)
+    tilde_observe(ctx, sampler, right, left, vname, vinds, vi) -> observed value
 
 This method is applied in the generated code for observed variables, e.g., `x ~ Normal()` where
 `x` does occur in the model inputs.
 
-Falls back to `tilde(ctx, sampler, right, left, vi)` ignoring the information about variable
-name and indices; if needed, these can be accessed through this function, though.
+Falls back to `tilde(ctx, sampler, right, left, vi)` ignoring the information about variable name
+and indices; if needed, these can be accessed through this function, though.  Automatically
+accumulates the log-probability and returns only the observed value.
 """
 function tilde_observe(ctx, sampler, right, left, vname, vinds, vi)
     logp = tilde(ctx, sampler, right, left, vi)
@@ -87,10 +89,11 @@ function tilde_observe(ctx, sampler, right, left, vname, vinds, vi)
 end
 
 """
-    tilde_observe(ctx, sampler, right, left, vi)
+    tilde_observe(ctx, sampler, right, left, vi) -> observed value
 
 This method is applied in the generated code for observed constants, e.g., `1.0 ~ Normal()`.
-Falls back to `tilde(ctx, sampler, right, left, vi)`.
+Falls back to `tilde(ctx, sampler, right, left, vi)`.  Automatically accumulates the log-probability
+and returns only the observed value.
 """
 function tilde_observe(ctx, sampler, right, left, vi)
     logp = tilde(ctx, sampler, right, left, vi)
@@ -195,12 +198,13 @@ function dot_tilde(
 end
 
 """
-    dot_tilde_assume(ctx, sampler, right, left, vn, inds, vi)
+    dot_tilde_assume(ctx, sampler, right, left, vn, inds, vi) -> sampled value
 
 This method is applied in the generated code for assumed vectorized variables, e.g., `x .~
 MvNormal()` where `x` does not occur in the model inputs.
 
-Falls back to `dot_tilde(ctx, sampler, right, left, vn, inds, vi)`.
+Falls back to `dot_tilde(ctx, sampler, right, left, vn, inds, vi)`, but automatically accumulates
+the log-probability and returns only the sampled value.
 """
 function dot_tilde_assume(ctx, sampler, right, left, vn, inds, vi)
     value, logp = dot_tilde(ctx, sampler, right, left, vn, inds, vi)
@@ -373,13 +377,14 @@ function dot_tilde(ctx::MiniBatchContext, sampler, right, left, vi)
 end
 
 """
-    dot_tilde_observe(ctx, sampler, right, left, vname, vinds, vi)
+    dot_tilde_observe(ctx, sampler, right, left, vname, vinds, vi) -> observed value
 
 This method is applied in the generated code for vectorized observed variables, e.g., `x .~
 MvNormal()` where `x` does occur the model inputs.
 
 Falls back to `dot_tilde(ctx, sampler, right, left, vi)` ignoring the information about variable
-name and indices; if needed, these can be accessed through this function, though.
+name and indices; if needed, these can be accessed through this function, though.  Automatically
+accumulates the log-probability and returns only the observed value.
 """
 function dot_tilde_observe(ctx, sampler, right, left, vn, inds, vi)
     logp = dot_tilde(ctx, sampler, right, left, vi)
@@ -388,10 +393,11 @@ function dot_tilde_observe(ctx, sampler, right, left, vn, inds, vi)
 end
 
 """
-    dot_tilde_observe(ctx, sampler, right, left, vi)
+    dot_tilde_observe(ctx, sampler, right, left, vi) -> observed value
 
 This method is applied in the generated code for vectorized observed constants, e.g., `[1.0] .~
-MvNormal()`.  Falls back to `dot_tilde(ctx, sampler, right, left, vi)`.
+MvNormal()`.  Falls back to `dot_tilde(ctx, sampler, right, left, vi)`.  Automatically
+accumulates the log-probability and returns only the observed value.
 """
 function dot_tilde_observe(ctx, sampler, right, left, vi)
     logp = dot_tilde(ctx, sampler, right, left, vi)

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -38,8 +38,8 @@ end
 """
     tilde_assume(ctx, sampler, right, vn, inds, vi)
 
-Handles assumed variables, e.g., `x ~ Normal()` (where `x` does occur in the model inputs),
-accumulates the log probability, and returns the sampled value.
+Handle assumed variables, e.g., `x ~ Normal()` (where `x` does occur in the model inputs),
+accumulate the log probability, and return the sampled value.
 
 Falls back to `tilde(ctx, sampler, right, vn, inds, vi)`.
 """
@@ -74,8 +74,8 @@ end
 """
     tilde_observe(ctx, sampler, right, left, vname, vinds, vi)
 
-Handles observed variables, e.g., `x ~ Normal()` (where `x` does occur in the model inputs),
-accumulates the log probability, and returns the observed value.
+Handle observed variables, e.g., `x ~ Normal()` (where `x` does occur in the model inputs),
+accumulate the log probability, and return the observed value.
 
 Falls back to `tilde(ctx, sampler, right, left, vi)` ignoring the information about variable name
 and indices; if needed, these can be accessed through this function, though.
@@ -89,7 +89,7 @@ end
 """
     tilde_observe(ctx, sampler, right, left, vi)
 
-Handles observed constants, e.g., `1.0 ~ Normal()`, accumulates the log probability, and returns the
+Handle observed constants, e.g., `1.0 ~ Normal()`, accumulate the log probability, and return the
 observed value.
 
 Falls back to `tilde(ctx, sampler, right, left, vi)`.
@@ -199,8 +199,8 @@ end
 """
     dot_tilde_assume(ctx, sampler, right, left, vn, inds, vi)
 
-Handles broadcasted assumed variables, e.g., `x .~ MvNormal()` (where `x` does not occur in the
-model inputs), accumulates the log probability, and returns the sampled value.
+Handle broadcasted assumed variables, e.g., `x .~ MvNormal()` (where `x` does not occur in the
+model inputs), accumulate the log probability, and return the sampled value.
 
 Falls back to `dot_tilde(ctx, sampler, right, left, vn, inds, vi)`.
 """
@@ -377,8 +377,8 @@ end
 """
     dot_tilde_observe(ctx, sampler, right, left, vname, vinds, vi)
 
-Handles broadcasted observed values, e.g., `x .~ MvNormal()` (where `x` does occur the model inputs),
-accumulates the log probability, and returns the observed value.
+Handle broadcasted observed values, e.g., `x .~ MvNormal()` (where `x` does occur the model inputs),
+accumulate the log probability, and return the observed value.
 
 Falls back to `dot_tilde(ctx, sampler, right, left, vi)` ignoring the information about variable
 name and indices; if needed, these can be accessed through this function, though.
@@ -392,8 +392,8 @@ end
 """
     dot_tilde_observe(ctx, sampler, right, left, vi)
 
-Handles broadcasted observed constants, e.g., `[1.0] .~ MvNormal()`, accumulates the log
-probability, and returns the observed value.
+Handle broadcasted observed constants, e.g., `[1.0] .~ MvNormal()`, accumulate the log
+probability, and return the observed value.
 
 Falls back to `dot_tilde(ctx, sampler, right, left, vi)`.
 """

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -44,7 +44,9 @@ This method is applied in the generated code for assumed variables, e.g., `x ~ N
 Falls back to `tilde(ctx, sampler, right, vn, inds, vi)`.
 """
 function tilde_assume(ctx, sampler, right, vn, inds, vi)
-    return tilde(ctx, sampler, right, vn, inds, vi)
+    (value, logp) = tilde(ctx, sampler, right, vn, inds, vi)
+    acclogp!(vi, logp)
+    return value
 end
 
 
@@ -79,7 +81,9 @@ Falls back to `tilde(ctx, sampler, right, left, vi)` ignoring the information ab
 name and indices; if needed, these can be accessed through this function, though.
 """
 function tilde_observe(ctx, sampler, right, left, vname, vinds, vi)
-    return tilde(ctx, sampler, right, left, vi)
+    logp = tilde(ctx, sampler, right, left, vi)
+    acclogp!(vi, logp)
+    return left
 end
 
 """
@@ -89,7 +93,9 @@ This method is applied in the generated code for observed constants, e.g., `1.0 
 Falls back to `tilde(ctx, sampler, right, left, vi)`.
 """
 function tilde_observe(ctx, sampler, right, left, vi)
-    return tilde(ctx, sampler, right, left, vi)
+    logp = tilde(ctx, sampler, right, left, vi)
+    acclogp!(vi, logp)
+    return left
 end
 
 
@@ -197,7 +203,9 @@ MvNormal()` where `x` does not occur in the model inputs.
 Falls back to `dot_tilde(ctx, sampler, right, left, vn, inds, vi)`.
 """
 function dot_tilde_assume(ctx, sampler, right, left, vn, inds, vi)
-    return dot_tilde(ctx, sampler, right, left, vn, inds, vi)
+    (value, logp) = dot_tilde(ctx, sampler, right, left, vn, inds, vi)
+    acclogp!(vi, logp)
+    return value
 end
 
 
@@ -374,7 +382,9 @@ Falls back to `dot_tilde(ctx, sampler, right, left, vi)` ignoring the informatio
 name and indices; if needed, these can be accessed through this function, though.
 """
 function dot_tilde_observe(ctx, sampler, right, left, vn, inds, vi)
-    return dot_tilde(ctx, sampler, right, left, vi)
+    logp = dot_tilde(ctx, sampler, right, left, vi)
+    acclogp!(vi, logp)
+    return left
 end
 
 """
@@ -384,7 +394,9 @@ This method is applied in the generated code for vectorized observed constants, 
 MvNormal()`.  Falls back to `dot_tilde(ctx, sampler, right, left, vi)`.
 """
 function dot_tilde_observe(ctx, sampler, right, left, vi)
-    return dot_tilde(ctx, sampler, right, left, vi)
+    logp = dot_tilde(ctx, sampler, right, left, vi)
+    acclogp!(vi, logp)
+    return left
 end
 
 

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -44,7 +44,7 @@ This method is applied in the generated code for assumed variables, e.g., `x ~ N
 Falls back to `tilde(ctx, sampler, right, vn, inds, vi)`.
 """
 function tilde_assume(ctx, sampler, right, vn, inds, vi)
-    (value, logp) = tilde(ctx, sampler, right, vn, inds, vi)
+    value, logp = tilde(ctx, sampler, right, vn, inds, vi)
     acclogp!(vi, logp)
     return value
 end
@@ -203,7 +203,7 @@ MvNormal()` where `x` does not occur in the model inputs.
 Falls back to `dot_tilde(ctx, sampler, right, left, vn, inds, vi)`.
 """
 function dot_tilde_assume(ctx, sampler, right, left, vn, inds, vi)
-    (value, logp) = dot_tilde(ctx, sampler, right, left, vn, inds, vi)
+    value, logp = dot_tilde(ctx, sampler, right, left, vn, inds, vi)
     acclogp!(vi, logp)
     return value
 end


### PR DESCRIPTION
Seems like I'm too late to veto the release, but anyway...

The PR changes the tilde functions used in the generated code to include `acclogp!`, and always just return the sampled value (instead of sometimes the logp, sometimes the logp and the value).  This is in light with the now consistent behaviour of making tildes always return their value, and cleans up the generated code a bit.

It shouldn't make any difference to the outside.  The `[dot_]tilde_{assume,observe}` functions were only added recently in #53 and aren't really part of the public interface -- `tilde` and `dot_tilde` work as before.