### PR TITLE
Fix ZygoteAD bug with do_observe

### DIFF
--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -468,9 +468,7 @@ function dot_observe(
     increment_num_produce!(vi)
     @debug "dists = $dists"
     @debug "value = $value"
-    return sum(zip(dists, value)) do (d, v)
-        Distributions.loglikelihood(d, v)
-    end
+    return sum(Distributions.loglikelihood.(dists, value))
 end
 function dot_observe(
     spl::Sampler,


### PR DESCRIPTION
This fixes [this issue](https://github.com/TuringLang/Turing.jl/issues/1595) where Zygote fails to compile `dot_observe` because of an exception clause.