### PR TITLE
Make `logp` concretely typed by default and respect types in `resetlogp!`

### DIFF
--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -485,7 +485,7 @@ end
 
 # VarInfo
 
-VarInfo(meta=Metadata()) = VarInfo(meta, Ref{Real}(0.0), Ref(0))
+VarInfo(meta=Metadata()) = VarInfo(meta, Ref{Float64}(0.0), Ref(0))
 
 """
     TypedVarInfo(vi::UntypedVarInfo)
@@ -618,8 +618,7 @@ acclogp!(vi::AbstractVarInfo, logp::Real) = vi.logp[] += logp
 Reset the value of the log of the joint probability of the observed data and parameters
 sampled in `vi` to 0.
 """
-resetlogp!(vi::AbstractVarInfo) = setlogp!(vi, 0)
-
+resetlogp!(vi::AbstractVarInfo) = setlogp!(vi, zero(getlogp(vi)))
 
 """
     get_num_produce(vi::VarInfo)

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -391,13 +391,13 @@ include(dir*"/test/test_utils/AllUtils.jl")
     @testset "varinfo" begin
         dists = [Normal(0, 1), MvNormal([0; 0], [1.0 0; 0 1.0]), Wishart(7, [1 0.5; 0.5 1])]
         function test_varinfo!(vi)
-            @test getlogp(vi) == 0
+            @test getlogp(vi) === 0.0
             setlogp!(vi, 1)
-            @test getlogp(vi) == 1
+            @test getlogp(vi) === 1.0
             acclogp!(vi, 1)
-            @test getlogp(vi) == 2
+            @test getlogp(vi) === 2.0
             resetlogp!(vi)
-            @test getlogp(vi) == 0
+            @test getlogp(vi) === 0.0
 
             spl2 = Sampler(PG(5, :w, :u), empty_model())
             vn_w = @varname w


### PR DESCRIPTION
While working on https://github.com/TuringLang/Turing.jl/pull/1242, I noticed that initially `getlogp(vi)` (where `vi` was initialized as `VarInfo()`) returned `0.0` but subsequently after calling `resetlogp!(vi)` it actually returned `0`. The reason is two-fold: first, `vi.logp` is initialized as a reference to a Real number if not specified explicitly, and then `resetlogp!` is implemented as `resetlogp!(vi) = (vi.logp[] = 0)` which does not perform any conversion to floating point numbers in this case.

I changed both the initialization and `resetlogp!`. I assume there were reasons for not concretely type `vi.logp` as default (maybe because of AD?) - however, all tests of Turing passed locally with this PR.