### PR TITLE
Remove redundant mutations in dot_assume

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.11.1"
+version = "0.11.2"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.11.2"
+version = "0.11.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -236,8 +236,7 @@ function dot_assume(
     @assert length(dist) == size(var, 1)
     r = get_and_set_val!(rng, vi, vns, dist, spl)
     lp = sum(Bijectors.logpdf_with_trans(dist, r, istrans(vi, vns[1])))
-    var .= r
-    return var, lp
+    return r, lp
 end
 function dot_assume(
     rng,
@@ -250,8 +249,7 @@ function dot_assume(
     r = get_and_set_val!(rng, vi, vns, dists, spl)
     # Make sure `r` is not a matrix for multivariate distributions
     lp = sum(Bijectors.logpdf_with_trans.(dists, r, istrans(vi, vns[1])))
-    var .= r
-    return var, lp
+    return r, lp
 end
 function dot_assume(rng, spl::Sampler, ::Any, ::AbstractArray{<:VarName}, ::Any, ::Any)
     return error(


### PR DESCRIPTION
In `dot_assume` we update the variable (`left` or `var`) in-place, but this is _also_ done in the model-scope https://github.com/TuringLang/DynamicPPL.jl/blob/tor%2Fremove-redundant-assignments/src/compiler.jl#L313-L322.

This PR simply removes the updates performed in `dot_assume`.

EDIT: I'm stupid. I started from `tor/prefix-fix`, so we first just merge this into that branch and then we take it from there.