### PR TITLE
[Merged by Bors] - Remove DEBUG

### DIFF
--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -96,8 +96,6 @@ export  AbstractVarInfo,
 using Distributions: loglikelihood
 export loglikelihood
 
-const DEBUG = Bool(parse(Int, get(ENV, "DEBUG_DYNAMICPPL", "0")))
-
 # Used here and overloaded in Turing
 function getspace end
 

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -444,8 +444,7 @@ function dot_observe(
     vi,
 )
     increment_num_produce!(vi)
-    DynamicPPL.DEBUG && @debug "dist = $dist"
-    DynamicPPL.DEBUG && @debug "value = $value"
+    @debug "dot_observe" dist value
     return sum(Distributions.logpdf(dist, value))
 end
 function dot_observe(
@@ -455,8 +454,7 @@ function dot_observe(
     vi,
 )
     increment_num_produce!(vi)
-    DynamicPPL.DEBUG && @debug "dists = $dists"
-    DynamicPPL.DEBUG && @debug "value = $value"
+    @debug "dot_observe" dists value
     return sum(Distributions.logpdf.(dists, value))
 end
 function dot_observe(

--- a/test/Turing/Turing.jl
+++ b/test/Turing/Turing.jl
@@ -23,8 +23,6 @@ function turnprogress(switch::Bool)
     PROGRESS[] = switch
 end
 
-const DEBUG = Bool(parse(Int, get(ENV, "DEBUG_TURING", "0")))
-
 # Random probability measures.
 include("stdlib/distributions.jl")
 include("stdlib/RandomMeasures.jl")

--- a/test/Turing/contrib/inference/AdvancedSMCExtensions.jl
+++ b/test/Turing/contrib/inference/AdvancedSMCExtensions.jl
@@ -79,9 +79,9 @@ function step(model, spl::Sampler{<:PMMH}, vi::VarInfo, is_first::Bool)
     new_likelihood_estimate = 0.0
     old_θ = copy(vi[spl])
 
-    Turing.DEBUG && @debug "Propose new parameters from proposals..."
+    @debug "Propose new parameters from proposals..."
     for local_spl in spl.info[:samplers][1:end-1]
-        Turing.DEBUG && @debug "$(typeof(local_spl)) proposing $(local_spl.alg.space)..."
+        @debug "$(typeof(local_spl)) proposing $(local_spl.alg.space)..."
         propose(model, local_spl, vi)
         if local_spl.info[:violating_support] violating_support=true; break end
         new_prior_prob += local_spl.info[:prior_prob]
@@ -92,11 +92,11 @@ function step(model, spl::Sampler{<:PMMH}, vi::VarInfo, is_first::Bool)
         # do not run SMC if going to refuse anyway
         accepted = false
     else
-        Turing.DEBUG && @debug "Propose new state with SMC..."
+        @debug "Propose new state with SMC..."
         vi, _ = step(model, spl.info[:samplers][end], vi)
         new_likelihood_estimate = spl.info[:samplers][end].info[:logevidence][end]
 
-        Turing.DEBUG && @debug "Decide whether to accept..."
+        @debug "Decide whether to accept..."
         accepted = mh_accept(
           spl.info[:old_likelihood_estimate] + spl.info[:old_prior_prob],
           new_likelihood_estimate + new_prior_prob,
@@ -150,7 +150,7 @@ function sample(  model::Model,
     accept_his = Bool[]
     PROGRESS[] && (spl.info[:progress] = ProgressMeter.Progress(n, 1, "[$alg_str] Sampling...", 0))
     for i = 1:n
-      Turing.DEBUG && @debug "$alg_str stepping..."
+      @debug "$alg_str stepping..."
       time_elapsed = @elapsed vi, is_accept = step(model, spl, vi, i==1)
 
       if is_accept # accepted => store the new predcits
@@ -305,7 +305,7 @@ function sample(model::Model, alg::IPMCMC)
   # IPMCMC steps
   if PROGRESS[] spl.info[:progress] = ProgressMeter.Progress(n, 1, "[IPMCMC] Sampling...", 0) end
   for i = 1:n
-    Turing.DEBUG && @debug "IPMCMC stepping..."
+    @debug "IPMCMC stepping..."
     time_elapsed = @elapsed VarInfos = step(model, spl, VarInfos, i==1)
 
     # Save each CSMS retained path as a sample

--- a/test/Turing/contrib/inference/sghmc.jl
+++ b/test/Turing/contrib/inference/sghmc.jl
@@ -82,29 +82,29 @@ function step(
     η, α = spl.alg.learning_rate, spl.alg.momentum_decay
     spl.info[:eval_num] = 0
 
-    Turing.DEBUG && @debug "X-> R..."
+    @debug "X-> R..."
     if spl.selector.tag != :default
         link!(vi, spl)
         model(vi, spl)
     end
 
-    Turing.DEBUG && @debug "recording old variables..."
+    @debug "recording old variables..."
     θ, v = vi[spl], spl.info[:v]
     _, grad = gradient_logp(θ, vi, model, spl)
     verifygrad(grad)
 
     # Implements the update equations from (15) of Chen et al. (2014).
-    Turing.DEBUG && @debug "update latent variables and velocity..."
+    @debug "update latent variables and velocity..."
     θ .+= v
     v .= (1 - α) .* v .+ η .* grad .+ rand.(Normal.(zeros(length(θ)), sqrt(2 * η * α)))
 
-    Turing.DEBUG && @debug "saving new latent variables..."
+    @debug "saving new latent variables..."
     vi[spl] = θ
 
-    Turing.DEBUG && @debug "R -> X..."
+    @debug "R -> X..."
     spl.selector.tag != :default && invlink!(vi, spl)
 
-    Turing.DEBUG && @debug "always accept..."
+    @debug "always accept..."
     return vi, true
 end
 
@@ -189,30 +189,30 @@ function step(
     spl.info[:i] += 1
     spl.info[:eval_num] = 0
 
-    Turing.DEBUG && @debug "compute current step size..."
+    @debug "compute current step size..."
     γ = .35
     ϵ_t = spl.alg.ϵ / spl.info[:i]^γ # NOTE: Choose γ=.55 in paper
     mssa = spl.info[:adaptor].ssa
     mssa.state.ϵ = ϵ_t
 
-    Turing.DEBUG && @debug "X-> R..."
+    @debug "X-> R..."
     if spl.selector.tag != :default
         link!(vi, spl)
         model(vi, spl)
     end
 
-    Turing.DEBUG && @debug "recording old variables..."
+    @debug "recording old variables..."
     θ = vi[spl]
     _, grad = gradient_logp(θ, vi, model, spl)
     verifygrad(grad)
 
-    Turing.DEBUG && @debug "update latent variables..."
+    @debug "update latent variables..."
     θ .+= ϵ_t .* grad ./ 2 .- rand.(Normal.(zeros(length(θ)), sqrt(ϵ_t)))
 
-    Turing.DEBUG && @debug "always accept..."
+    @debug "always accept..."
     vi[spl] = θ
 
-    Turing.DEBUG && @debug "R -> X..."
+    @debug "R -> X..."
     spl.selector.tag != :default && invlink!(vi, spl)
 
     return vi, true

--- a/test/Turing/inference/Inference.jl
+++ b/test/Turing/inference/Inference.jl
@@ -18,7 +18,6 @@ using StatsFuns: logsumexp
 using Random: GLOBAL_RNG, AbstractRNG, randexp
 using DynamicPPL
 using AbstractMCMC: AbstractModel, AbstractSampler
-using Bijectors: _debug
 using DocStringExtensions: TYPEDEF, TYPEDFIELDS
 
 import AbstractMCMC

--- a/test/Turing/inference/gibbs.jl
+++ b/test/Turing/inference/gibbs.jl
@@ -173,11 +173,11 @@ function AbstractMCMC.step!(
     transition::Union{Nothing,GibbsTransition};
     kwargs...
 )
-    Turing.DEBUG && @debug "Gibbs stepping..."
+    @debug "Gibbs stepping..."
 
     # Iterate through each of the samplers.
     transitions = map(enumerate(spl.state.samplers)) do (i, local_spl)
-        Turing.DEBUG && @debug "$(typeof(local_spl)) stepping..."
+        @debug "$(typeof(local_spl)) stepping..."
 
         # Update the sampler's VarInfo.
         local_spl.state.vi = spl.state.vi

--- a/test/Turing/inference/hmc.jl
+++ b/test/Turing/inference/hmc.jl
@@ -514,14 +514,10 @@ function DynamicPPL.assume(
     vn::VarName,
     vi,
 )
-    _debug("assuming...")
     updategid!(vi, vn, spl)
     r = vi[vn]
     # acclogp!(vi, logpdf_with_trans(dist, r, istrans(vi, vn)))
     # r
-    _debug("dist = $dist")
-    _debug("vn = $vn")
-    _debug("r = $r, typeof(r)=$(typeof(r))")
     return r, logpdf_with_trans(dist, r, istrans(vi, vn))
 end
 

--- a/test/Turing/inference/hmc.jl
+++ b/test/Turing/inference/hmc.jl
@@ -411,12 +411,12 @@ function AbstractMCMC.step!(
     spl.state.i += 1
     spl.state.eval_num = 0
 
-    Turing.DEBUG && @debug "current ϵ: $ϵ"
+    @debug "current ϵ: $ϵ"
 
     # When a Gibbs component
     if spl.selector.tag != :default
         # Transform the space
-        Turing.DEBUG && @debug "X-> R..."
+        @debug "X-> R..."
         link!(spl.state.vi, spl)
         model(spl.state.vi, spl)
     end
@@ -440,7 +440,7 @@ function AbstractMCMC.step!(
                         spl.state.i, spl.alg.n_adapts, t.z.θ, t.stat.acceptance_rate)
     end
 
-    Turing.DEBUG && @debug "decide whether to accept..."
+    @debug "decide whether to accept..."
 
     # Update `vi` based on acceptance
     if t.stat.is_accept
@@ -453,7 +453,7 @@ function AbstractMCMC.step!(
 
     # Gibbs component specified cares
     # Transform the space back
-    Turing.DEBUG && @debug "R -> X..."
+    @debug "R -> X..."
     spl.selector.tag != :default && invlink!(spl.state.vi, spl)
 
     return HamiltonianTransition(spl, t)
@@ -514,14 +514,14 @@ function DynamicPPL.assume(
     vn::VarName,
     vi,
 )
-    Turing.DEBUG && _debug("assuming...")
+    _debug("assuming...")
     updategid!(vi, vn, spl)
     r = vi[vn]
     # acclogp!(vi, logpdf_with_trans(dist, r, istrans(vi, vn)))
     # r
-    Turing.DEBUG && _debug("dist = $dist")
-    Turing.DEBUG && _debug("vn = $vn")
-    Turing.DEBUG && _debug("r = $r, typeof(r)=$(typeof(r))")
+    _debug("dist = $dist")
+    _debug("vn = $vn")
+    _debug("r = $r, typeof(r)=$(typeof(r))")
     return r, logpdf_with_trans(dist, r, istrans(vi, vn))
 end
 

--- a/test/Turing/variational/VariationalInference.jl
+++ b/test/Turing/variational/VariationalInference.jl
@@ -217,7 +217,7 @@ function optimize!(
             Δ = apply!(optimizer, θ, Δ)
             @. θ = θ - Δ
 
-            Turing.DEBUG && @debug "Step $i" Δ DiffResults.value(diff_result)
+            @debug "Step $i" Δ DiffResults.value(diff_result)
 
             # Update the progress bar.
             progress && ProgressLogging.@logprogress i/max_iters

--- a/test/Turing/variational/advi.jl
+++ b/test/Turing/variational/advi.jl
@@ -131,7 +131,7 @@ function vi(model::Model, alg::ADVI; optimizer = TruncatedADAGrad())
 end
 
 function vi(model, alg::ADVI, q::TransformedDistribution{<:TuringDiagMvNormal}; optimizer = TruncatedADAGrad())
-    Turing.DEBUG && @debug "Optimizing ADVI..."
+    @debug "Optimizing ADVI..."
     # Initial parameters for mean-field approx
     μ, σs = params(q)
     θ = vcat(μ, invsoftplus.(σs))
@@ -144,7 +144,7 @@ function vi(model, alg::ADVI, q::TransformedDistribution{<:TuringDiagMvNormal}; 
 end
 
 function vi(model, alg::ADVI, q, θ_init; optimizer = TruncatedADAGrad())
-    Turing.DEBUG && @debug "Optimizing ADVI..."
+    @debug "Optimizing ADVI..."
     θ = copy(θ_init)
     optimize!(elbo, alg, q, model, θ; optimizer = optimizer)
 


### PR DESCRIPTION
This PR removes the variables `Turing.DEBUG` and `DynamicPPL.DEBUG`. Instead one can just set the environment variable `JULIA_DEBUG` to "Turing" or "DynamicPPL", if desired (see https://docs.julialang.org/en/v1/stdlib/Logging/#Environment-variables-1). By default, debug logging is not enabled and the messages are filtered immediately without being evaluated (see https://docs.julialang.org/en/v1/stdlib/Logging/#Early-filtering-and-message-handling-1), and hence the additional check `Turing.DEBUG` or `DynamicPPL.DEBUG` is not needed even from a performance perspective.