### PR TITLE
Fix Zygote support

### DIFF
--- a/src/compat/ad.jl
+++ b/src/compat/ad.jl
@@ -7,18 +7,12 @@ ZygoteRules.@adjoint function push!(
     dist::Distribution,
     gidset::Set{Selector}
 )
-    return push!(vi, vn, r, dist, gidset), _ -> nothing
+    return push!(vi, vn, r, dist, gidset), _ -> ntuple(_ -> nothing, 5)
 end
 
-# Multithreaded evaluation is not compatible with Zygote.
-ZygoteRules.@adjoint function (model::Model)(
-    vi::AbstractVarInfo,
-    spl::AbstractSampler,
-    ctx::AbstractContext
-)
-    function evaluate(vi, spl, ctx)
-        return evaluate_singlethreaded(model, vi, spl, ctx)
-    end
-    return ZygoteRules.pullback(evaluate, vi, spl, ctx)
+ZygoteRules.@adjoint function Threads.nthreads()
+    Threads.nthreads(), _ -> (nothing,)
 end
-
+ZygoteRules.@adjoint function Threads.threadid()
+    Threads.threadid(), _ -> (nothing,)
+end

--- a/src/compat/ad.jl
+++ b/src/compat/ad.jl
@@ -7,7 +7,7 @@ ZygoteRules.@adjoint function push!(
     dist::Distribution,
     gidset::Set{Selector}
 )
-    return push!(vi, vn, r, dist, gidset), _ -> ntuple(_ -> nothing, 5)
+    return push!(vi, vn, r, dist, gidset), _ -> nothing
 end
 
 ZygoteRules.@adjoint function Threads.nthreads()

--- a/src/compat/ad.jl
+++ b/src/compat/ad.jl
@@ -11,8 +11,8 @@ ZygoteRules.@adjoint function push!(
 end
 
 ZygoteRules.@adjoint function Threads.nthreads()
-    Threads.nthreads(), _ -> (nothing,)
+    return Threads.nthreads(), _ -> nothing
 end
 ZygoteRules.@adjoint function Threads.threadid()
-    Threads.threadid(), _ -> (nothing,)
+    return Threads.threadid(), _ -> nothing
 end

--- a/src/threadsafe.jl
+++ b/src/threadsafe.jl
@@ -5,12 +5,10 @@
 struct VectorOfLogps{T1, T2 <: Vector{Base.RefValue{T1}}}
     v::T2
 end
-VectorOfLogps(::Type{T}, n::Int) where {T} = VectorOfLogps(zero(T), n)
 function VectorOfLogps(val::T, n::Int) where {T}
-    v = [val for i in 1:Threads.nthreads()]
+    v = [Ref(val) for i in 1:n]
     return VectorOfLogps(v)
 end
-VectorOfLogps(v::Vector) = VectorOfLogps(Ref.(v))
 Base.getindex(v::VectorOfLogps, i::Integer) = v.v[i][]
 function Base.setindex!(v::VectorOfLogps, val, i::Integer)
     v.v[i][] = val

--- a/test/compat/ad.jl
+++ b/test/compat/ad.jl
@@ -62,6 +62,6 @@ using Tracker
 
     y, back = Zygote.pullback(logp_model, x)
     @test y ≈ lp
-    @test back(1) ≈ grad
+    @test back(1)[1] ≈ grad
 end
 


### PR DESCRIPTION
This PR fixes Zygote support in the branch `fixes_threaded`. It currently does some type piracy to define an adjoint for `nthreads` and `threadid`. I will make a PR to Zygote with these now, then they can be removed from here when the PR is merged and released.