### PR TITLE
[Merged by Bors] - Save user-provided name in `Model`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -343,7 +343,10 @@ function build_output(modelinfo)
     modeldef[:body] = quote
         $evaluator = $(combinedef_anonymous(evaluatordef))
         return $(DynamicPPL.Model)(
-            $evaluator, $allargs_namedtuple, $defaults_namedtuple
+            $(QuoteNode(modeldef[:name])),
+            $evaluator,
+            $allargs_namedtuple,
+            $defaults_namedtuple,
         )
     end
 

--- a/src/model.jl
+++ b/src/model.jl
@@ -1,5 +1,6 @@
 """
     struct Model{F,argnames,defaultnames,missings,Targs,Tdefaults}
+        name::Symbol
         f::F
         args::NamedTuple{argnames,Targs}
         defaults::NamedTuple{defaultnames,Tdefaults}
@@ -32,39 +33,44 @@ Model{typeof(f),(:x, :y),(:x,),(:y,),Tuple{Float64,Float64},Tuple{Int64}}(f, (x 
 ```
 """
 struct Model{F,argnames,defaultnames,missings,Targs,Tdefaults} <: AbstractModel
+    name::Symbol
     f::F
     args::NamedTuple{argnames,Targs}
     defaults::NamedTuple{defaultnames,Tdefaults}
 
     """
-        Model{missings}(f, args::NamedTuple, defaults::NamedTuple)
+        Model{missings}(name::Symbol, f, args::NamedTuple, defaults::NamedTuple)
 
-    Create a model with evaluation function `f` and missing arguments overwritten by `missings`.
+    Create a model of name `name` with evaluation function `f` and missing arguments
+    overwritten by `missings`.
     """
     function Model{missings}(
+        name::Symbol,
         f::F,
         args::NamedTuple{argnames,Targs},
         defaults::NamedTuple{defaultnames,Tdefaults},
     ) where {missings,F,argnames,Targs,defaultnames,Tdefaults}
-        return new{F,argnames,defaultnames,missings,Targs,Tdefaults}(f, args, defaults)
+        return new{F,argnames,defaultnames,missings,Targs,Tdefaults}(name, f, args, defaults)
     end
 end
 
 """
-    Model(f, args::NamedTuple[, defaults::NamedTuple = ()])
+    Model(name::Symbol, f, args::NamedTuple[, defaults::NamedTuple = ()])
 
-Create a model with evaluation function `f` and missing arguments deduced from `args`.
+Create a model of name `name` with evaluation function `f` and missing arguments deduced
+from `args`.
 
 Default arguments `defaults` are used internally when constructing instances of the same
 model with different arguments.
 """
 @generated function Model(
+    name::Symbol,
     f::F,
     args::NamedTuple{argnames,Targs},
     defaults::NamedTuple = NamedTuple(),
 ) where {F,argnames,Targs}
     missings = Tuple(name for (name, typ) in zip(argnames, Targs.types) if typ <: Missing)
-    return :(Model{$missings}(f, args, defaults))
+    return :(Model{$missings}(name, f, args, defaults))
 end
 
 """
@@ -173,6 +179,13 @@ getmissings(model::Model{_F,_a,_d,missings}) where {missings,_F,_a,_d} = missing
 
 getmissing(model::Model) = getmissings(model)
 @deprecate getmissing(model) getmissings(model)
+
+"""
+    nameof(model::Model)
+
+Get the name of the `model` as `Symbol`.
+"""
+Base.nameof(model::Model) = model.name
 
 """
     logjoint(model::Model, varinfo::AbstractVarInfo)

--- a/src/prob_macro.jl
+++ b/src/prob_macro.jl
@@ -171,8 +171,9 @@ end
     # `missings` is splatted into a tuple at compile time and inserted as literal
     return quote
         $(warnings...)
-        Model{$(Tuple(missings))}(model.f, $(to_namedtuple_expr(argnames, argvals)),
-                                  model.defaults)
+        Model{$(Tuple(missings))}(
+            model.name, model.f, $(to_namedtuple_expr(argnames, argvals)), model.defaults,
+        )
     end
 end
 
@@ -229,6 +230,7 @@ end
 
     # `args` is inserted as properly typed NamedTuple expression;
     # `missings` is splatted into a tuple at compile time and inserted as literal
-    return :(Model{$(Tuple(missings))}(model.f, $(to_namedtuple_expr(argnames, argvals)),
-                                       model.defaults))
+    return :(Model{$(Tuple(missings))}(
+        model.name, model.f, $(to_namedtuple_expr(argnames, argvals)), model.defaults,
+    ))
 end

--- a/test/model.jl
+++ b/test/model.jl
@@ -148,4 +148,18 @@ Random.seed!(1234)
         # Ensure that they're not all the same (some can be, because rejected samples)
         @test any(res34[1:end - 1] .!= res34[2:end])
     end
+
+    @testset "nameof" begin
+        @model function test1(x)
+            m ~ Normal(0, 1)
+            x ~ Normal(m, 1)
+        end
+        @model test2(x) = begin
+            m ~ Normal(0, 1)
+            x ~ Normal(m, 1)
+        end
+
+        @test nameof(test1(rand())) == :test1
+        @test nameof(test2(rand())) == :test2
+    end
 end


### PR DESCRIPTION
This PR implements the functionality requested in https://github.com/TuringLang/Turing.jl/issues/1429 and saves the user-provided name of a model in `Model`. It can be retrieved from a `Model` instance with `Base.nameof`.