### PR TITLE
[Merged by Bors] - Change CI configuration

### DIFF
--- a/.github/workflows/DynamicPPL-CI.yml
+++ b/.github/workflows/DynamicPPL-CI.yml
@@ -3,14 +3,12 @@ name: DynamicPPL-CI
 on:
   push:
     branches:
-      - master
-      - dev
       # This is where pull requests from "bors r+" are built.
       - staging
       # This is where pull requests from "bors try" are built.
       - trying
-  # Enable building pull requests.
-  pull_request:
+      # Build the master branch.
+      - master
 
 jobs:
   test:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@
 language: julia
 branches:
   only:
-    # Enable building pull requests to master and dev.
-    - master
-    - dev
     # This is where pull requests from "bors r+" are built.
     - staging
     # This is where pull requests from "bors try" are built.
     - trying
+    # Build the master branch.
+    - master
 os:
   - linux
   - osx
@@ -32,4 +31,5 @@ notifications:
 after_success:
   - if [[ $TRAVIS_JULIA_VERSION = 1 ]] && [[ $JULIA_NUM_THREADS = 1 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
       julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';
+      julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())';
     fi

--- a/bors.toml
+++ b/bors.toml
@@ -12,8 +12,10 @@ status = [
   "test (1, windows-latest, x64)"
 ]
 delete_merged_branches = true
-# Uncomment this to require at least on approval of a project member.
-#required_approvals = 1
+# Require at least on approval of a project member.
+required_approvals = 1
+# Squash commits before merging.
+use_squash_merge = true
 # Uncomment this to use a two hour timeout.
 # The default is one hour.
 #timeout_sec = 7200


### PR DESCRIPTION
The changes in this PR try to enforce the use of bors to a larger extent. PRs are not tested automatically anymore but instead only when one comments with `bors try` (does not merge afterwards) or `bors r+` (merges automatically afterwards). Additionally, the configuration requires at least one approval of a project member and squashes commits before merging.

I'm not sure about building the master branch as well - in my experience it leads to redundant tests (since the commits are tested in the staging branch already) but works a bit better with the display of the Github check status and the badges.