### PR TITLE
Run Turing integration test with Julia 1.5

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: 1
+          version: 1.5
           arch: x64
       - uses: julia-actions/julia-buildpkg@latest
       - name: Clone Downstream


### PR DESCRIPTION
Since Turing (or rather Libtask_jll) is not compatible with Julia 1.6 yet.

I guess it would be good to open an issue that reminds us to revert this change once a compatible version is available.