### PR TITLE
[Merged by Bors] - Reenable Turing tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,6 +52,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
         env:
+          GROUP: All
           JULIA_NUM_THREADS: ${{ matrix.num_threads }}
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.num_threads == 1

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: 1.5
+          version: 1
           arch: x64
       - uses: julia-actions/julia-buildpkg@latest
       - name: Clone Downstream

--- a/.github/workflows/JuliaNightly.yml
+++ b/.github/workflows/JuliaNightly.yml
@@ -31,3 +31,5 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        env:
+          GROUP: DynamicPPL

--- a/bors.toml
+++ b/bors.toml
@@ -24,4 +24,4 @@ required_approvals = 1
 use_squash_merge = true
 # Uncomment this to use a two hour timeout.
 # The default is one hour.
-#timeout_sec = 7200
+timeout_sec = 7200

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,30 +45,26 @@ include("test_util.jl")
         include(joinpath("compat", "ad.jl"))
     end
 
-    @static if VERSION <= v"1.5.3"
-        @testset "turing" begin
-            # activate separate test environment
-            Pkg.activate(DIRECTORY_Turing_tests)
-            Pkg.develop(PackageSpec(path=DIRECTORY_DynamicPPL))
-            Pkg.instantiate()
+    @testset "turing" begin
+        # activate separate test environment
+        Pkg.activate(DIRECTORY_Turing_tests)
+        Pkg.develop(PackageSpec(path=DIRECTORY_DynamicPPL))
+        Pkg.instantiate()
 
-            # make sure that the new environment is considered `using` and `import` statements
-            # (not added automatically on Julia 1.3, see e.g. PR #209)
-            if !(joinpath(DIRECTORY_Turing_tests, "Project.toml") in Base.load_path())
-                pushfirst!(LOAD_PATH, DIRECTORY_Turing_tests)
-            end
-
-            include(joinpath("turing", "runtests.jl"))
+        # make sure that the new environment is considered `using` and `import` statements
+        # (not added automatically on Julia 1.3, see e.g. PR #209)
+        if !(joinpath(DIRECTORY_Turing_tests, "Project.toml") in Base.load_path())
+            pushfirst!(LOAD_PATH, DIRECTORY_Turing_tests)
         end
+
+        include(joinpath("turing", "runtests.jl"))
     end
 
     @testset "doctests" begin
         DocMeta.setdocmeta!(
             DynamicPPL,
             :DocTestSetup,
-            quote
-            using DynamicPPL
-            end;
+            :(using DynamicPPL);
             recursive=true,
         )
         doctest(DynamicPPL; manual=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,52 +21,59 @@ using DynamicPPL: getargs_dottilde, getargs_tilde, Selector
 
 const DIRECTORY_DynamicPPL = dirname(dirname(pathof(DynamicPPL)))
 const DIRECTORY_Turing_tests = joinpath(DIRECTORY_DynamicPPL, "test", "turing")
+const GROUP = get(ENV, "GROUP", "All")
 
 Random.seed!(100)
 
 include("test_util.jl")
 
 @testset "DynamicPPL.jl" begin
-    include("utils.jl")
-    include("compiler.jl")
-    include("varinfo.jl")
-    include("model.jl")
-    include("sampler.jl")
-    include("prob_macro.jl")
-    include("independence.jl")
-    include("distribution_wrappers.jl")
-    include("context_implementations.jl")
+    if GROUP == "All" || GROUP == "DynamicPPL"
+        @testset "interface" begin
+            include("utils.jl")
+            include("compiler.jl")
+            include("varinfo.jl")
+            include("model.jl")
+            include("sampler.jl")
+            include("prob_macro.jl")
+            include("independence.jl")
+            include("distribution_wrappers.jl")
+            include("context_implementations.jl")
 
-    include("threadsafe.jl")
+            include("threadsafe.jl")
 
-    include("serialization.jl")
-
-    @testset "compat" begin
-        include(joinpath("compat", "ad.jl"))
-    end
-
-    @testset "turing" begin
-        # activate separate test environment
-        Pkg.activate(DIRECTORY_Turing_tests)
-        Pkg.develop(PackageSpec(path=DIRECTORY_DynamicPPL))
-        Pkg.instantiate()
-
-        # make sure that the new environment is considered `using` and `import` statements
-        # (not added automatically on Julia 1.3, see e.g. PR #209)
-        if !(joinpath(DIRECTORY_Turing_tests, "Project.toml") in Base.load_path())
-            pushfirst!(LOAD_PATH, DIRECTORY_Turing_tests)
+            include("serialization.jl")
         end
 
-        include(joinpath("turing", "runtests.jl"))
+        @testset "compat" begin
+            include(joinpath("compat", "ad.jl"))
+        end
+
+        @testset "doctests" begin
+            DocMeta.setdocmeta!(
+                DynamicPPL,
+                :DocTestSetup,
+                :(using DynamicPPL);
+                recursive=true,
+            )
+            doctest(DynamicPPL; manual=false)
+        end
     end
 
-    @testset "doctests" begin
-        DocMeta.setdocmeta!(
-            DynamicPPL,
-            :DocTestSetup,
-            :(using DynamicPPL);
-            recursive=true,
-        )
-        doctest(DynamicPPL; manual=false)
+    if GROUP == "All" || GROUP == "Downstream"
+        @testset "turing" begin
+            # activate separate test environment
+            Pkg.activate(DIRECTORY_Turing_tests)
+            Pkg.develop(PackageSpec(path=DIRECTORY_DynamicPPL))
+            Pkg.instantiate()
+
+            # make sure that the new environment is considered `using` and `import` statements
+            # (not added automatically on Julia 1.3, see e.g. PR #209)
+            if !(joinpath(DIRECTORY_Turing_tests, "Project.toml") in Base.load_path())
+                pushfirst!(LOAD_PATH, DIRECTORY_Turing_tests)
+            end
+
+            include(joinpath("turing", "runtests.jl"))
+        end
     end
 end


### PR DESCRIPTION
The new release of Libtask_jll is compatible with Julia 1.6.0 (to fix the multithreading issues on Julia 1.5.4 a different version is needed which should be available soon).