### PR TITLE
Add ColPrac guide

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -14,4 +14,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
-        run: julia -e 'using CompatHelper; CompatHelper.main(; master_branch = "dev", subdirs = ["", "test"])'
+        run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs = ["", "test"])'

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,0 +1,17 @@
+name: Pull request to dev on push to master and new tags
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+jobs:
+  auto-pull-request:
+    name: PullRequestAction
+    runs-on: ubuntu-latest
+    steps:
+      - name: pull-request-action
+        uses: vsoch/pull-request-action@1.0.6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST_BRANCH: "dev"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DynamicPPL.jl
 
 [![Build Status](https://travis-ci.com/TuringLang/DynamicPPL.jl.svg?branch=master)](https://travis-ci.com/TuringLang/DynamicPPL.jl)
+[![Build Status](https://github.com/TuringLang/DynamicPPL.jl/workflows/DynamicPPL-CI/badge.svg)](https://github.com/TuringLang/DynamicPPL.jl/actions?query=workflow%3ADynamicPPL-CI+branch%3Amaster)
 [![Codecov](https://codecov.io/gh/TuringLang/DynamicPPL.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/TuringLang/DynamicPPL.jl)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://colprac.sciml.ai/)
 [![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/24589)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
-# DynamicPPL
+# DynamicPPL.jl
 
 [![Build Status](https://travis-ci.com/TuringLang/DynamicPPL.jl.svg?branch=master)](https://travis-ci.com/TuringLang/DynamicPPL.jl)
 [![Codecov](https://codecov.io/gh/TuringLang/DynamicPPL.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/TuringLang/DynamicPPL.jl)
+[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 
 A domain-specific language and backend for probabilistic programming languages, used by [Turing.jl](https://github.com/TuringLang/Turing.jl).
+
+## Do you want to contribute?
+
+If you feel you have some relevant skills and are interested in contributing then please do get in touch and open an issue on Github.
+
+This project follows the [ColPrac guide on collaborative practices](http://colprac.sciml.ai/), apart from the following slight variation:
+
+- The master branch contains the most recent release at any point in time. All non-breaking changes (bug fixes etc.) are merged directly into master and a new patch version is released immediately.
+- A separate dev branch contains all breaking changes, and is merged into master when a minor version release happens.
+
+For instance, suppose we are currently on version 0.13.5.
+
+- If someone produces a bug fix, it is merged directly into master and bumps the version to 0.13.6. This change is also merged into dev so that it remains up-to-date with master.
+- If someone is working on a new feature that is not breaking (performance-related, fancy new syntax that is backwards-compatible etc.), the same happens.
+- New breaking changes are merged into dev until a release is ready to go, at which point dev is merged into master and version 0.14 is released.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Build Status](https://travis-ci.com/TuringLang/DynamicPPL.jl.svg?branch=master)](https://travis-ci.com/TuringLang/DynamicPPL.jl)
 [![Codecov](https://codecov.io/gh/TuringLang/DynamicPPL.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/TuringLang/DynamicPPL.jl)
-[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
+[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://colprac.sciml.ai/)
+[![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/24589)
 
 A domain-specific language and backend for probabilistic programming languages, used by [Turing.jl](https://github.com/TuringLang/Turing.jl).
 
@@ -10,7 +11,9 @@ A domain-specific language and backend for probabilistic programming languages, 
 
 If you feel you have some relevant skills and are interested in contributing then please do get in touch and open an issue on Github.
 
-This project follows the [ColPrac guide on collaborative practices](http://colprac.sciml.ai/), apart from the following slight variation:
+### Contributor's Guide
+
+This project follows the [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://colprac.sciml.ai/), apart from the following slight variation:
 
 - The master branch contains the most recent release at any point in time. All non-breaking changes (bug fixes etc.) are merged directly into master and a new patch version is released immediately.
 - A separate dev branch contains all breaking changes, and is merged into master when a minor version release happens.
@@ -20,3 +23,14 @@ For instance, suppose we are currently on version 0.13.5.
 - If someone produces a bug fix, it is merged directly into master and bumps the version to 0.13.6. This change is also merged into dev so that it remains up-to-date with master.
 - If someone is working on a new feature that is not breaking (performance-related, fancy new syntax that is backwards-compatible etc.), the same happens.
 - New breaking changes are merged into dev until a release is ready to go, at which point dev is merged into master and version 0.14 is released.
+
+### Bors
+
+This project uses [Bors](https://bors.tech/) for merging PRs. Bors is a Github bot that prevents merge skew / semantic merge conflicts by testing
+the exact integration of pull requests before merging them.
+
+When a PR is good enough for merging and has been approved by at least one reviewer, instead of merging immediately, it is added to the merge queue
+by commenting with `bors r+`. The Bors bot merges the pull request into a staging area, and runs the CI tests. If tests pass, the commit in the staging
+area is copied to the target branch (i.e., usually master).
+
+PRs can be tested by adding a comment with `bors try`. Additional commands can be found in the [Bors documentation](https://bors.tech/documentation/).


### PR DESCRIPTION
In my opinion, currently bug fixes and new features take too much time to propagate through the Turing ecosystem, leading to open issues about problems that are already fixed but not released etc. I guess it also leads to outdated docs more easily since we don't want to update the publicly accessible docs as long as the new features or syntax are not publicly available.

There was some discussion about adopting ColPrac in @willtebbutt's PR over at Turing (https://github.com/TuringLang/Turing.jl/pull/1348), and I basically just added @willtebbutt's suggestions regarding the dev branch to the README explicitly, so that any possible contributor can spot this deviation from ColPrac.

IMO this could smoothen the development and release process quite a bit, and I'm very much in favour of adopting the same policy throughout the Turing ecosystem (although not all packages might need a separate dev branch).

I'm happy to hear your comments and suggestions :smiley: 