### PR TITLE
Makes _setval! and thus the prob-macro compatible with v4

### DIFF
--- a/src/prob_macro.jl
+++ b/src/prob_macro.jl
@@ -233,7 +233,7 @@ _setval!(vi::TypedVarInfo, c::AbstractChains) = _setval!(vi.metadata, vi, c)
     return Expr(:block, map(names) do n
         quote
             for vn in md.$n.vns
-                val = copy(vec(c[MCMCChains.namesingroup(c, Symbol(vn)].value))
+                val = copy(vec(MCMCChains.group(c, Symbol(vn)).value))
                 setval!(vi, val, vn)
                 settrans!(vi, false, vn)
             end

--- a/src/prob_macro.jl
+++ b/src/prob_macro.jl
@@ -233,7 +233,7 @@ _setval!(vi::TypedVarInfo, c::AbstractChains) = _setval!(vi.metadata, vi, c)
     return Expr(:block, map(names) do n
         quote
             for vn in md.$n.vns
-                val = vec(c[Symbol(vn)])
+                val = copy(vec(c[MCMCChains.namesingroup(c, Symbol(vn)].value))
                 setval!(vi, val, vn)
                 settrans!(vi, false, vn)
             end


### PR DESCRIPTION
Currently the following fails:
```julia
DynamicPPL._setval!(vi, c)
```
where `vi` is a `VarInfo` and `c` is a `MCMCChains.Chains` if the model contains non-univariate variables. This PR provides a fix by using the new `MCMCChains.namesingroup` to get the corresponding index-symbols which is then used to extract the values from the chain `c`.

The issue is that after `v4.0` `vi.metadata[key].vns` results in a `VarName` which is "identical" to `key` in the sense that even if `a` represents a multivariate variable, `vi.metadata[:a].vns == [VarName(:a, ())]`, _not_ the varnames corresponding to the _indices_ for that variable. See https://github.com/TuringLang/Turing.jl/issues/1352 for a related issue. 