### PR TITLE
Update Turing src in tests

### DIFF
--- a/test/Turing/Turing.jl
+++ b/test/Turing/Turing.jl
@@ -11,12 +11,11 @@ module Turing
 using Requires, Reexport, ForwardDiff
 using DistributionsAD, Bijectors, StatsFuns, SpecialFunctions
 using Statistics, LinearAlgebra
-using Markdown, Libtask, MacroTools
-@reexport using Distributions, MCMCChains, Libtask
+using Libtask
+@reexport using Distributions, MCMCChains, Libtask, AbstractMCMC
 using Tracker: Tracker
 
-import Base: ~, ==, convert, hash, promote_rule, rand, getindex, setindex!
-import DynamicPPL: getspace
+import DynamicPPL: getspace, NoDist, NamedDist
 
 const PROGRESS = Ref(true)
 function turnprogress(switch::Bool)
@@ -68,6 +67,8 @@ export  @model,                 # modelling
         @varname,
         DynamicPPL,
 
+        Prior,                  # Sampling from the prior
+
         MH,                     # classic sampling
         RWMH,
         ESS,
@@ -90,7 +91,6 @@ export  @model,                 # modelling
         ADVI,
 
         sample,                 # inference
-        psample,
         setchunksize,
         resume,
         @logprob_str,
@@ -105,15 +105,10 @@ export  @model,                 # modelling
         Flat,
         FlatPos,
         BinomialLogit,
-        VecBinomialLogit,
+        BernoulliLogit,
         OrderedLogistic,
         LogPoisson,
         NamedDist,
         filldist,
         arraydist
-
-# Reexports
-using AbstractMCMC: sample, psample
-export sample, psample
-
 end

--- a/test/Turing/contrib/inference/dynamichmc.jl
+++ b/test/Turing/contrib/inference/dynamichmc.jl
@@ -46,7 +46,7 @@ mutable struct DynamicNUTSState{V<:VarInfo, D} <: AbstractSamplerState
     draws::Vector{D}
 end
 
