### PR TITLE
[Merged by Bors] - Rename internal variables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.10.10"
+version = "0.10.11"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,7 +9,7 @@ Add the result of the evaluation of `ex` to the joint log probability.
 """
 macro addlogprob!(ex)
     return quote
-        acclogp!($(esc(:(_varinfo))), $(esc(ex)))
+        acclogp!($(esc(:(__varinfo__))), $(esc(ex)))
     end
 end
 

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -172,12 +172,12 @@ end
         # Test use of internal names
         @model function testmodel_missing3(x)
             x[1] ~ Bernoulli(0.5)
-            global varinfo_ = _varinfo
-            global sampler_ = _sampler
-            global model_ = _model
-            global context_ = _context
-            global rng_ = _rng
-            global lp = getlogp(_varinfo)
+            global varinfo_ = __varinfo__
+            global sampler_ = __sampler__
+            global model_ = __model__
+            global context_ = __context__
+            global rng_ = __rng__
+            global lp = getlogp(__varinfo__)
             return x
         end
         model = testmodel_missing3([1.0])
@@ -192,12 +192,12 @@ end
         # disable warnings
         @model function testmodel_missing4(x)
             x[1] ~ Bernoulli(0.5)
-            global varinfo_ = _varinfo
-            global sampler_ = _sampler
-            global model_ = _model
-            global context_ = _context
-            global rng_ = _rng
-            global lp = getlogp(_varinfo)
+            global varinfo_ = __varinfo__
+            global sampler_ = __sampler__
+            global model_ = __model__
+            global context_ = __context__
+            global rng_ = __rng__
+            global lp = getlogp(__varinfo__)
             return x
         end false
         lpold = lp
@@ -236,7 +236,7 @@ end
         function makemodel(p)
             @model function testmodel(x)
                 x[1] ~ Bernoulli(p)
-                global lp = getlogp(_varinfo)
+                global lp = getlogp(__varinfo__)
                 return x
             end
             return testmodel
@@ -295,11 +295,11 @@ end
 
     @testset "macros within model" begin
         # Macro expansion
-        @model function demo()
+        @model function demo1()
             @mymodel1(y ~ Uniform())
         end
 
-        @test haskey(VarInfo(demo()), @varname(x))
+        @test haskey(VarInfo(demo1()), @varname(x))
 
         # Interpolation
         # Will fail if:
@@ -308,9 +308,9 @@ end
         # 2. `@mymodel` is expanded before entire `@model` has been
         #    expanded => errors since `MyModelStruct` is not a distribution,
         #    and hence `tilde_observe` errors.
-        @model function demo()
+        @model function demo2()
             $(@mymodel2(y ~ Uniform()))
         end
-        @test demo()() == 42
+        @test demo2()() == 42
     end
 end

--- a/test/threadsafe.jl
+++ b/test/threadsafe.jl
@@ -39,7 +39,7 @@
         x = rand(10_000)
 
         @model function wthreads(x)
-            global vi_ = _varinfo
+            global vi_ = __varinfo__
             x[1] ~ Normal(0, 1)
             Threads.@threads for i in 2:length(x)
                 x[i] ~ Normal(x[i-1], 1)
@@ -70,7 +70,7 @@
                                              SampleFromPrior(), DefaultContext())
 
         @model function wothreads(x)
-            global vi_ = _varinfo
+            global vi_ = __varinfo__
             x[1] ~ Normal(0, 1)
             for i in 2:length(x)
                 x[i] ~ Normal(x[i-1], 1)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,9 +1,9 @@
 @testset "utils.jl" begin
     @testset "addlogprob!" begin
         @model function testmodel()
-            global lp_before = getlogp(_varinfo)
+            global lp_before = getlogp(__varinfo__)
             @addlogprob!(42)
-            global lp_after = getlogp(_varinfo)
+            global lp_after = getlogp(__varinfo__)
         end
 
         model = testmodel()


### PR DESCRIPTION
This PR contains only a cosmetic change and makes the internal variable names consistent with the convention used by other packages, such as Julia base (`__module__` and `__source__`) and Zygote (`__context__`).

It is not strictly necessary to deprecate the current variable names since they are not exported but it seemed reasonable since probably at least `_varinfo` is known and used.