### PR TITLE
[Merged by Bors] - Use `convert` for obtaining matching values when running models

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.9.5"
+version = "0.9.6"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -369,7 +369,7 @@ Convert the `value` to the correct type for the `sampler` and the `vi` object.
 function matchingvalue(sampler, vi, value)
     T = typeof(value)
     if hasmissing(T)
-        return get_matching_type(sampler, vi, T)(value)
+        return convert(get_matching_type(sampler, vi, T), value)
     else
         return value
     end


### PR DESCRIPTION
As explained in https://github.com/TuringLang/Libtask.jl/issues/74#issuecomment-706680984, together with https://github.com/TuringLang/Libtask.jl/pull/77 this PR fixes https://github.com/TuringLang/Libtask.jl/issues/74.