### PR TITLE
Add minimum/maximum for NoDist

### DIFF
--- a/src/distribution_wrappers.jl
+++ b/src/distribution_wrappers.jl
@@ -37,6 +37,8 @@ function Distributions.logpdf(d::NoDist{<:Multivariate}, x::AbstractMatrix{<:Rea
     return zeros(Int, size(x, 2))
 end
 Distributions.logpdf(d::NoDist{<:Matrixvariate}, ::AbstractMatrix{<:Real}) = 0
+Distributions.minimum(d::NoDist) = minimum(d.dist)
+Distributions.maximum(d::NoDist) = maximum(d.dist)
 
 Bijectors.logpdf_with_trans(d::NoDist{<:Univariate}, ::Real) = 0
 Bijectors.logpdf_with_trans(d::NoDist{<:Multivariate}, ::AbstractVector{<:Real}) = 0


### PR DESCRIPTION
I noticed there wasn't a `minimum` or `maximum` implementation for `NoDist`, so I added them.