### PR TITLE
Docstring for models

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -352,7 +352,7 @@ function build_output(model_info)
         $generator($(args...)) = $(DynamicPPL.Model)($evaluator, $args_nt, $model_gen_constructor)
         $(generator_kw_form...)
 
-        $model_gen = $model_gen_constructor
+        Base.@__doc__ $model_gen = $model_gen_constructor
     end
 end
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -352,7 +352,7 @@ function build_output(model_info)
         $generator($(args...)) = $(DynamicPPL.Model)($evaluator, $args_nt, $model_gen_constructor)
         $(generator_kw_form...)
 
-        Base.@__doc__ $model_gen = $model_gen_constructor
+        $(Base).@__doc__ $model_gen = $model_gen_constructor
     end
 end
 

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -624,7 +624,7 @@ end
         end
 
         s = @doc(demo)
-        @test s == "This is a test"
+        @test "$s" == "This is a test\n"
 
         # Verify that adding docstring didn't completely break execution of model
         m = demo(0.)

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -615,4 +615,16 @@ end
 
         @test lp_w_threads ≈ lp_wo_threads
     end
+
+    @testset "docstring" begin
+        "This is a test"
+        @model function demo(x)
+            m ~ Normal()
+            x ~ Normal(m, 1)
+        end
+
+        m = demo(0.)
+        s = @doc(m)
+        @test s == "This is a test"
+    end
 end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -623,8 +623,11 @@ end
             x ~ Normal(m, 1)
         end
 
-        m = demo(0.)
-        s = @doc(m)
+        s = @doc(demo)
         @test s == "This is a test"
+
+        # Verify that adding docstring didn't completely break execution of model
+        m = demo(0.)
+        @test m() isa Float64
     end
 end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -624,7 +624,7 @@ end
         end
 
         s = @doc(demo)
-        @test "$s" == "This is a test\n"
+        @test string(s) == "This is a test\n"
 
         # Verify that adding docstring didn't completely break execution of model
         m = demo(0.)


### PR DESCRIPTION
Now something like the following works:
```julia
julia> using DynamicPPL, Distributions

julia> """
           demo(x)
           
       This is a demo model.
       """
       @model function demo(x)
           m ~ Normal()
           x ~ Normal(m, 1)
           
           return m
       end
demo

help?> demo
search: demo denominator ReadOnlyMemoryError widemul StridedMatrix DenseMatrix divrem code_llvm @code_llvm StridedVecOrMat DimensionMismatch DenseVecOrMat

  demo(x)

  This is a demo model.

julia> m = demo(1)
Model{var"###evaluator#307",(:x,),Tuple{Int64},(),ModelGen{var"###generator#308",(:x,),(),Tuple{}}}(##evaluator#307, (x = 1,), ModelGen{var"###generator#308",(:x,),(),Tuple{}}(##generator#308, NamedTuple()))

julia> m()
-0.2797280925807616
```