### PR TITLE
Fix CompatHelper and reduce frequency of TagBot

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -14,4 +14,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+        run: julia -e 'using CompatHelper; CompatHelper.main(; master_branch = "dev")'

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -8,12 +8,10 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: 1.3
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,7 +1,7 @@
 name: TagBot
 on:
   schedule:
-    - cron: 0 * * * *
+    - cron: 0 0 * * *
 jobs:
   TagBot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes CompatHelper (there's no need to install Julia, CompatHelper takes care of that) and sets it up for running the CI tests on Github (currently CompatHelper does not run any tests). Moreover, it reduces the frequency of TagBot to once per day to save resources.

~~Someone with sufficient permissions has to follow the steps in https://github.com/bcbi/CompatHelper.jl#122-instructions-for-setting-up-the-ssh-deploy-key and add a private key and a deploy key to make it actually work.~~
Edit: Seems I could fix it.