### PR TITLE
[Merged by Bors] - Small addition to `link!` and `invlink!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.10.13"
+version = "0.10.14"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.10.14"
+version = "0.10.15"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -722,8 +722,11 @@ function link!(vi::UntypedVarInfo, spl::Sampler)
     end
 end
 function link!(vi::TypedVarInfo, spl::AbstractSampler)
+    return link!(vi, spl, Val(getspace(spl)))
+end
+function link!(vi::TypedVarInfo, spl::AbstractSampler, spaceval::Val)
     vns = _getvns(vi, spl)
-    return _link!(vi.metadata, vi, vns, Val(getspace(spl)))
+    return _link!(vi.metadata, vi, vns, spaceval)
 end
 @generated function _link!(metadata::NamedTuple{names}, vi, vns, ::Val{space}) where {names, space}
     expr = Expr(:block)
@@ -770,8 +773,11 @@ function invlink!(vi::UntypedVarInfo, spl::AbstractSampler)
     end
 end
 function invlink!(vi::TypedVarInfo, spl::AbstractSampler)
+    return invlink!(vi, spl, Val(getspace(spl)))
+end
+function invlink!(vi::TypedVarInfo, spl::AbstractSampler, spaceval::Val)
     vns = _getvns(vi, spl)
-    return _invlink!(vi.metadata, vi, vns, Val(getspace(spl)))
+    return _invlink!(vi.metadata, vi, vns, spaceval)
 end
 @generated function _invlink!(metadata::NamedTuple{names}, vi, vns, ::Val{space}) where {names, space}
     expr = Expr(:block)

--- a/test/turing/varinfo.jl
+++ b/test/turing/varinfo.jl
@@ -67,6 +67,16 @@
         @test all(x -> !istrans(vi, x), meta.m.vns)
         @test meta.s.vals == v_s
         @test meta.m.vals == v_m
+
+        # Transforming only a subset of the variables
+        link!(vi, spl, (:m, ))
+        @test all(x -> !istrans(vi, x), meta.s.vns)
+        @test all(x -> istrans(vi, x), meta.m.vns)
+        invlink!(vi, spl, (:m, ))
+        @test all(x -> !istrans(vi, x), meta.s.vns)
+        @test all(x -> !istrans(vi, x), meta.m.vns)
+        @test meta.s.vals == v_s
+        @test meta.m.vals == v_m
     end
     @testset "orders" begin
         csym = gensym() # unique per model

--- a/test/turing/varinfo.jl
+++ b/test/turing/varinfo.jl
@@ -69,10 +69,10 @@
         @test meta.m.vals == v_m
 
         # Transforming only a subset of the variables
-        link!(vi, spl, (:m, ))
+        link!(vi, spl, Val((:m, )))
         @test all(x -> !istrans(vi, x), meta.s.vns)
         @test all(x -> istrans(vi, x), meta.m.vns)
-        invlink!(vi, spl, (:m, ))
+        invlink!(vi, spl, Val((:m, )))
         @test all(x -> !istrans(vi, x), meta.s.vns)
         @test all(x -> !istrans(vi, x), meta.m.vns)
         @test meta.s.vals == v_s


### PR DESCRIPTION
Makes it possible to only link/invlink a subset of the space of a sampler *for static models only* (as there's no equivalent for `UntypedVarInfo`). Is non-breaking since this is just adding an intermediate method to an existing implementation, giving increased flexbility.

Probably don't want to encourage use of this, but it can be useful in cases such as the MH sampler https://github.com/TuringLang/Turing.jl/pull/1582#issuecomment-817148192.

