### PR TITLE
Fix SampleFromUniform and implement AbstractMCMC interface for SampleFromPrior and SampleFromUniform

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -4,6 +4,9 @@ using AbstractMCMC: AbstractSampler, AbstractChains, AbstractModel
 using Distributions
 using Bijectors
 using MacroTools
+
+import AbstractMCMC
+import Random
 import ZygoteRules
 
 import Base: Symbol,

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -43,3 +43,18 @@ end
 Sampler(alg) = Sampler(alg, Selector())
 Sampler(alg, model::Model) = Sampler(alg, model, Selector())
 Sampler(alg, model::Model, s::Selector) = Sampler(alg, model, s)
+
+# AbstractMCMC interface for SampleFromUniform and SampleFromPrior
+
+function AbstractMCMC.step!(
+    rng::Random.AbstractRNG,
+    model::Model,
+    sampler::Union{SampleFromUniform,SampleFromPrior},
+    ::Integer,
+    transition;
+    kwargs...
+)
+    vi = VarInfo()
+    model(vi, sampler)
+    return vi
+end

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -6,6 +6,15 @@ struct SampleFromPrior <: AbstractSampler end
 
 getspace(::Union{SampleFromPrior, SampleFromUniform}) = ()
 
+# Initializations.
+init(dist, ::SampleFromPrior) = rand(dist)
+init(dist, ::SampleFromUniform) = istransformable(dist) ? inittrans(dist) : rand(dist)
+
+init(dist, ::SampleFromPrior, n::Int) = rand(dist, n)
+function init(dist, ::SampleFromUniform, n::Int)
+    return istransformable(dist) ? inittrans(dist, n) : rand(dist, n)
+end
+
 """
     has_eval_num(spl::AbstractSampler)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -114,37 +114,31 @@ function reconstruct!(r, d::MultivariateDistribution, val::AbstractVector, n::In
     return r
 end
 
-
-# ROBUST INITIALISATIONS
-# Uniform rand with range 2; ref: https://mc-stan.org/docs/2_19/reference-manual/initialization.html
+# Uniform random numbers with range 4 for robust initializations
+# Reference: https://mc-stan.org/docs/2_19/reference-manual/initialization.html
 randrealuni() = 4 * rand() - 2
 randrealuni(args...) = 4 .* rand(args...) .- 2
 
-const Transformable = Union{TransformDistribution, SimplexDistribution, PDMatDistribution}
-
+const Transformable = Union{PositiveDistribution,UnitDistribution,TransformDistribution,
+                            SimplexDistribution,PDMatDistribution}
+istransformable(dist) = false
+istransformable(::Transformable) = true
 
 #################################
 # Single-sample initialisations #
 #################################
 
-init(dist::Transformable) = inittrans(dist)
-init(dist::Distribution) = rand(dist)
-
 inittrans(dist::UnivariateDistribution) = invlink(dist, randrealuni())
-inittrans(dist::MultivariateDistribution) = invlink(dist, randrealuni(size(dist)[1]))
+inittrans(dist::MultivariateDistribution) = invlink(dist, randrealuni(size(dist, 1)))
 inittrans(dist::MatrixDistribution) = invlink(dist, randrealuni(size(dist)...))
-
 
 ################################
 # Multi-sample initialisations #
 ################################
 
-init(dist::Transformable, n::Int) = inittrans(dist, n)
-init(dist::Distribution, n::Int) = rand(dist, n)
-
 inittrans(dist::UnivariateDistribution, n::Int) = invlink(dist, randrealuni(n))
 function inittrans(dist::MultivariateDistribution, n::Int)
-    return invlink(dist, randrealuni(size(dist)[1], n))
+    return invlink(dist, randrealuni(size(dist, 1), n))
 end
 function inittrans(dist::MatrixDistribution, n::Int)
     return invlink(dist, [randrealuni(size(dist)...) for _ in 1:n])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ turnprogress(false)
     include("utils.jl")
     include("compiler.jl")
     include("varinfo.jl")
+    include("sampler.jl")
     include("prob_macro.jl")
     include("independence.jl")
 end

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -6,29 +6,37 @@ using Random
 using Statistics
 using Test
 
-Random.seed!(1234)
+Random.seed!(100)
 
 @testset "AbstractMCMC interface" begin
     @model gdemo(x, y) = begin
         s ~ InverseGamma(2, 3)
-        m ~ Normal(0.0, sqrt(s))
+        m ~ Normal(2.0, sqrt(s))
         x ~ Normal(m, sqrt(s))
         y ~ Normal(m, sqrt(s))
     end
 
     model = gdemo(1.0, 2.0)
-    N = 10_000
+    N = 1_000
 
     chains = sample(model, SampleFromPrior(), N; progress = false)
     @test chains isa Vector{<:VarInfo}
     @test length(chains) == N
-    @test mean(vi[@varname(m)] for vi in chains) ≈ 0 atol = 0.1
+
+    # Expected value of ``X`` where ``X ~ N(2, ...)`` is 2.
+    @test mean(vi[@varname(m)] for vi in chains) ≈ 2 atol = 0.1
+
+    # Expected value of ``X`` where ``X ~ IG(2, 3)`` is 3.
     @test mean(vi[@varname(s)] for vi in chains) ≈ 3 atol = 0.1
 
     chains = sample(model, SampleFromUniform(), N; progress = false)
     @test chains isa Vector{<:VarInfo}
     @test length(chains) == N
-    @test mean(vi[@varname(m)] for vi in chains) ≈ 1 atol = 0.1
-    @test mean(vi[@varname(s)] for vi in chains) ≈ 3.3 atol = 0.1
+
+    # Expected value of ``X`` where ``X ~ U[-2, 2]`` is ≈ 0.
+    @test mean(vi[@varname(m)] for vi in chains) ≈ 0 atol = 0.1
+
+    # Expected value of ``exp(X)`` where ``X ~ U[-2, 2]`` is ≈ 1.8.
+    @test mean(vi[@varname(s)] for vi in chains) ≈ 1.8 atol = 0.1
 end
 

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -1,0 +1,34 @@
+using DynamicPPL
+using Distributions
+using AbstractMCMC: sample
+
+using Random
+using Statistics
+using Test
+
+Random.seed!(1234)
+
+@testset "AbstractMCMC interface" begin
+    @model gdemo(x, y) = begin
+        s ~ InverseGamma(2, 3)
+        m ~ Normal(0.0, sqrt(s))
+        x ~ Normal(m, sqrt(s))
+        y ~ Normal(m, sqrt(s))
+    end
+
+    model = gdemo(1.0, 2.0)
+    N = 10_000
+
+    chains = sample(model, SampleFromPrior(), N; progress = false)
+    @test chains isa Vector{<:VarInfo}
+    @test length(chains) == N
+    @test mean(vi[@varname(m)] for vi in chains) ≈ 0 atol = 0.1
+    @test mean(vi[@varname(s)] for vi in chains) ≈ 3 atol = 0.1
+
+    chains = sample(model, SampleFromUniform(), N; progress = false)
+    @test chains isa Vector{<:VarInfo}
+    @test length(chains) == N
+    @test mean(vi[@varname(m)] for vi in chains) ≈ 1 atol = 0.1
+    @test mean(vi[@varname(s)] for vi in chains) ≈ 3.3 atol = 0.1
+end
+

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -165,34 +165,35 @@ include(dir*"/test/test_utils/AllUtils.jl")
 
         vi = VarInfo()
         meta = vi.metadata
-        model(vi, SampleFromUniform())
 
-        @test all(x -> istrans(vi, x), meta.vns)
+        model(vi, SampleFromUniform())
+        @test all(x -> !istrans(vi, x), meta.vns)
+
         alg = HMC(0.1, 5)
         spl = Sampler(alg, model)
         v = copy(meta.vals)
-        invlink!(vi, spl)
-        @test all(x -> ~istrans(vi, x), meta.vns)
         link!(vi, spl)
         @test all(x -> istrans(vi, x), meta.vns)
-        @test norm(meta.vals - v) <= 1e-6
+        invlink!(vi, spl)
+        @test all(x -> !istrans(vi, x), meta.vns)
+        @test meta.vals == v
 
         vi = TypedVarInfo(vi)
         meta = vi.metadata
         alg = HMC(0.1, 5)
         spl = Sampler(alg, model)
-        @test all(x -> istrans(vi, x), meta.s.vns)
-        @test all(x -> istrans(vi, x), meta.m.vns)
+        @test all(x -> !istrans(vi, x), meta.s.vns)
+        @test all(x -> !istrans(vi, x), meta.m.vns)
         v_s = copy(meta.s.vals)
         v_m = copy(meta.m.vals)
-        invlink!(vi, spl)
-        @test all(x -> ~istrans(vi, x), meta.s.vns)
-        @test all(x -> ~istrans(vi, x), meta.m.vns)
         link!(vi, spl)
         @test all(x -> istrans(vi, x), meta.s.vns)
         @test all(x -> istrans(vi, x), meta.m.vns)
-        @test norm(meta.s.vals - v_s) <= 1e-6
-        @test norm(meta.m.vals - v_m) <= 1e-6
+        invlink!(vi, spl)
+        @test all(x -> ~istrans(vi, x), meta.s.vns)
+        @test all(x -> ~istrans(vi, x), meta.m.vns)
+        @test meta.s.vals == v_s
+        @test meta.m.vals == v_m
     end
     @testset "setgid!" begin
         vi = VarInfo()


### PR DESCRIPTION
This PR enables sampling from the prior and with the uniform initialization.

Unfortunately, I have no idea what distributions we expect with the uniform initialization - I studied the code in utils.jl, but I'm a bit confused why we don't just sample from the normal and inverse gamma prior - shouldn't only `TransformDistribution`, `SimplexDistribution`, and `PDMatDistribution` be initialized with a different algorithm? So the test for the uniform initialization has to be adjusted to the correct expected values.