### PR TITLE
Fix SampleFromUniform

### DIFF
--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -103,8 +103,9 @@ function observe(spl::Sampler, weight)
     error("DynamicPPL.observe: unmanaged inference algorithm: $(typeof(spl))")
 end
 
+# If parameters exist, they are used and not overwritten.
 function assume(
-    spl::Union{SampleFromPrior, SampleFromUniform},
+    spl::SampleFromPrior,
     dist::Distribution,
     vn::VarName,
     vi::VarInfo,
@@ -112,15 +113,38 @@ function assume(
     if haskey(vi, vn)
         if is_flagged(vi, vn, "del")
             unset_flag!(vi, vn, "del")
-            r = spl isa SampleFromUniform ? init(dist) : rand(dist)
+            r = rand(dist)
             vi[vn] = vectorize(dist, r)
+            settrans!(vi, false, vn)
             setorder!(vi, vn, get_num_produce(vi))
         else
-        r = vi[vn]
+            r = vi[vn]
         end
     else
-        r = isa(spl, SampleFromUniform) ? init(dist) : rand(dist)
+        r = rand(dist)
         push!(vi, vn, r, dist, spl)
+        settrans!(vi, false, vn)
+    end
+    return r, Bijectors.logpdf_with_trans(dist, r, istrans(vi, vn))
+end
+
+# Always overwrites the parameters with new ones.
+function assume(
+    spl::SampleFromUniform,
+    dist::Distribution,
+    vn::VarName,
+    vi::VarInfo,
+)
+    if haskey(vi, vn)
+        unset_flag!(vi, vn, "del")
+        r = init(dist)
+        vi[vn] = vectorize(dist, r)
+        settrans!(vi, true, vn)
+        setorder!(vi, vn, get_num_produce(vi))
+    else
+        r = init(dist)
+        push!(vi, vn, r, dist, spl)
+        settrans!(vi, true, vn)
     end
     # NOTE: The importance weight is not correctly computed here because
     #       r is genereated from some uniform distribution which is different from the prior

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -117,8 +117,8 @@ end
 
 # ROBUST INITIALISATIONS
 # Uniform rand with range 2; ref: https://mc-stan.org/docs/2_19/reference-manual/initialization.html
-randrealuni() = Real(2rand())
-randrealuni(args...) = map(Real, 2rand(args...))
+randrealuni() = Real(4rand()-2)
+randrealuni(args...) = map(Real, 4rand(args...)-2)
 
 const Transformable = Union{TransformDistribution, SimplexDistribution, PDMatDistribution}
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -118,7 +118,7 @@ end
 # ROBUST INITIALISATIONS
 # Uniform rand with range 2; ref: https://mc-stan.org/docs/2_19/reference-manual/initialization.html
 randrealuni() = Real(4rand()-2)
-randrealuni(args...) = map(Real, 4rand(args...)-2)
+randrealuni(args...) = map(Real, 4 .* rand(args...) .- 2)
 
 const Transformable = Union{TransformDistribution, SimplexDistribution, PDMatDistribution}
 

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -820,6 +820,7 @@ Return the current value(s) of the random variables sampled by `spl` in `vi`.
 The value(s) may or may not be transformed to Euclidean space.
 """
 getindex(vi::AbstractVarInfo, spl::SampleFromPrior) = copy(getall(vi))
+getindex(vi::AbstractVarInfo, spl::SampleFromUniform) = copy(getall(vi))
 getindex(vi::UntypedVarInfo, spl::Sampler) = copy(getval(vi, _getranges(vi, spl)))
 function getindex(vi::TypedVarInfo, spl::Sampler)
     # Gets the ranges as a NamedTuple


### PR DESCRIPTION
This PR fixes the SampleFromUniform code. SampleFromUniform is only useful in initializing the HMC state. This means that:
1. A new value should always be sampled overwriting the existing values in `VarInfo` which may have come from `SampleFromPrior`, and
2. The `"trans"` flag should be set to `true` because we are not sampling in the support of the random variables' distributions.

This PR also fixes the uniform distribution's support as per @xukai92's suggestion.