-getspace(::DynamicNUTS{<:Any, space}) where {space} = space
+DynamicPPL.getspace(::DynamicNUTS{<:Any, space}) where {space} = space
 
 function AbstractMCMC.sample_init!(
     rng::AbstractRNG,
@@ -60,15 +60,22 @@ function AbstractMCMC.sample_init!(
         gradient_logp(x, spl.state.vi, model, spl)
     end
 
-    model(spl.state.vi, SampleFromUniform())
+    # Set the parameters to a starting value.
+    initialize_parameters!(spl; kwargs...)
 
-    if spl.selector.tag == :default
+    model(spl.state.vi, SampleFromUniform())
+    link!(spl.state.vi, spl)
+    l, dl = _lp(spl.state.vi[spl])
+    while !isfinite(l) || !isfinite(dl)
+        model(spl.state.vi, SampleFromUniform())
+        link!(spl.state.vi, spl)
+        l, dl = _lp(spl.state.vi[spl])
+    end
+
+    if spl.selector.tag == :default && !islinked(spl.state.vi, spl)
         link!(spl.state.vi, spl)
         model(spl.state.vi, spl)
     end
-
-    # Set the parameters to a starting value.
-    initialize_parameters!(spl; kwargs...)
 
     results = mcmc_with_warmup(
         rng,
@@ -114,7 +121,7 @@ end
     model::AbstractModel,
     alg::DynamicNUTS,
     N::Integer;
-    chain_type=Chains,
+    chain_type=MCMCChains.Chains,
     resume_from=nothing,
     progress=PROGRESS[],
     kwargs...
@@ -130,19 +137,20 @@ end
     end
 end
 
-function AbstractMCMC.psample(
+function AbstractMCMC.sample(
     rng::AbstractRNG,
     model::AbstractModel,
     alg::DynamicNUTS,
+    parallel::AbstractMCMC.AbstractMCMCParallel,
     N::Integer,
     n_chains::Integer;
-    chain_type=Chains,
+    chain_type=MCMCChains.Chains,
     progress=PROGRESS[],
     kwargs...
 )
     if progress
         @warn "[$(alg_str(alg))] Progress logging in Turing is disabled since DynamicHMC provides its own progress meter"
     end
-    return AbstractMCMC.psample(rng, model, Sampler(alg, model), N, n_chains;
-                                chain_type=chain_type, progress=false, kwargs...)
+    return AbstractMCMC.sample(rng, model, Sampler(alg, model), parallel, N, n_chains;
+                               chain_type=chain_type, progress=false, kwargs...)
 end

--- a/test/Turing/contrib/inference/sghmc.jl
+++ b/test/Turing/contrib/inference/sghmc.jl
@@ -172,7 +172,7 @@ function step(
     spl.selector.tag != :default && link!(vi, spl)
 
     mssa = AHMC.Adaptation.ManualSSAdaptor(AHMC.Adaptation.MSSState(spl.alg.ϵ))
-    spl.info[:adaptor] = AHMC.NaiveHMCAdaptor(AHMC.UnitPreconditioner(), mssa)
+    spl.info[:adaptor] = AHMC.NaiveHMCAdaptor(AHMC.UnitMassMatrix(), mssa)
 
     spl.selector.tag != :default && invlink!(vi, spl)
     return vi, true

--- a/test/Turing/core/Core.jl
+++ b/test/Turing/core/Core.jl
@@ -1,13 +1,12 @@
 module Core
 
 using DistributionsAD, Bijectors
-using MacroTools, Libtask, ForwardDiff, Random
+using Libtask, ForwardDiff, Random
 using Distributions, LinearAlgebra
 using ..Utilities, Reexport
 using Tracker: Tracker
 using ..Turing: Turing
-using DynamicPPL: Model,
-    AbstractSampler, Sampler, SampleFromPrior
+using DynamicPPL: Model, AbstractSampler, Sampler, SampleFromPrior
 using LinearAlgebra: copytri!
 using Bijectors: PDMatDistribution
 import Bijectors: link, invlink
@@ -17,9 +16,15 @@ using Requires
 
 include("container.jl")
 include("ad.jl")
-@init @require Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f" begin
-    include("compat/zygote.jl")
-    export ZygoteAD
+function __init__()
+    @require Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f" begin
+        include("compat/zygote.jl")
+        export ZygoteAD
+    end
+    @require ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267" begin
+        include("compat/reversediff.jl")
+        export ReverseDiffAD, getrdcache, setrdcache, emptyrdcache
+    end
 end
 
 export  @model,
@@ -36,10 +41,9 @@ export  @model,
         forkr,
         current_trace,
         getweights,
+        getweight,
         effectiveSampleSize,
-        increase_logweight,
-        inrease_logevidence,
-        resample!,
+        sweep!,
         ResampleWithESSThreshold,
         ADBackend,
         setadbackend,

--- a/test/Turing/core/ad.jl
+++ b/test/Turing/core/ad.jl
@@ -1,14 +1,23 @@
 ##############################
 # Global variables/constants #
 ##############################
-const ADBACKEND = Ref(:forward_diff)
+const ADBACKEND = Ref(:forwarddiff)
 setadbackend(backend_sym::Symbol) = setadbackend(Val(backend_sym))
 function setadbackend(::Val{:forward_diff})
-    CHUNKSIZE[] == 0 && setchunksize(40)
-    ADBACKEND[] = :forward_diff
+    Base.depwarn("`Turing.setadbackend(:forward_diff)` is deprecated. Please use `Turing.setadbackend(:forwarddiff)` to use `ForwardDiff`.", :setadbackend)
+    setadbackend(Val(:forwarddiff))
 end
+function setadbackend(::Val{:forwarddiff})
+    CHUNKSIZE[] == 0 && setchunksize(40)
+    ADBACKEND[] = :forwarddiff
+end
+
 function setadbackend(::Val{:reverse_diff})
-    ADBACKEND[] = :reverse_diff
+    Base.depwarn("`Turing.setadbackend(:reverse_diff)` is deprecated. Please use `Turing.setadbackend(:tracker)` to use `Tracker` or `Turing.setadbackend(:reversediff)` to use `ReverseDiff`. To use `ReverseDiff`, please make sure it is loaded separately with `using ReverseDiff`.",  :setadbackend)
+    setadbackend(Val(:tracker))
+end
+function setadbackend(::Val{:tracker})
+    ADBACKEND[] = :tracker
 end
 
 const ADSAFE = Ref(false)
@@ -37,8 +46,8 @@ struct TrackerAD <: ADBackend end
 ADBackend() = ADBackend(ADBACKEND[])
 ADBackend(T::Symbol) = ADBackend(Val(T))
 
-ADBackend(::Val{:forward_diff}) = ForwardDiffAD{CHUNKSIZE[]}
-ADBackend(::Val{:reverse_diff}) = TrackerAD
+ADBackend(::Val{:forwarddiff}) = ForwardDiffAD{CHUNKSIZE[]}
+ADBackend(::Val{:tracker}) = TrackerAD
 ADBackend(::Val) = error("The requested AD backend is not available. Make sure to load all required packages.")
 
 """

--- a/test/Turing/core/compat/reversediff.jl
+++ b/test/Turing/core/compat/reversediff.jl
@@ -1,0 +1,93 @@
+using .ReverseDiff: compile, GradientTape
+using .ReverseDiff.DiffResults: GradientResult
+
+struct ReverseDiffAD{cache} <: ADBackend end
+const RDCache = Ref(false)
+setrdcache(b::Bool) = setrdcache(Val(b))
+setrdcache(::Val{false}) = RDCache[] = false
+setrdcache(::Val) = throw("Memoization.jl is not loaded. Please load it before setting the cache to true.")
+function emptyrdcache end
+
+getrdcache() = RDCache[]
+ADBackend(::Val{:reversediff}) = ReverseDiffAD{getrdcache()}
+function setadbackend(::Val{:reversediff})
+    ADBACKEND[] = :reversediff
+end
+
+function gradient_logp(
+    backend::ReverseDiffAD{false},
+    θ::AbstractVector{<:Real},
+    vi::VarInfo,
+    model::Model,
+    sampler::AbstractSampler = SampleFromPrior(),
+)
+    T = typeof(getlogp(vi))
+    
+    # Specify objective function.
+    function f(θ)
+        new_vi = VarInfo(vi, sampler, θ)
+        model(new_vi, sampler)
+        return getlogp(new_vi)
+    end
+    tp, result = taperesult(f, θ)
+    ReverseDiff.gradient!(result, tp, θ)
+    l = DiffResults.value(result)
+    ∂l∂θ::typeof(θ) = DiffResults.gradient(result)
+
+    return l, ∂l∂θ
+end
+
+tape(f, x) = GradientTape(f, x)
+function taperesult(f, x)
+    return tape(f, x), GradientResult(x)
+end
+
+@require Memoization = "6fafb56a-5788-4b4e-91ca-c0cea6611c73" @eval begin
+    setrdcache(::Val{true}) = RDCache[] = true
+    function emptyrdcache()
+        for k in keys(Memoization.caches)
+            if k[1] === typeof(memoized_taperesult)
+                pop!(Memoization.caches, k)
+            end
+        end
+    end
+    function gradient_logp(
+        backend::ReverseDiffAD{true},
+        θ::AbstractVector{<:Real},
+        vi::VarInfo,
+        model::Model,
+        sampler::AbstractSampler = SampleFromPrior(),
+    )
+        T = typeof(getlogp(vi))
+        
+        # Specify objective function.
+        function f(θ)
+            new_vi = VarInfo(vi, sampler, θ)
+            model(new_vi, sampler)
+            return getlogp(new_vi)
+        end
+        ctp, result = memoized_taperesult(f, θ)
+        ReverseDiff.gradient!(result, ctp, θ)
+        l = DiffResults.value(result)
+        ∂l∂θ = DiffResults.gradient(result)
+
+        return l, ∂l∂θ
+    end
+
+    # This makes sure we generate a single tape per Turing model and sampler
+    struct RDTapeKey{F, Tx}
+        f::F
+        x::Tx
+    end
+    function Memoization._get!(f::Union{Function, Type}, d::IdDict, keys::Tuple{Tuple{RDTapeKey}, Any})
+        key = keys[1][1]
+        return Memoization._get!(f, d, (typeof(key.f), typeof(key.x), size(key.x)))
+    end
+    memoized_taperesult(f, x) = memoized_taperesult(RDTapeKey(f, x))
+    Memoization.@memoize function memoized_taperesult(k::RDTapeKey)
+        return compiledtape(k.f, k.x), GradientResult(k.x)
+    end
+    memoized_tape(f, x) = memoized_tape(RDTapeKey(f, x))
+    Memoization.@memoize memoized_tape(k::RDTapeKey) = compiledtape(k.f, k.x)
+    compiledtape(f, x) = compile(GradientTape(f, x))
+end

--- a/test/Turing/core/container.jl
+++ b/test/Turing/core/container.jl
@@ -20,9 +20,13 @@ function Base.copy(trace::Trace)
 end
 
 # NOTE: this function is called by `forkr`
-function Trace(f::Function, m::Model, spl::AbstractSampler, vi::AbstractVarInfo)
-    res = Trace{typeof(spl)}(m, spl, deepcopy(vi));
-    ctask = CTask(() -> (res = f(); produce(Val{:done}); res))
+function Trace(f, m::Model, spl::AbstractSampler, vi::AbstractVarInfo)
+    res = Trace{typeof(spl)}(m, spl, deepcopy(vi))
+    ctask = CTask() do
+        res = f()
+        produce(nothing)
+        return res
+    end
     task = ctask.task
     if task.storage === nothing
         task.storage = IdDict()
@@ -31,10 +35,15 @@ function Trace(f::Function, m::Model, spl::AbstractSampler, vi::AbstractVarInfo)
     res.ctask = ctask
     return res
 end
+
 function Trace(m::Model, spl::AbstractSampler, vi::AbstractVarInfo)
-    res = Trace{typeof(spl)}(m, spl, deepcopy(vi));
+    res = Trace{typeof(spl)}(m, spl, deepcopy(vi))
     reset_num_produce!(res.vi)
-    ctask = CTask(() -> (vi_new = m(vi, spl); produce(Val{:done}); vi_new))
+    ctask = CTask() do
+        res = m(vi, spl)
+        produce(nothing)
+        return res
+    end
     task = ctask.task
     if task.storage === nothing
         task.storage = IdDict()
@@ -74,19 +83,16 @@ Data structure for particle filters
 - normalise!(pc::ParticleContainer)
 - consume(pc::ParticleContainer): return incremental likelihood
 """
-mutable struct ParticleContainer{T<:Particle, F}
-    model::F
+mutable struct ParticleContainer{T<:Particle}
+    "Particles."
     vals::Vector{T}
-    # logarithmic weights (Trace) or incremental log-likelihoods (ParticleContainer)
+    "Unnormalized logarithmic weights."
     logWs::Vector{Float64}
-    # log model evidence
-    logE::Float64
-    # helpful for rejuvenation steps, e.g. in SMC2
-    n_consume::Int
 end
 
-ParticleContainer(model, particles::Vector{<:Particle}) =
-    ParticleContainer(model, particles, zeros(length(particles)), 0.0, 0)
+function ParticleContainer(particles::Vector{<:Particle})
+    return ParticleContainer(particles, zeros(length(particles)))
+end
 
 Base.collect(pc::ParticleContainer) = pc.vals
 Base.length(pc::ParticleContainer) = length(pc.vals)
@@ -107,69 +113,74 @@ function Base.copy(pc::ParticleContainer)
     # copy weights
     logWs = copy(pc.logWs)
 
-    ParticleContainer(pc.model, vals, logWs, pc.logE, pc.n_consume)
+    ParticleContainer(vals, logWs)
 end
 
-# run particle filter for one step, return incremental likelihood
-function Libtask.consume(pc :: ParticleContainer)
-    # normalisation factor: 1/N
-    z1 = logZ(pc)
-    n = length(pc)
+"""
+    reset_logweights!(pc::ParticleContainer)
 
-    particles = collect(pc)
-    num_done = 0
-    for i=1:n
-        p = particles[i]
-        score = Libtask.consume(p)
-        if score isa Real
-            score += getlogp(p.vi)
-            resetlogp!(p.vi)
-            increase_logweight(pc, i, Float64(score))
-        elseif score == Val{:done}
-            num_done += 1
-        else
-            error("[consume]: error in running particle filter.")
-        end
-    end
-
-    if num_done == n
-        res = Val{:done}
-    elseif num_done != 0
-        error("[consume]: mis-aligned execution traces, num_particles= $(n), num_done=$(num_done).")
-    else
-        # update incremental likelihoods
-        z2 = logZ(pc)
-        res = increase_logevidence(pc, z2 - z1)
-        pc.n_consume += 1
-        # res = increase_loglikelihood(pc, z2 - z1)
-    end
-
-    res
+Reset all unnormalized logarithmic weights to zero.
+"""
+function reset_logweights!(pc::ParticleContainer)
+    fill!(pc.logWs, 0.0)
+    return pc
 end
 
-# compute the normalized weights
+"""
+    increase_logweight!(pc::ParticleContainer, i::Int, x)
+
+Increase the unnormalized logarithmic weight of the `i`th particle with `x`.
+"""
+function increase_logweight!(pc::ParticleContainer, i, logw)
+    pc.logWs[i] += logw
+    return pc
+end
+
+"""
+    getweights(pc::ParticleContainer)
+
+Compute the normalized weights of the particles.
+"""
 getweights(pc::ParticleContainer) = softmax(pc.logWs)
 
-# compute the log-likelihood estimate, ignoring constant term ``- \log num_particles``
+"""
+    getweight(pc::ParticleContainer, i)
+
+Compute the normalized weight of the `i`th particle.
+"""
+getweight(pc::ParticleContainer, i) = exp(pc.logWs[i] - logZ(pc))
+
+"""
+    logZ(pc::ParticleContainer)
+
+Return the logarithm of the normalizing constant of the unnormalized logarithmic weights.
+"""
 logZ(pc::ParticleContainer) = logsumexp(pc.logWs)
 
-# compute the effective sample size ``1 / ∑ wᵢ²``, where ``wᵢ```are the normalized weights
-function effectiveSampleSize(pc :: ParticleContainer)
+"""
+    effectiveSampleSize(pc::ParticleContainer)
+
+Compute the effective sample size ``1 / ∑ wᵢ²``, where ``wᵢ```are the normalized weights.
+"""
+function effectiveSampleSize(pc::ParticleContainer)
     Ws = getweights(pc)
     return inv(sum(abs2, Ws))
 end
 
-increase_logweight(pc :: ParticleContainer, t :: Int, logw :: Float64) =
-    (pc.logWs[t]  += logw)
+"""
+    resample_propagate!(pc::ParticleContainer[, randcat = resample_systematic, ref = nothing;
+                        weights = getweights(pc)])
 
-increase_logevidence(pc :: ParticleContainer, logw :: Float64) =
-    (pc.logE += logw)
+Resample and propagate the particles in `pc`.
 
-
-function resample!(
-    pc :: ParticleContainer,
-    randcat :: Function = Turing.Inference.resample_systematic,
-    ref :: Union{Particle, Nothing} = nothing;
+Function `randcat` is used for sampling ancestor indices from the categorical distribution
+of the particle `weights`. For Particle Gibbs sampling, one can provide a reference particle
+`ref` that is ensured to survive the resampling step.
+"""
+function resample_propagate!(
+    pc::ParticleContainer,
+    randcat = Turing.Inference.resample_systematic,
+    ref::Union{Particle, Nothing} = nothing;
     weights = getweights(pc)
 )
     # check that weights are not NaN
@@ -215,9 +226,112 @@ function resample!(
 
     # replace particles and log weights in the container with new particles and weights
     pc.vals = children
-    pc.logWs = zeros(n)
+    reset_logweights!(pc)
 
     pc
+end
+
+"""
+    reweight!(pc::ParticleContainer)
+
+Check if the final time step is reached, and otherwise reweight the particles by
+considering the next observation.
+"""
+function reweight!(pc::ParticleContainer)
+    n = length(pc)
+
+    particles = collect(pc)
+    numdone = 0
+    for i in 1:n
+        p = particles[i]
+
+        # Obtain ``\\log p(yₜ | y₁, …, yₜ₋₁, x₁, …, xₜ, θ₁, …, θₜ)``, or `nothing` if the
+        # the execution of the model is finished.
+        # Here ``yᵢ`` are observations, ``xᵢ`` variables of the particle filter, and
+        # ``θᵢ`` are variables of other samplers.
+        score = Libtask.consume(p)
+
+        if score === nothing
+            numdone += 1
+        else
+            # Increase the unnormalized logarithmic weights, accounting for the variables
+            # of other samplers.
+            increase_logweight!(pc, i, score + getlogp(p.vi))
+
+            # Reset the accumulator of the log probability in the model so that we can
+            # accumulate log probabilities of variables of other samplers until the next
+            # observation.
+            resetlogp!(p.vi)
+        end
+    end
+
+    # Check if all particles are propagated to the final time point.
+    numdone == n && return true
+
+    # The posterior for models with random number of observations is not well-defined.
+    if numdone != 0
+        error("mis-aligned execution traces: # particles = ", n,
+              " # completed trajectories = ", numdone,
+              ". Please make sure the number of observations is NOT random.")
+    end
+
+    return false
+end
+
+"""
+    sweep!(pc::ParticleContainer, resampler)
+
+Perform a particle sweep and return an unbiased estimate of the log evidence.
+
+The resampling steps use the given `resampler`.
+
+# Reference
+
+Del Moral, P., Doucet, A., & Jasra, A. (2006). Sequential monte carlo samplers.
+Journal of the Royal Statistical Society: Series B (Statistical Methodology), 68(3), 411-436.
+"""
+function sweep!(pc::ParticleContainer, resampler)
+    # Initial step:
+
+    # Resample and propagate particles.
+    resample_propagate!(pc, resampler)
+
+    # Compute the current normalizing constant ``Z₀`` of the unnormalized logarithmic
+    # weights.
+    # Usually it is equal to the number of particles in the beginning but this
+    # implementation covers also the unlikely case of a particle container that is
+    # initialized with non-zero logarithmic weights.
+    logZ0 = logZ(pc)
+
+    # Reweight the particles by including the first observation ``y₁``.
+    isdone = reweight!(pc)
+
+    # Compute the normalizing constant ``Z₁`` after reweighting.
+    logZ1 = logZ(pc)
+
+    # Compute the estimate of the log evidence ``\\log p(y₁)``.
+    logevidence = logZ1 - logZ0
+
+    # For observations ``y₂, …, yₜ``:
+    while !isdone
+        # Resample and propagate particles.
+        resample_propagate!(pc, resampler)
+
+        # Compute the current normalizing constant ``Z₀`` of the unnormalized logarithmic
+        # weights.
+        logZ0 = logZ(pc)
+
+        # Reweight the particles by including the next observation ``yₜ``.
+        isdone = reweight!(pc)
+
+        # Compute the normalizing constant ``Z₁`` after reweighting.
+        logZ1 = logZ(pc)
+
+        # Compute the estimate of the log evidence ``\\log p(y₁, …, yₜ)``.
+        logevidence += logZ1 - logZ0
+    end
+
+    return logevidence
 end
 
 struct ResampleWithESSThreshold{R, T<:Real}
@@ -225,12 +339,11 @@ struct ResampleWithESSThreshold{R, T<:Real}
     threshold::T
 end
 
-function ResampleWithESSThreshold()
-    ResampleWithESSThreshold(Turing.Inference.resample_systematic)
+function ResampleWithESSThreshold(resampler = Turing.Inference.resample_systematic)
+    ResampleWithESSThreshold(resampler, 0.5)
 end
-ResampleWithESSThreshold(resampler) = ResampleWithESSThreshold(resampler, 0.5)
 
-function resample!(
+function resample_propagate!(
     pc::ParticleContainer,
     resampler::ResampleWithESSThreshold,
     ref::Union{Particle,Nothing} = nothing;
@@ -240,7 +353,7 @@ function resample!(
     ess = inv(sum(abs2, weights))
 
     if ess ≤ resampler.threshold * length(pc)
-        resample!(pc, resampler.resampler, ref; weights = weights)
+        resample_propagate!(pc, resampler.resampler, ref; weights = weights)
     end
 
     pc

--- a/test/Turing/inference/AdvancedSMC.jl
+++ b/test/Turing/inference/AdvancedSMC.jl
@@ -26,33 +26,48 @@ function additional_parameters(::Type{<:ParticleTransition})
     return [:lp,:le, :weight]
 end
 
+DynamicPPL.getlogp(t::ParticleTransition) = t.lp
+
 ####
 #### Generic Sequential Monte Carlo sampler.
 ####
 
 """
-    SMC()
+$(TYPEDEF)
 
 Sequential Monte Carlo sampler.
 
-Note that this method is particle-based, and arrays of variables
-must be stored in a [`TArray`](@ref) object.
+# Fields
 
-Usage:
-
-```julia
-SMC()
-```
+$(TYPEDFIELDS)
 """
 struct SMC{space, R} <: ParticleInference
     resampler::R
 end
 
+"""
+    SMC(space...)
+    SMC([resampler = ResampleWithESSThreshold(), space = ()])
+    SMC([resampler = resample_systematic, ]threshold[, space = ()])
+
+Create a sequential Monte Carlo sampler of type [`SMC`](@ref) for the variables in `space`.
+
+If the algorithm for the resampling step is not specified explicitly, systematic resampling
+is performed if the estimated effective sample size per particle drops below 0.5.
+"""
 function SMC(resampler = Turing.Core.ResampleWithESSThreshold(), space::Tuple = ())
-    SMC{space, typeof(resampler)}(resampler)
+    return SMC{space, typeof(resampler)}(resampler)
 end
-SMC(::Tuple{}) = SMC()
+
+# Convenient constructors with ESS threshold
+function SMC(resampler, threshold::Real, space::Tuple = ())
+    return SMC(Turing.Core.ResampleWithESSThreshold(resampler, threshold), space)
+end
+SMC(threshold::Real, space::Tuple = ()) = SMC(resample_systematic, threshold, space)
+
+# If only the space is defined
 SMC(space::Symbol...) = SMC(space)
+SMC(space::Tuple) = SMC(Turing.Core.ResampleWithESSThreshold(), space)
 
 mutable struct SMCState{V<:VarInfo, F<:AbstractFloat} <: AbstractSamplerState
     vi                   ::   V
@@ -63,7 +78,7 @@ end
 
 function SMCState(model::Model)
     vi = VarInfo(model)
-    particles = ParticleContainer(model, Trace[])
+    particles = ParticleContainer(Trace[])
 
     return SMCState(vi, 0.0, particles)
 end
@@ -76,7 +91,7 @@ end
 
 function AbstractMCMC.sample_init!(
     ::AbstractRNG,
-    model::Model,
+    model::AbstractModel,
     spl::Sampler{<:SMC},
     N::Integer;
     kwargs...
@@ -96,16 +111,18 @@ function AbstractMCMC.sample_init!(
     particles = T[Trace(model, spl, vi) for _ in 1:N]
 
     # create a new particle container
-    spl.state.particles = pc = ParticleContainer(model, particles)
+    spl.state.particles = pc = ParticleContainer(particles)
 
-    while consume(pc) !== Val{:done}
-        resample!(pc, spl.alg.resampler)
-    end
+    # Perform particle sweep.
+    logevidence = sweep!(pc, spl.alg.resampler)
+    spl.state.average_logevidence = logevidence
+
+    return
 end
 
 function AbstractMCMC.step!(
     ::AbstractRNG,
-    model::Model,
+    model::AbstractModel,
     spl::Sampler{<:SMC},
     ::Integer,
     transition;
@@ -115,16 +132,19 @@ function AbstractMCMC.step!(
     # check that we received a real iteration number
     @assert iteration >= 1 "step! needs to be called with an 'iteration' keyword argument."
 
-    # grab the weights
+    # grab the weight
     pc = spl.state.particles
-    Ws = getweights(pc)
+    weight = getweight(pc, iteration)
 
     # update the master vi
     particle = pc.vals[iteration]
     params = tonamedtuple(particle.vi)
+
+    # This is pretty useless since we reset the log probability continuously in the
+    # particle sweep.
     lp = getlogp(particle.vi)
 
-    return ParticleTransition(params, lp, pc.logE, Ws[iteration])
+    return ParticleTransition(params, lp, spl.state.average_logevidence, weight)
 end
 
 ####
@@ -132,29 +152,55 @@ end
 ####
 
 """
-    PG(n_particles::Int)
+$(TYPEDEF)
 
 Particle Gibbs sampler.
 
 Note that this method is particle-based, and arrays of variables
 must be stored in a [`TArray`](@ref) object.
 
-Usage:
+# Fields
 
-```julia
-PG(100, 100)
-```
+$(TYPEDFIELDS)
 """
-struct PG{space} <: ParticleInference
-  n_particles           ::    Int         # number of particles used
-  resampler             ::    Function    # function to resample
+struct PG{space,R} <: ParticleInference
+    """Number of particles."""
+    nparticles::Int
+    """Resampling algorithm."""
+    resampler::R
 end
-function PG(n_particles::Int, resampler::Function, space::Tuple)
-    return PG{space}(n_particles, resampler)
+
+"""
+    PG(n, space...)
+    PG(n, [resampler = ResampleWithESSThreshold(), space = ()])
+    PG(n, [resampler = resample_systematic, ]threshold[, space = ()])
+
+Create a Particle Gibbs sampler of type [`PG`](@ref) with `n` particles for the variables
+in `space`.
+
+If the algorithm for the resampling step is not specified explicitly, systematic resampling
+is performed if the estimated effective sample size per particle drops below 0.5.
+"""
+function PG(
+    nparticles::Int,
+    resampler = Turing.Core.ResampleWithESSThreshold(),
+    space::Tuple = (),
+)
+    return PG{space, typeof(resampler)}(nparticles, resampler)
 end
-PG(n1::Int, ::Tuple{}) = PG(n1)
-function PG(n1::Int, space::Symbol...)
-    PG(n1, resample_systematic, space)
+
+# Convenient constructors with ESS threshold
+function PG(nparticles::Int, resampler, threshold::Real, space::Tuple = ())
+    return PG(nparticles, Turing.Core.ResampleWithESSThreshold(resampler, threshold), space)
+end
+function PG(nparticles::Int, threshold::Real, space::Tuple = ())
+    return PG(nparticles, resample_systematic, threshold, space)
+end
+
+# If only the number of particles and the space is defined
+PG(nparticles::Int, space::Symbol...) = PG(nparticles, space)
+function PG(nparticles::Int, space::Tuple)
+    return PG(nparticles, Turing.Core.ResampleWithESSThreshold(), space)
 end
 
 mutable struct PGState{V<:VarInfo, F<:AbstractFloat} <: AbstractSamplerState
@@ -183,7 +229,7 @@ end
 
 function AbstractMCMC.step!(
     ::AbstractRNG,
-    model::Model,
+    model::AbstractModel,
     spl::Sampler{<:PG},
     ::Integer,
     transition;
@@ -199,7 +245,7 @@ function AbstractMCMC.step!(
     resetlogp!(vi)
 
     # create a new set of particles
-    num_particles = spl.alg.n_particles
+    num_particles = spl.alg.nparticles
     T = Trace{typeof(spl),typeof(vi),typeof(model)}
     if ref_particle === nothing
         particles = T[Trace(model, spl, vi) for _ in 1:num_particles]
@@ -212,12 +258,10 @@ function AbstractMCMC.step!(
     end
 
     # create a new particle container
-    pc = ParticleContainer(model, particles)
+    pc = ParticleContainer(particles)
 
-    # run the particle filter
-    while consume(pc) !== Val{:done}
-        resample!(pc, spl.alg.resampler, ref_particle)
-    end
+    # Perform a particle sweep.
+    logevidence = sweep!(pc, spl.alg.resampler)
 
     # pick a particle to be retained.
     Ws = getweights(pc)
@@ -226,15 +270,18 @@ function AbstractMCMC.step!(
     # extract the VarInfo from the retained particle.
     params = tonamedtuple(vi)
     spl.state.vi = pc.vals[indx].vi
+
+    # This is pretty useless since we reset the log probability continuously in the
+    # particle sweep.
     lp = getlogp(spl.state.vi)
 
     # update the master vi.
-    return ParticleTransition(params, lp, pc.logE, 1.0)
+    return ParticleTransition(params, lp, logevidence, 1.0)
 end
 
 function AbstractMCMC.sample_end!(
     ::AbstractRNG,
-    ::Model,
+    ::AbstractModel,
     spl::Sampler{<:ParticleInference},
     N::Integer,
     ts::Vector{<:ParticleTransition};
@@ -246,14 +293,14 @@ function AbstractMCMC.sample_end!(
     loge = mean(t.le for t in ts)
 
     # If we already had a chain, grab the logevidence.
-    if resume_from isa Chains
+    if resume_from isa MCMCChains.Chains
         # pushfirst!(samples, resume_from.info[:samples]...)
         pre_loge = resume_from.logevidence
         # Calculate new log-evidence
         pre_n = length(resume_from)
         loge = (pre_loge * pre_n + loge * N) / (pre_n + N)
     elseif resume_from !== nothing
-        error("keyword argument `resume_from` has to be `nothing` or a `Chains` object")
+        error("keyword argument `resume_from` has to be `nothing` or a `MCMCChains.Chains` object")
     end
 
     # Store the logevidence.
@@ -264,10 +311,10 @@ function DynamicPPL.assume(
     spl::Sampler{<:Union{PG,SMC}},
     dist::Distribution,
     vn::VarName,
-    vi
+    ::Any
 )
     vi = current_trace().vi
-    if DynamicPPL.inspace(vn, getspace(spl))
+    if inspace(vn, spl)
         if ~haskey(vi, vn)
             r = rand(dist)
             push!(vi, vn, r, dist, spl)

--- a/test/Turing/inference/Inference.jl
+++ b/test/Turing/inference/Inference.jl
@@ -1,12 +1,15 @@
 module Inference
 
-using ..Core, ..Utilities
+using ..Core
+using ..Core: logZ
+using ..Utilities
 using DynamicPPL: Metadata, _tail, VarInfo, TypedVarInfo, 
     islinked, invlink!, getlogp, tonamedtuple, VarName, getsym, vectorize, 
     settrans!, _getvns, getdist, CACHERESET, AbstractSampler,
     Model, Sampler, SampleFromPrior, SampleFromUniform,
     Selector, AbstractSamplerState, DefaultContext, PriorContext,
-    LikelihoodContext, MiniBatchContext, set_flag!, unset_flag!, NamedDist, NoDist
+    LikelihoodContext, MiniBatchContext, set_flag!, unset_flag!, NamedDist, NoDist,
+    getspace, inspace
 using Distributions, Libtask, Bijectors
 using DistributionsAD: VectorOfMultivariate
 using LinearAlgebra
@@ -16,16 +19,17 @@ using Random: GLOBAL_RNG, AbstractRNG, randexp
 using DynamicPPL
 using AbstractMCMC: AbstractModel, AbstractSampler
 using Bijectors: _debug
-using MCMCChains: Chains
+using DocStringExtensions: TYPEDEF, TYPEDFIELDS
 
 import AbstractMCMC
 import AdvancedHMC; const AHMC = AdvancedHMC
 import AdvancedMH; const AMH = AdvancedMH
 import ..Core: getchunksize, getADbackend
-import DynamicPPL: tilde, dot_tilde, getspace, get_matching_type,
+import DynamicPPL: get_matching_type,
     VarName, _getranges, _getindex, getval, _getvns
 import EllipticalSliceSampling
 import Random
+import MCMCChains
 
 export  InferenceAlgorithm,
         Hamiltonian,
@@ -47,6 +51,7 @@ export  InferenceAlgorithm,
         SMC,
         CSMC,
         PG,
+        Prior,
         assume,
         dot_assume,
         observe,
@@ -65,6 +70,9 @@ abstract type AdaptiveHamiltonian{AD} <: Hamiltonian{AD} end
 
 getchunksize(::Type{<:Hamiltonian{AD}}) where AD = getchunksize(AD)
 getADbackend(::Hamiltonian{AD}) where AD = AD()
+
+# Algorithm for sampling from the prior
+struct Prior <: InferenceAlgorithm end
 
 """
     mh_accept(logp_current::Real, logp_proposal::Real, log_proposal_ratio::Real)
@@ -102,6 +110,8 @@ end
 function additional_parameters(::Type{<:Transition})
     return [:lp]
 end
+
+DynamicPPL.getlogp(t::Transition) = t.lp
 
 ##########################################
 # Internal variable names for MCMCChains #
@@ -146,47 +156,106 @@ function AbstractMCMC.sample(
     model::AbstractModel,
     alg::InferenceAlgorithm,
     N::Integer;
-    chain_type=Chains,
+    kwargs...
+)
+    return AbstractMCMC.sample(rng, model, Sampler(alg, model), N; kwargs...)
+end
+
+function AbstractMCMC.sample(
+    rng::AbstractRNG,
+    model::AbstractModel,
+    sampler::Sampler{<:InferenceAlgorithm},
+    N::Integer;
+    chain_type=MCMCChains.Chains,
     resume_from=nothing,
     progress=PROGRESS[],
     kwargs...
 )
     if resume_from === nothing
-        return AbstractMCMC.sample(rng, model, Sampler(alg, model), N;
-                                   chain_type=chain_type, progress=progress, kwargs...)
+        return AbstractMCMC.mcmcsample(rng, model, sampler, N;
+                                       chain_type=chain_type, progress=progress, kwargs...)
     else
         return resume(resume_from, N; chain_type=chain_type, progress=progress, kwargs...)
     end
 end
 
-function AbstractMCMC.psample(
-    model::AbstractModel,
-    alg::InferenceAlgorithm,
-    N::Integer,
-    n_chains::Integer;
-    kwargs...
-)
-    return AbstractMCMC.psample(Random.GLOBAL_RNG, model, alg, N, n_chains; kwargs...)
-end
-
-function AbstractMCMC.psample(
+function AbstractMCMC.sample(
     rng::AbstractRNG,
     model::AbstractModel,
-    alg::InferenceAlgorithm,
-    N::Integer,
-    n_chains::Integer;
-    chain_type=Chains,
+    alg::Prior,
+    N::Integer;
+    chain_type=MCMCChains.Chains,
+    resume_from=nothing,
     progress=PROGRESS[],
     kwargs...
 )
-    return AbstractMCMC.psample(rng, model, Sampler(alg, model), N, n_chains;
-                                chain_type=chain_type, progress=progress, kwargs...)
+    if resume_from === nothing
+        return AbstractMCMC.mcmcsample(rng, model, SampleFromPrior(), N;
+                                       chain_type=chain_type, progress=progress, kwargs...)
+    else
+        return resume(resume_from, N; chain_type=chain_type, progress=progress, kwargs...)
+    end
+end
+
+function AbstractMCMC.sample(
+    model::AbstractModel,
+    alg::InferenceAlgorithm,
+    parallel::AbstractMCMC.AbstractMCMCParallel,
+    N::Integer,
+    n_chains::Integer;
+    kwargs...
+)
+    return AbstractMCMC.sample(Random.GLOBAL_RNG, model, alg, parallel, N, n_chains;
+                               kwargs...)
+end
+
+function AbstractMCMC.sample(
+    rng::AbstractRNG,
+    model::AbstractModel,
+    alg::InferenceAlgorithm,
+    parallel::AbstractMCMC.AbstractMCMCParallel,
+    N::Integer,
+    n_chains::Integer;
+    kwargs...
+)
+    return AbstractMCMC.sample(rng, model, Sampler(alg, model), parallel, N, n_chains;
+                               kwargs...)
+end
+
+function AbstractMCMC.sample(
+    rng::AbstractRNG,
+    model::AbstractModel,
+    sampler::Sampler{<:InferenceAlgorithm},
+    parallel::AbstractMCMC.AbstractMCMCParallel,
+    N::Integer,
+    n_chains::Integer;
+    chain_type=MCMCChains.Chains,
+    progress=PROGRESS[],
+    kwargs...
+)
+    return AbstractMCMC.mcmcsample(rng, model, sampler, parallel, N, n_chains;
+                                   chain_type=chain_type, progress=progress, kwargs...)
+end
+
+function AbstractMCMC.sample(
+    rng::AbstractRNG,
+    model::AbstractModel,
+    alg::Prior,
+    parallel::AbstractMCMC.AbstractMCMCParallel,
+    N::Integer,
+    n_chains::Integer;
+    chain_type=MCMCChains.Chains,
+    progress=PROGRESS[],
+    kwargs...
+)
+    return AbstractMCMC.sample(rng, model, SampleFromPrior(), parallel, N, n_chains;
+                               chain_type=chain_type, progress=progress, kwargs...)
 end
 
 function AbstractMCMC.sample_init!(
     ::AbstractRNG,
-    model::Model,
-    spl::Sampler,
+    model::AbstractModel,
+    spl::Sampler{<:InferenceAlgorithm},
     N::Integer;
     kwargs...
 )
@@ -197,23 +266,13 @@ function AbstractMCMC.sample_init!(
     initialize_parameters!(spl; kwargs...)
 end
 
-function AbstractMCMC.sample_end!(
-    ::AbstractRNG,
-    ::Model,
-    ::Sampler,
-    ::Integer,
-    ::Vector;
-    kwargs...
-)
-    # Silence the default API function.
-end
-
 function initialize_parameters!(
     spl::Sampler;
     init_theta::Union{Nothing,Vector}=nothing,
     verbose::Bool=false,
     kwargs...
 )
+    islinked(spl.state.vi, spl) && invlink!(spl.state.vi, spl)
     # Get `init_theta`
     if init_theta !== nothing
         verbose && @info "Using passed-in initial variable values" init_theta
@@ -238,11 +297,19 @@ end
 # Chain making utilities #
 ##########################
 
-function _params_to_array(ts::Vector, spl::Sampler)
+"""
+    getparams(t)
+
+Return a named tuple of parameters.
+"""
+getparams(t) = t.θ
+getparams(t::VarInfo) = tonamedtuple(TypedVarInfo(t))
+
+function _params_to_array(ts)
     names_set = Set{String}()
     # Extract the parameter names and values from each transition.
     dicts = map(ts) do t
-        nms, vs = flatten_namedtuple(t.θ)
+        nms, vs = flatten_namedtuple(getparams(t))
         for nm in nms
             push!(names_set, nm)
         end
@@ -250,7 +317,7 @@ function _params_to_array(ts::Vector, spl::Sampler)
         return Dict(nms[j] => vs[j] for j in 1:length(vs))
     end
     names = collect(names_set)
-    vals = [get(dicts[i], key, missing) for i in eachindex(dicts), 
+    vals = [get(dicts[i], key, missing) for i in eachindex(dicts),
         (j, key) in enumerate(names)]
 
     return names, vals
@@ -270,7 +337,12 @@ function flatten_namedtuple(nt::NamedTuple)
     return [vn[1] for vn in names_vals], [vn[2] for vn in names_vals]
 end
 
-function get_transition_extras(ts::Vector)
+function get_transition_extras(ts::AbstractVector{<:VarInfo})
+    valmat = reshape([getlogp(t) for t in ts], :, 1)
+    return ["lp"], valmat
+end
+
+function get_transition_extras(ts::AbstractVector)
     # Get the extra field names from the sampler state type.
     # This handles things like :lp or :weight.
     extra_params = additional_parameters(eltype(ts))
@@ -310,56 +382,55 @@ function get_transition_extras(ts::Vector)
     return extra_names, valmat
 end
 
-# Default Chains constructor.
+getlogevidence(sampler) = missing
+function getlogevidence(sampler::Sampler)
+    if isdefined(sampler.state, :average_logevidence)
+        return sampler.state.average_logevidence
+    elseif isdefined(sampler.state, :final_logevidence)
+        return sampler.state.final_logevidence
+    else
+        return missing
+    end
+end
+
+# Default MCMCChains.Chains constructor.
+# This is type piracy (at least for SampleFromPrior).
 function AbstractMCMC.bundle_samples(
     rng::AbstractRNG,
-    model::Model,
-    spl::Sampler,
+    model::AbstractModel,
+    spl::Union{Sampler{<:InferenceAlgorithm},SampleFromPrior},
     N::Integer,
     ts::Vector,
-    chain_type::Type{Chains};
-    discard_adapt::Bool=true,
-    save_state=false,
+    chain_type::Type{MCMCChains.Chains};
+    save_state = false,
     kwargs...
 )
-    # Check if we have adaptation samples.
-    if discard_adapt && :n_adapts in fieldnames(typeof(spl.alg))
-        ts = ts[(spl.alg.n_adapts+1):end]
-    end
-
     # Convert transitions to array format.
     # Also retrieve the variable names.
-    nms, vals = _params_to_array(ts, spl)
+    nms, vals = _params_to_array(ts)
 
-    # Get the values of the extra parameters in each Transition struct.
+    # Get the values of the extra parameters in each transition.
     extra_params, extra_values = get_transition_extras(ts)
 
     # Extract names & construct param array.
     nms = [nms; extra_params]
     parray = hcat(vals, extra_values)
 
-    # If the state field has average_logevidence or final_logevidence, grab that.
-    le = missing
-    if :average_logevidence in fieldnames(typeof(spl.state))
-        le = getproperty(spl.state, :average_logevidence)
-    elseif :final_logevidence in fieldnames(typeof(spl.state))
-        le = getproperty(spl.state, :final_logevidence)
-    end
-
-    # Check whether to invlink! the varinfo
-    if islinked(spl.state.vi, spl)
-        invlink!(spl.state.vi, spl)
-    end
+    # Get the average or final log evidence, if it exists.
+    le = getlogevidence(spl)
 
     # Set up the info tuple.
     if save_state
-        info = (range = rng, model = model, spl = spl, vi = spl.state.vi)
+        info = (range = rng, model = model, spl = spl)
     else
         info = NamedTuple()
     end
 
+    # Conretize the array before giving it to MCMCChains.
+    parray = MCMCChains.concretize(parray)
+
     # Chain construction.
-    return Chains(
+    return MCMCChains.Chains(
         parray,
         string.(nms),
         deepcopy(TURING_INTERNAL_VARS);
@@ -369,10 +440,11 @@ function AbstractMCMC.bundle_samples(
     )
 end
 
+# This is type piracy (for SampleFromPrior).
 function AbstractMCMC.bundle_samples(
     rng::AbstractRNG,
-    model::Model,
-    spl::Sampler,
+    model::AbstractModel,
+    spl::Union{Sampler{<:InferenceAlgorithm},SampleFromPrior},
     N::Integer,
     ts::Vector,
     chain_type::Type{Vector{NamedTuple}};
@@ -382,39 +454,46 @@ function AbstractMCMC.bundle_samples(
 )
     nts = Vector{NamedTuple}(undef, N)
 
-    for (i,t) in enumerate(ts)
-        k = collect(keys(t.θ))
+    for (i, t) in enumerate(ts)
+        params = getparams(t)
+
+        k = collect(keys(params))
         vs = []
-        for v in values(t.θ)
+        for v in values(params)
             push!(vs, v[1])
         end
 
         push!(k, :lp)
-        
-        
-        nts[i] = NamedTuple{tuple(k...)}(tuple(vs..., t.lp))
+
+        nts[i] = NamedTuple{tuple(k...)}(tuple(vs..., getlogp(t)))
     end
 
     return map(identity, nts)
 end
 
-function save(c::Chains, spl::Sampler, model, vi, samples)
+function save(c::MCMCChains.Chains, spl::Sampler, model, vi, samples)
     nt = NamedTuple{(:spl, :model, :vi, :samples)}((spl, model, deepcopy(vi), samples))
     return setinfo(c, merge(nt, c.info))
 end
 
-function resume(c::Chains, n_iter::Int; chain_type=Chains, progress=PROGRESS[], kwargs...)
+function resume(
+    c::MCMCChains.Chains,
+    n_iter::Int;
+    chain_type=MCMCChains.Chains,
+    progress=PROGRESS[],
+    kwargs...
+)
     @assert !isempty(c.info) "[Turing] cannot resume from a chain without state info"
 
     # Sample a new chain.
-    newchain = AbstractMCMC.sample(
+    newchain = AbstractMCMC.mcmcsample(
         c.info[:range],
         c.info[:model],
         c.info[:spl],
         n_iter;
         resume_from=c,
         reuse_spl_n=n_iter,
-        chain_type=Chains,
+        chain_type=MCMCChains.Chains,
         progress=progress,
         kwargs...
     )
@@ -425,7 +504,7 @@ end
 
 function set_resume!(
     s::Sampler;
-    resume_from::Union{Chains, Nothing}=nothing,
+    resume_from::Union{MCMCChains.Chains, Nothing}=nothing,
     kwargs...
 )
     # If we're resuming, grab the sampler info.
@@ -462,10 +541,10 @@ include("../contrib/inference/sghmc.jl")
 ################
 
 for alg in (:SMC, :PG, :MH, :IS, :ESS, :Gibbs)
-    @eval getspace(::$alg{space}) where {space} = space
+    @eval DynamicPPL.getspace(::$alg{space}) where {space} = space
 end
 for alg in (:HMC, :HMCDA, :NUTS, :SGLD, :SGHMC)
-    @eval getspace(::$alg{<:Any, space}) where {space} = space
+    @eval DynamicPPL.getspace(::$alg{<:Any, space}) where {space} = space
 end
 
 floatof(::Type{T}) where {T <: Real} = typeof(one(T)/one(T))
@@ -480,27 +559,20 @@ function get_matching_type(
 end
 function get_matching_type(
     spl::AbstractSampler, 
-    vi,
-    ::Type{<:AbstractFloat},
-)
-    return floatof(eltype(vi, spl))
-end
-function get_matching_type(
-    spl::Sampler{<:Hamiltonian}, 
-    vi,
+    vi, 
     ::Type{<:Union{Missing, AbstractFloat}},
 )
     return Union{Missing, floatof(eltype(vi, spl))}
 end
 function get_matching_type(
-    spl::Sampler{<:Hamiltonian}, 
+    spl::AbstractSampler,
     vi,
     ::Type{<:AbstractFloat},
 )
     return floatof(eltype(vi, spl))
 end
 function get_matching_type(
-    spl::Sampler{<:Hamiltonian}, 
+    spl::AbstractSampler,
     vi,
     ::Type{TV},
 ) where {T, N, TV <: Array{T, N}}
@@ -518,12 +590,7 @@ end
 # Utilities  #
 ##############
 
-getspace(spl::Sampler) = getspace(spl.alg)
-function ambiguity_error_msg()
-    return "Ambiguous `lhs .~ rhs` or `@. lhs ~ rhs` syntax. The broadcasting can either be 
-    column-wise following the convention of Distributions.jl or element-wise following 
-    Julia's general broadcasting semantics. Please make sure that the element type of `lhs` 
-    is not a supertype of the support type of `AbstractVector` to eliminate ambiguity."
-end
+DynamicPPL.getspace(spl::Sampler) = getspace(spl.alg)
+DynamicPPL.inspace(vn::VarName, spl::Sampler) = inspace(vn, getspace(spl.alg))
 
 end # module

--- a/test/Turing/inference/ess.jl
+++ b/test/Turing/inference/ess.jl
@@ -145,7 +145,7 @@ function Distributions.loglikelihood(model::ESSModel, f)
 end
 
 function DynamicPPL.tilde(ctx::DefaultContext, sampler::Sampler{<:ESS}, right, vn::VarName, inds, vi)
-    if DynamicPPL.inspace(vn, getspace(sampler))
+    if inspace(vn, sampler)
         return DynamicPPL.tilde(LikelihoodContext(), SampleFromPrior(), right, vn, inds, vi)
     else
         return DynamicPPL.tilde(ctx, SampleFromPrior(), right, vn, inds, vi)
@@ -157,7 +157,7 @@ function DynamicPPL.tilde(ctx::DefaultContext, sampler::Sampler{<:ESS}, right, l
 end
 
 function DynamicPPL.dot_tilde(ctx::DefaultContext, sampler::Sampler{<:ESS}, right, left, vn::VarName, inds, vi)
-    if DynamicPPL.inspace(vn, getspace(sampler))
+    if inspace(vn, sampler)
         return DynamicPPL.dot_tilde(LikelihoodContext(), SampleFromPrior(), right, left, vn, inds, vi)
     else
         return DynamicPPL.dot_tilde(ctx, SampleFromPrior(), right, left, vn, inds, vi)

--- a/test/Turing/inference/gibbs.jl
+++ b/test/Turing/inference/gibbs.jl
@@ -98,6 +98,32 @@ function Sampler(alg::Gibbs, model::Model, s::Selector)
     return spl
 end
 
+"""
+    GibbsTransition
+
+Fields:
+- `θ`: The parameters for any given sample.
+- `lp`: The log pdf for the sample's parameters.
+- `transitions`: The transitions of the samplers.
+"""
+struct GibbsTransition{T,F,S<:AbstractVector}
+    θ::T
+    lp::F
+    transitions::S
+end
+
+function GibbsTransition(spl::Sampler{<:Gibbs}, transitions::AbstractVector)
+    theta = tonamedtuple(spl.state.vi)
+    lp = getlogp(spl.state.vi)
+    return GibbsTransition(theta, lp, transitions)
+end
+
+function additional_parameters(::Type{<:GibbsTransition})
+    return [:lp]
+end
+
+DynamicPPL.getlogp(t::GibbsTransition) = t.lp
+
 # Initialize the Gibbs sampler.
 function AbstractMCMC.sample_init!(
     rng::AbstractRNG,
@@ -132,39 +158,55 @@ function AbstractMCMC.step!(
     model::Model,
     spl::Sampler{<:Gibbs},
     N::Integer,
-    transition;
+    transition::Union{Nothing,GibbsTransition};
     kwargs...
 )
     Turing.DEBUG && @debug "Gibbs stepping..."
 
-    time_elapsed = 0.0
-
     # Iterate through each of the samplers.
-    for local_spl in spl.state.samplers
+    transitions = map(enumerate(spl.state.samplers)) do (i, local_spl)
         Turing.DEBUG && @debug "$(typeof(local_spl)) stepping..."
-
-        Turing.DEBUG && @debug "recording old θ..."
 
         # Update the sampler's VarInfo.
         local_spl.state.vi = spl.state.vi
 
         # Step through the local sampler.
-        time_elapsed_thin =
-            @elapsed trans = AbstractMCMC.step!(rng, model, local_spl, N, transition; kwargs...)
+        if transition === nothing
+            trans = AbstractMCMC.step!(rng, model, local_spl, N, nothing; kwargs...)
+        else
+            trans = AbstractMCMC.step!(rng, model, local_spl, N, transition.transitions[i];
+                                       kwargs...)
+        end
 
         # After the step, update the master varinfo.
         spl.state.vi = local_spl.state.vi
 
-        # Uncomment when developing thinning functionality.
-        # Retrieve symbol to store this subsample.
-        # symbol_id = Symbol(local_spl.selector.gid)
-        #
-        # # Store the subsample.
-        # spl.state.subsamples[symbol_id][] = trans
-
-        # Record elapsed time.
-        time_elapsed += time_elapsed_thin
+        trans
     end
 
-    return Transition(spl)
+    return GibbsTransition(spl, transitions)
+end
+
+# Do not store transitions of subsamplers
+function AbstractMCMC.transitions_init(
+    transition::GibbsTransition,
+    ::Model,
+    ::Sampler{<:Gibbs},
+    N::Integer;
+    kwargs...
+)
+    return Vector{Transition{typeof(transition.θ),typeof(transition.lp)}}(undef, N)
+end
+
+function AbstractMCMC.transitions_save!(
+    transitions::Vector{<:Transition},
+    iteration::Integer,
+    transition::GibbsTransition,
+    ::Model,
+    ::Sampler{<:Gibbs},
+    ::Integer;
+    kwargs...
+)
+    transitions[iteration] = Transition(transition.θ, transition.lp)
+    return
 end

--- a/test/Turing/inference/hmc.jl
+++ b/test/Turing/inference/hmc.jl
@@ -37,6 +37,7 @@ function additional_parameters(::Type{<:HamiltonianTransition})
     return [:lp,:stat]
 end
 
+DynamicPPL.getlogp(t::HamiltonianTransition) = t.lp
 
 ###
 ### Hamiltonian Monte Carlo samplers.
@@ -78,7 +79,7 @@ end
 
 alg_str(::Sampler{<:Hamiltonian}) = "HMC"
 
-HMC(args...) = HMC{ADBackend()}(args...)
+HMC(args...; kwargs...) = HMC{ADBackend()}(args...; kwargs...)
 function HMC{AD}(ϵ::Float64, n_leapfrog::Int, ::Type{metricT}, space::Tuple) where {AD, metricT <: AHMC.AbstractMetric}
     return HMC{AD, space, metricT}(ϵ, n_leapfrog)
 end
@@ -99,21 +100,54 @@ function HMC{AD}(
     return HMC{AD}(ϵ, n_leapfrog, metricT, space)
 end
 
+function update_hamiltonian!(spl, model, n)
+    metric = gen_metric(n, spl)
+    ℓπ = gen_logπ(spl.state.vi, spl, model)
+    ∂ℓπ∂θ = gen_∂logπ∂θ(spl.state.vi, spl, model)
+    spl.state.h = AHMC.Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
+    return spl
+end
+
 function AbstractMCMC.sample_init!(
     rng::AbstractRNG,
-    model::Model,
+    model::AbstractModel,
     spl::Sampler{<:Hamiltonian},
     N::Integer;
     verbose::Bool=true,
     resume_from=nothing,
+    init_theta=nothing,
     kwargs...
 )
-
     # Resume the sampler.
     set_resume!(spl; resume_from=resume_from, kwargs...)
 
     # Get `init_theta`
     initialize_parameters!(spl; verbose=verbose, kwargs...)
+    if init_theta !== nothing
+        # Doesn't support dynamic models
+        link!(spl.state.vi, spl)
+        model(spl.state.vi, spl)
+        theta = spl.state.vi[spl]
+        update_hamiltonian!(spl, model, length(theta))
+        # Refresh the internal cache phase point z's hamiltonian energy.
+        spl.state.z = AHMC.phasepoint(rng, theta, spl.state.h)
+    else
+        # Samples new values and sets trans to true, then computes the logp
+        model(empty!(spl.state.vi), SampleFromUniform())
+        link!(spl.state.vi, spl)
+        theta = spl.state.vi[spl]
+        update_hamiltonian!(spl, model, length(theta))
+        # Refresh the internal cache phase point z's hamiltonian energy.
+        spl.state.z = AHMC.phasepoint(rng, theta, spl.state.h)
+        while !isfinite(spl.state.z.ℓπ.value) || !isfinite(spl.state.z.ℓπ.gradient)
+            model(empty!(spl.state.vi), SampleFromUniform())
+            link!(spl.state.vi, spl)
+            theta = spl.state.vi[spl]
+            update_hamiltonian!(spl, model, length(theta))
+            # Refresh the internal cache phase point z's hamiltonian energy.
+            spl.state.z = AHMC.phasepoint(rng, theta, spl.state.h)
+        end
+    end
 
     # Set the default number of adaptations, if relevant.
     if spl.alg isa AdaptiveHamiltonian
@@ -138,7 +172,47 @@ function AbstractMCMC.sample_init!(
     if !islinked(spl.state.vi, spl) && spl.selector.tag == :default
         link!(spl.state.vi, spl)
         model(spl.state.vi, spl)
+    elseif islinked(spl.state.vi, spl) && spl.selector.tag != :default
+        invlink!(spl.state.vi, spl)
+        model(spl.state.vi, spl)        
     end
+end
+
+function AbstractMCMC.transitions_init(
+    transition,
+    ::AbstractModel,
+    sampler::Sampler{<:Hamiltonian},
+    N::Integer;
+    discard_adapt = true,
+    kwargs...
+)
+    if discard_adapt && isdefined(sampler.alg, :n_adapts)
+        n = max(0, N - sampler.alg.n_adapts)
+    else
+        n = N
+    end
+    return Vector{typeof(transition)}(undef, n)
+end
+
+function AbstractMCMC.transitions_save!(
+    transitions::AbstractVector,
+    iteration::Integer,
+    transition,
+    ::AbstractModel,
+    sampler::Sampler{<:Hamiltonian},
+    ::Integer;
+    discard_adapt = true,
+    kwargs...
+)
+    if discard_adapt && isdefined(sampler.alg, :n_adapts)
+        if iteration > sampler.alg.n_adapts
+            transitions[iteration - sampler.alg.n_adapts] = transition
+        end
+        return
+    end
+
+    transitions[iteration] = transition
+    return
 end
 
 """
@@ -337,22 +411,21 @@ function AbstractMCMC.step!(
     spl.state.eval_num = 0
 
     Turing.DEBUG && @debug "current ϵ: $ϵ"
-    
-    # Gibbs component specified cares
+
+    # When a Gibbs component
     if spl.selector.tag != :default
         # Transform the space
         Turing.DEBUG && @debug "X-> R..."
         link!(spl.state.vi, spl)
         model(spl.state.vi, spl)
-        # Update Hamiltonian
-        metric = gen_metric(length(spl.state.vi[spl]), spl)
-        ∂logπ∂θ = gen_∂logπ∂θ(spl.state.vi, spl, model)
-        logπ = gen_logπ(spl.state.vi, spl, model)
-        spl.state.h = AHMC.Hamiltonian(metric, logπ, ∂logπ∂θ)
     end
-
     # Get position and log density before transition
     θ_old, log_density_old = spl.state.vi[spl], getlogp(spl.state.vi)
+    if spl.selector.tag != :default
+        update_hamiltonian!(spl, model, length(θ_old))
+        resize!(spl.state.z.θ, length(θ_old))
+        spl.state.z.θ .= θ_old
+    end
 
     # Transition
     t = AHMC.step(rng, spl.state.h, spl.state.traj, spl.state.z)
@@ -499,8 +572,8 @@ end
 ####
 
 function AHMCAdaptor(alg::AdaptiveHamiltonian, metric::AHMC.AbstractMetric; ϵ=alg.ϵ)
-    pc = AHMC.Preconditioner(metric)
-    da = AHMC.NesterovDualAveraging(alg.δ, ϵ)
+    pc = AHMC.MassMatrixAdaptor(metric)
+    da = AHMC.StepSizeAdaptor(alg.δ, ϵ)
 
     if iszero(alg.n_adapts)
         adaptor = AHMC.Adaptation.NoAdaptation()
@@ -549,7 +622,7 @@ function HMCState(
 
     # Find good eps if not provided one
     if spl.alg.ϵ == 0.0
-        ϵ = AHMC.find_good_eps(h, θ_init)
+        ϵ = AHMC.find_good_stepsize(h, θ_init)
         @info "Found initial step size" ϵ
     else
         ϵ = spl.alg.ϵ

--- a/test/Turing/inference/mh.jl
+++ b/test/Turing/inference/mh.jl
@@ -12,8 +12,6 @@ function MH(space...)
     prop_syms = Symbol[]
     props = AMH.Proposal[]
 
-    check_support(dist) = insupport(dist, z)
-
     for s in space
         if s isa Symbol
             push!(syms, s)
@@ -23,9 +21,9 @@ function MH(space...)
             if s[2] isa AMH.Proposal
                 push!(props, s[2])
             elseif s[2] isa Distribution
-                push!(props, AMH.Proposal(AMH.Static(), s[2]))
+                push!(props, AMH.StaticProposal(s[2]))
             elseif s[2] isa Function
-                push!(props, AMH.Proposal(AMH.Static(), s[2]))
+                push!(props, AMH.StaticProposal(s[2]))
             end
         end
     end
@@ -35,22 +33,22 @@ function MH(space...)
     return MH{tuple(syms...), typeof(proposals)}(proposals)
 end
 
+function Sampler(
+    alg::MH,
+    model::Model,
+    s::Selector=Selector()
+)
+    # Set up info dict.
+    info = Dict{Symbol, Any}()
+
+    # Set up state struct.
+    state = SamplerState(VarInfo(model))
+
+    # Generate a sampler.
+    return Sampler(alg, info, s, state)
+end
+
 alg_str(::Sampler{<:MH}) = "MH"
-
-#################
-# MH Transition #
-#################
-
-struct MHTransition{T, F<:AbstractFloat, M<:AMH.Transition}
-    θ    :: T
-    lp   :: F
-    mh_trans :: M
-end
-
-function MHTransition(spl::Sampler{<:MH}, mh_trans::AMH.Transition)
-    theta = tonamedtuple(spl.state.vi)
-    return MHTransition(theta, mh_trans.lp, mh_trans)
-end
 
 #####################
 # Utility functions #
@@ -68,7 +66,7 @@ function set_namedtuple!(vi::VarInfo, nt::NamedTuple)
         n_vns = length(vns)
         n_vals = length(vals)
         v_isarr = vals isa AbstractArray
-        
+
         if v_isarr && n_vals == 1 && n_vns > 1
             for (vn, val) in zip(vns, vals[1])
                 vi[vn] = val isa AbstractArray ? val : [val]
@@ -94,35 +92,40 @@ function set_namedtuple!(vi::VarInfo, nt::NamedTuple)
 end
 
 """
-    gen_logπ_mh(vi, spl::Sampler, model)
+    MHLogDensityFunction
 
-Generate a log density function -- this variant uses the
-`set_namedtuple!` function to update the `VarInfo`.
+A log density function for the MH sampler.
+
+This variant uses the  `set_namedtuple!` function to update the `VarInfo`.
 """
-function gen_logπ_mh(spl::Sampler, model)
-    function logπ(x)::Float64
-        vi = spl.state.vi
-        x_old, lj_old = vi[spl], getlogp(vi)
-        # vi[spl] = x
-        set_namedtuple!(vi, x)
-        model(vi)
-        lj = getlogp(vi)
-        vi[spl] = x_old
-        setlogp!(vi, lj_old)
-        return lj
-    end
-    return logπ
+struct MHLogDensityFunction{M<:Model,S<:Sampler{<:MH}} <: Function # Relax AMH.DensityModel?
+    model::M
+    sampler::S
 end
 
-function scalar_map(vi, vns::Vector{V}) where V<:VarName
-    vals = getindex(vi, vns)
-    if length(vals) == length(vns) == 1
-        # It's a scalar!
-        return vals[1]
-    else 
-        # Go home, vector, you're drunk.
-        return vals
-    end
+function (f::MHLogDensityFunction)(x)::Float64
+    sampler = f.sampler
+    vi = sampler.state.vi
+    x_old, lj_old = vi[sampler], getlogp(vi)
+    # vi[sampler] = x
+    set_namedtuple!(vi, x)
+    f.model(vi)
+    lj = getlogp(vi)
+    vi[sampler] = x_old
+    setlogp!(vi, lj_old)
+    return lj
+end
+
+# unpack a vector if possible
+unvectorize(dists::AbstractVector) = length(dists) == 1 ? first(dists) : dists
+
+# possibly unpack and reshape samples according to the prior distribution 
+reconstruct(dist::Distribution, val::AbstractVector) = DynamicPPL.reconstruct(dist, val)
+function reconstruct(
+    dist::AbstractVector{<:UnivariateDistribution},
+    val::AbstractVector
+)
+    return val
 end
 
 """
@@ -132,78 +135,42 @@ Returns two `NamedTuples`. The first `NamedTuple` has symbols as keys and distri
 The second `NamedTuple` has model symbols as keys and their stored values as values.
 """
 function dist_val_tuple(spl::Sampler{<:MH})
-    vns = _getvns(spl.state.vi, spl)
-    dt = _dist_tuple(spl.state.vi.metadata, spl.alg.proposals, spl.state.vi, vns)
-    vt = _val_tuple(spl.state.vi.metadata, spl.state.vi, vns)
+    vi = spl.state.vi
+    vns = _getvns(vi, spl)
+    dt = _dist_tuple(spl.alg.proposals, vi, vns)
+    vt = _val_tuple(vi, vns)
     return dt, vt
 end
 
-@generated function _val_tuple(metadata::NamedTuple, vi, vns::NamedTuple{names}) where {names}
-    length(names) === 0 && return :(NamedTuple())
+@generated function _val_tuple(
+    vi::VarInfo,
+    vns::NamedTuple{names}
+) where {names}
+    isempty(names) === 0 && return :(NamedTuple())
     expr = Expr(:tuple)
-    map(names) do f
-        push!(expr.args, Expr(:(=), f, :(scalar_map(vi, metadata.$f.vns))))
-    end
+    expr.args = Any[
+        :($name = reconstruct(unvectorize(DynamicPPL.getdist.(Ref(vi), vns.$name)),
+                              DynamicPPL.getval(vi, vns.$name)))
+        for name in names]
     return expr
 end
 
 @generated function _dist_tuple(
-    metadata::NamedTuple, 
     props::NamedTuple{propnames}, 
-    vi, 
+    vi::VarInfo,
     vns::NamedTuple{names}
-) where {names, propnames}
-    length(names) === 0 && return :(NamedTuple())
+) where {names,propnames}
+    isempty(names) === 0 && return :(NamedTuple())
     expr = Expr(:tuple)
-    map(names) do f
-        if f in propnames
+    expr.args = Any[
+        if name in propnames
             # We've been given a custom proposal, use that instead.
-            push!(expr.args, Expr(:(=), f, :(props.$f)))
+            :($name = props.$name)
         else
             # Otherwise, use the default proposal.
-            push!(expr.args, Expr(:(=), f, :(AMH.Proposal(AMH.Static(), metadata.$f.dists[1]))))
-        end
-    end
+            :($name = AMH.StaticProposal(unvectorize(DynamicPPL.getdist.(Ref(vi), vns.$name))))
+        end for name in names]
     return expr
-end
-
-#################
-# Sampler state #
-#################
-
-mutable struct MHState{V<:VarInfo} <: AbstractSamplerState
-    vi :: V
-    density_model :: AMH.DensityModel
-end
-
-###############################
-# Static MH (from prior only) #
-###############################
-
-function Sampler(
-    alg::MH,
-    model::Model,
-    s::Selector=Selector()
-)
-    # Set up info dict.
-    info = Dict{Symbol, Any}()
-
-    # Make a varinfo.
-    vi = VarInfo(model)
-
-    # Make a density model.
-    dm = AMH.DensityModel(x -> 0.0)
-
-    # Set up state struct.
-    state = MHState(vi, dm)
-
-    # Generate a sampler.
-    spl = Sampler(alg, info, s, state)
-
-    # Update the density model.
-    spl.state.density_model = AMH.DensityModel(gen_logπ_mh(spl, model))
-
-    return spl
 end
 
 function AbstractMCMC.sample_init!(
@@ -242,7 +209,8 @@ function AbstractMCMC.step!(
     prev_trans = AMH.Transition(vt, getlogp(spl.state.vi))
 
     # Make a new transition.
-    trans = AbstractMCMC.step!(rng, spl.state.density_model, mh_sampler, 1, prev_trans)
+    densitymodel = AMH.DensityModel(MHLogDensityFunction(model, spl))
+    trans = AbstractMCMC.step!(rng, densitymodel, mh_sampler, 1, prev_trans)
 
     # Update the values in the VarInfo.
     set_namedtuple!(spl.state.vi, trans.params)

--- a/test/Turing/stdlib/distributions.jl
+++ b/test/Turing/stdlib/distributions.jl
@@ -47,16 +47,6 @@ struct BinomialLogit{T<:Real, I<:Integer} <: DiscreteUnivariateDistribution
     logitp::T
 end
 
-"""
-    BinomialLogit(n<:Real, I<:Integer)
-
-A multivariate binomial logit distribution.
-"""
-struct VecBinomialLogit{T<:Real, I<:Integer} <: DiscreteUnivariateDistribution
-    n::Vector{I}
-    logitp::Vector{T}
-end
-
 function logpdf_binomial_logit(n, logitp, k)
     logcomb = -StatsFuns.log1p(n) - SpecialFunctions.logbeta(n - k + 1, k + 1)
     return logcomb + k * logitp - n * StatsFuns.log1pexp(logitp)
@@ -66,8 +56,17 @@ function Distributions.logpdf(d::BinomialLogit{<:Real}, k::Int)
     return logpdf_binomial_logit(d.n, d.logitp, k)
 end
 
-function Distributions.logpdf(d::VecBinomialLogit{<:Real}, ks::Vector{<:Integer})
-    return sum(logpdf_binomial_logit.(d.n, d.logitp, ks))
+function Distributions.pdf(d::BinomialLogit{<:Real}, k::Int)
+    return exp(logpdf_binomial_logit(d.n, d.logitp, k))
+end
+
+"""
+    BernoulliLogit(p<:Real)
+
+A univariate logit-parameterised Bernoulli distribution.
+"""
+function BernoulliLogit(logitp::Real)
+    return BinomialLogit(1, logitp)
 end
 
 """
@@ -134,3 +133,10 @@ end
 function Distributions.logpdf(lp::LogPoisson, k::Int)
     return k * lp.logλ - exp(lp.logλ) - SpecialFunctions.loggamma(k + 1)
 end
+
+Bijectors.logpdf_with_trans(d::NoDist{<:Univariate}, ::Real, ::Bool) = 0
+Bijectors.logpdf_with_trans(d::NoDist{<:Multivariate}, ::AbstractVector{<:Real}, ::Bool) = 0
+function Bijectors.logpdf_with_trans(d::NoDist{<:Multivariate}, x::AbstractMatrix{<:Real}, ::Bool)
+    return zeros(Int, size(x, 2))
+end
+Bijectors.logpdf_with_trans(d::NoDist{<:Matrixvariate}, ::AbstractMatrix{<:Real}, ::Bool) = 0

--- a/test/Turing/utilities/Utilities.jl
+++ b/test/Turing/utilities/Utilities.jl
@@ -1,9 +1,9 @@
 module Utilities
 
 using DynamicPPL: AbstractSampler, Sampler
+using DynamicPPL: init, inittrans, reconstruct, reconstruct!, vectorize
 using Distributions, Bijectors
 using StatsFuns, SpecialFunctions
-using MCMCChains: Chains, setinfo
 import Distributions: sample
 
 export  vectorize,
@@ -12,11 +12,9 @@ export  vectorize,
         Sample,
         Chain,
         init,
-        vectorize,
         set_resume!,
         FlattenIterator
 
-include("robustinit.jl")
 include("helper.jl")
 
 end # module

--- a/test/Turing/utilities/stan-interface.jl
+++ b/test/Turing/utilities/stan-interface.jl
@@ -70,8 +70,8 @@ end
 function AHMCAdaptor(adaptor)
     if :engaged in fieldnames(typeof(adaptor)) # CmdStan.Adapt
         adaptor.engaged ? spl.alg.n_adapts : 0,
-        AHMC.Preconditioner(metric),
-        AHMC.NesterovDualAveraging(adaptor.gamma,
+        AHMC.MassMatrixAdaptor(metric),
+        AHMC.StepSizeAdaptor(adaptor.gamma,
             adaptor.t0, adaptor.kappa, adaptor.δ, init_ϵ),
             adaptor.init_buffer,
             adaptor.term_buffer,
@@ -79,8 +79,8 @@ function AHMCAdaptor(adaptor)
     else # default adaptor
         @warn "Invalid adaptor type: $(typeof(adaptor)). Default adaptor is used instead."
         adaptor = AHMC.StanHMCAdaptor(
-            AHMC.Preconditioner(:DiagEuclideanMetric),
-            AHMC.NesterovDualAveraging(spl.alg.δ, init_ϵ)
+            AHMC.MassMatrixAdaptor(:DiagEuclideanMetric),
+            AHMC.StepSizeAdaptor(spl.alg.δ, init_ϵ)
         )
         AHMC.initialize!(adaptor, spl.alg.n_adapts)
         adaptor

--- a/test/Turing/variational/VariationalInference.jl
+++ b/test/Turing/variational/VariationalInference.jl
@@ -38,8 +38,51 @@ function __init__()
             else
                 - vo(alg, q(θ), model, args...)
             end
-            out .= Zygote.gradient(f, θ)
+            y, back = Tracker.pullback(f, θ)
+            dy = back(1.0)
+            DiffResults.value!(out, y)
+            DiffResults.gradient!(out, dy)
             return out
+        end
+    end
+    @require ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267" begin
+        function Variational.grad!(
+            vo,
+            alg::VariationalInference{<:Turing.ReverseDiffAD{false}},
+            q,
+            model,
+            θ::AbstractVector{<:Real},
+            out::DiffResults.MutableDiffResult,
+            args...
+        )
+            f(θ) = if (q isa VariationalPosterior)
+                - vo(alg, update(q, θ), model, args...)
+            else
+                - vo(alg, q(θ), model, args...)
+            end
+            tp = Turing.Core.tape(f, θ)
+            ReverseDiff.gradient!(out, tp, θ)
+            return out
+        end
+        @require Memoization = "6fafb56a-5788-4b4e-91ca-c0cea6611c73" begin
+            function Variational.grad!(
+                vo,
+                alg::VariationalInference{<:Turing.ReverseDiffAD{true}},
+                q,
+                model,
+                θ::AbstractVector{<:Real},
+                out::DiffResults.MutableDiffResult,
+                args...
+            )
+                f(θ) = if (q isa VariationalPosterior)
+                    - vo(alg, update(q, θ), model, args...)
+                else
+                    - vo(alg, q(θ), model, args...)
+                end
+                ctp = Turing.Core.memoized_tape(f, θ)
+                ReverseDiff.gradient!(out, ctp, θ)
+                return out
+            end
         end
     end
 end

--- a/test/Turing/variational/advi.jl
+++ b/test/Turing/variational/advi.jl
@@ -44,7 +44,7 @@ function bijector(model::Model; sym_to_ranges::Val{sym2ranges} = Val(false)) whe
         idx += varinfo.metadata[sym].ranges[end][end]
     end
 
-    bs = inv.(bijector.(tuple(dists...)))
+    bs = bijector.(tuple(dists...))
 
     if sym2ranges
         return Stacked(bs, ranges), (; collect(zip(keys(sym_lookup), values(sym_lookup)))...)


### PR DESCRIPTION
This PR syncs Turing with the DPPL tests version of Turing. This is helpful because locally I like to develop both Turing and DPPL simultaneously calling `using Turing` instead of `using .Turing` in the DPPL tests and then at the end I copy and paste the Turing src to the test folder.