### PR TITLE
Replace `elementwise_loglikelihoods` with `pointwise_loglikelihoods`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.9.4"
+version = "0.9.5"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -91,7 +91,7 @@ export  AbstractVarInfo,
 # Convenience functions
         logprior,
         logjoint,
-        elementwise_loglikelihoods,
+        pointwise_loglikelihoods,
 # Convenience macros
         @addlogprob!
 
@@ -121,5 +121,7 @@ include("compiler.jl")
 include("prob_macro.jl")
 include("compat/ad.jl")
 include("loglikelihoods.jl")
+
+include("deprecations.jl")
 
 end # module

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,22 @@
+@deprecate getmissing(model) getmissings(model)
+
+# `@deprecate` doesn't work with qualified function names,
+# so we use the following hack
+const _base_in = Base.in
+@deprecate _base_in(vn::VarName, space::Tuple) inspace(vn, space)
+
+@deprecate elementwise_loglikelihoods(
+    model::Model, chain,
+) pointwise_loglikelihoods(
+    model, chain, String,
+)
+@deprecate elementwise_loglikelihoods(
+    model::Model, chain, ::Type{T},
+) where {T} pointwise_loglikelihoods(
+    model, chain, T,
+)
+@deprecate elementwise_loglikelihoods(
+    model::Model, varinfo::AbstractVarInfo,
+) pointwise_loglikelihoods(
+    model, varinfo,
+)

--- a/src/model.jl
+++ b/src/model.jl
@@ -177,9 +177,6 @@ Get a tuple of the names of the missing arguments of the `model`.
 """
 getmissings(model::Model{_F,_a,_d,missings}) where {missings,_F,_a,_d} = missings
 
-getmissing(model::Model) = getmissings(model)
-@deprecate getmissing(model) getmissings(model)
-
 """
     nameof(model::Model)
 

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -82,12 +82,6 @@ inspace(vn, space::Tuple) = vn in space
 inspace(vn::VarName, space::Tuple{}) = true
 inspace(vn::VarName, space::Tuple) = any(_in(vn, s) for s in space)
 
-@noinline function Base.in(vn::VarName, space::Tuple)
-    Base.depwarn("`Base.in(vn::VarName, space::Tuple)` is deprecated, use `inspace(vn, space)` instead.",
-                 nameof(Base.in))
-    return inspace(vn, space)
-end
-
 _in(vn::VarName, s::Symbol) = getsym(vn) == s
 _in(vn::VarName, s::VarName) = subsumes(s, vn)
 

--- a/test/Turing/Turing.jl
+++ b/test/Turing/Turing.jl
@@ -67,7 +67,7 @@ end
 # Exports #
 ###########
 # `using` statements for stuff to re-export
-using DynamicPPL: elementwise_loglikelihoods, generated_quantities, logprior, logjoint
+using DynamicPPL: pointwise_loglikelihoods, generated_quantities, logprior, logjoint
 using StatsBase: predict
 
 # Turing essentials - modelling macros and inference algorithms
@@ -122,7 +122,7 @@ export  @model,                 # modelling
         arraydist,
 
         predict,
-        elementwise_loglikelihoods,
+        pointwise_loglikelihoods,
         genereated_quantities,
         logprior,
         logjoint

--- a/test/loglikelihoods.jl
+++ b/test/loglikelihoods.jl
@@ -15,7 +15,7 @@ using .Turing
     y = randn();
     model = demo(xs, y);
     chain = sample(model, MH(), MCMCThreads(), 100, 2);
-    var_to_likelihoods = elementwise_loglikelihoods(model, chain)
+    var_to_likelihoods = pointwise_loglikelihoods(model, chain)
     @test haskey(var_to_likelihoods, "xs[1]")
     @test haskey(var_to_likelihoods, "xs[2]")
     @test haskey(var_to_likelihoods, "xs[3]")
@@ -31,7 +31,7 @@ using .Turing
     end
 
     var_info = VarInfo(model)
-    results = DynamicPPL.elementwise_loglikelihoods(model, var_info)
+    results = pointwise_loglikelihoods(model, var_info)
     var_to_likelihoods = Dict(string(vn) => ℓ for (vn, ℓ) in results)
     s, m = var_info[SampleFromPrior()]
     @test logpdf(Normal(m, √s), xs[1]) == var_to_likelihoods["xs[1]"]


### PR DESCRIPTION
This PR replaces `elementwise_loglikelihoods` with `pointwise_loglikelihoods`, as discussed in https://github.com/TuringLang/MCMCChains.jl/issues/243#issuecomment-706549998.