### PR TITLE
Allow linking for SampleFromPrior

### DIFF
--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -420,6 +420,7 @@ end
 
 # Get all vns of variables belonging to spl
 _getvns(vi::AbstractVarInfo, spl::Sampler) = _getvns(vi, spl.selector, Val(getspace(spl)))
+_getvns(vi::AbstractVarInfo, spl::Union{SampleFromPrior, SampleFromUniform}) = _getvns(vi, Selector(), Val(()))
 _getvns(vi::UntypedVarInfo, s::Selector, space) = view(vi.metadata.vns, _getidcs(vi, s, space))
 function _getvns(vi::TypedVarInfo, s::Selector, space)
     return _getvns(vi.metadata, _getidcs(vi, s, space))


### PR DESCRIPTION
Looks like I couldn't link a `VarInfo` from `SampleFromPrior` without this, and wanted to see if it was an appropriate fix to add to DynamicPPL. If not, any tips on the better solution?
