### PR TITLE
[Merged by Bors] - Fix test errors

### DIFF
--- a/test/serialization.jl
+++ b/test/serialization.jl
@@ -51,7 +51,7 @@
             for samples in (samples1, samples2)
                 @test samples isa Vector{Float64}
                 @test length(samples) == n
-                @test mean(samples) ≈ 0 atol=0.1
+                @test mean(samples) ≈ 0 atol=0.15
                 @test std(samples) ≈ 1 atol=0.1
             end
         end


### PR DESCRIPTION
Some tests failed on 32bit systems, seems tolerances were too strict (-0.108... in the test and absolute tolerance was 0.1).