### PR TITLE
Use Bors?

### DIFF
--- a/.github/workflows/DynamicPPL-CI.yml
+++ b/.github/workflows/DynamicPPL-CI.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
       - dev
+      # This is where pull requests from "bors r+" are built.
+      - staging
+      # This is where pull requests from "bors try" are built.
+      - trying
+  # Enable building pull requests.
   pull_request:
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,13 @@
 language: julia
 branches:
   only:
+    # Enable building pull requests to master and dev.
     - master
+    - dev
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
 os:
   - linux
   - osx

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,10 @@
+status = [
+  "continuous-integration/travis-ci/push",
+  "DynamicPPL-CI / test (1%"
+]
+delete_merged_branches = true
+# Uncomment this to require at least on approval of a project member.
+#required_approvals = 1
+# Uncomment this to use a two hour timeout.
+# The default is one hour.
+#timeout_sec = 7200


### PR DESCRIPTION
Yesterday merging two PRs in a row (both had passed the CI tests) broke master (see https://github.com/TuringLang/DynamicPPL.jl/pull/96). The problem is that PRs are tested independently of each other, and hence it is possible to break master even if the CI tests succeed. [Bors](https://bors.tech/) solves this problem by not merging PRs directly but adding them to a merge queue instead and testing them before actually merging them. However, it would change our current workflow quite a bit so I'm not sure if we want to do that (basically using `bors merge` or `bors r+` instead of merging directly, see [the getting started guide](https://bors.tech/documentation/getting-started/) for more information).

I know that Flux and Zygote use Bors but I've never used it myself. I've tried to just copy the default settings and instructions from the Bors reference manual, but haven't disabled tests in PRs (apparently it would be possible to run them only by commenting `bors try`). I'm not completely sure if everything is configured correctly, but apparently this PR must be merged manually since [Github actions are not allowed to modify other Github actions](https://forum.bors.tech/t/resource-not-accessible-by-integration/408/3).

And, of course, Bors would have to be enabled for this repo.