### PR TITLE
[Merged by Bors] - Add `@addlogprob!` macro

### DIFF
--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -93,7 +93,9 @@ export  AbstractVarInfo,
         @logprob_str,
 # Convenience functions
         logprior,
-        logjoint
+        logjoint,
+# Convenience macros
+        @addlogprob!
 
 # Reexport
 using Distributions: loglikelihood

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,15 @@
 """
+    @addlogprob!(ex)
+
+Add the result of the evaluation of `ex` to the joint log probability.
+"""
+macro addlogprob!(ex)
+    return quote
+        acclogp!($(esc(:(_varinfo))), $(esc(ex)))
+    end
+end
+
+"""
     getargs_dottilde(x)
 
 Return the arguments `L` and `R`, if `x` is an expression of the form `L .~ R` or

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -3,6 +3,20 @@ using DynamicPPL: getargs_dottilde, getargs_tilde
 
 using Test
 
+@testset "addlogprob!" begin
+    @model function testmodel()
+        global lp_before = getlogp(_varinfo)
+        @addlogprob!(42)
+        global lp_after = getlogp(_varinfo)
+    end
+
+    model = testmodel()
+    varinfo = DynamicPPL.VarInfo(model)
+    model(varinfo)
+    @test iszero(lp_before)
+    @test getlogp(varinfo) == lp_after == 42
+end
+
 @testset "getargs_dottilde" begin
     # Some things that are not expressions.
     @test getargs_dottilde(:x) === nothing


### PR DESCRIPTION
This PR tries to address the inconvenience for users having to know about the internal variable `_varinfo` and writing `Turing.acclogp!(_varinfo, myvalue)` to modify the accumulated joint log probability by adding a `@addlogprob!` macro which allows to simply write `@addlogprob!(myvalue)`.

In particular, it addresses https://github.com/TuringLang/Turing.jl/issues/1332#issuecomment-646853570 (partly, the documentation still has to be updated) and might have avoided the discussion in https://github.com/TuringLang/Turing.jl/issues/1328.

BTW, this macro is quite different from the removed `@logprob` and `@varinfo` macros since it is a "proper" Julia macro that is not replaced or touched by the DynamicPPL compiler.

It might seem natural to call it `@acclogp!` (since it just adds a call to `acclogp!`) but IMO a more descriptive name (such as `@addlogprob!`?) might be more intuitive for users.