### PR TITLE
Allow usage of array literals on LHS of `~`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.11.2"
+version = "0.11.3"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -43,7 +43,7 @@ Return `true` if `expr` is a literal, e.g. `1.0` or `[1.0, ]`, and `false` other
 """
 isliteral(e) = false
 isliteral(::Number) = true
-isliteral(e::Expr) = all(isliteral, e.args)
+isliteral(e::Expr) = !isempty(e.args) && all(isliteral, e.args)
 
 """
     check_tilde_rhs(x)

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -240,7 +240,7 @@ variables.
 """
 function generate_tilde(left, right)
     # If the LHS is a literal, it is always an observation
-    if !(left isa Symbol || left isa Expr)
+    if !(left isa Symbol || left isa Expr) || Meta.isexpr(left, :vect)
         return quote
             $(DynamicPPL.tilde_observe)(
                 __context__,
@@ -290,7 +290,7 @@ Generate the expression that replaces `left .~ right` in the model body.
 """
 function generate_dot_tilde(left, right)
     # If the LHS is a literal, it is always an observation
-    if !(left isa Symbol || left isa Expr)
+    if !(left isa Symbol || left isa Expr) || Meta.isexpr(left, :vect)
         return quote
             $(DynamicPPL.dot_tilde_observe)(
                 __context__,

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -37,6 +37,15 @@ end
 isassumption(expr) = :(false)
 
 """
+    isliteral(expr)
+
+Return `true` if `expr` is a literal, e.g. `1.0` or `[1.0, ]`, and `false` otherwise.
+"""
+isliteral(e) = false
+isliteral(::Number) = true
+isliteral(e::Expr) = all(isliteral, e.args)
+
+"""
     check_tilde_rhs(x)
 
 Check if the right-hand side `x` of a `~` is a `Distribution` or an array of
@@ -240,7 +249,7 @@ variables.
 """
 function generate_tilde(left, right)
     # If the LHS is a literal, it is always an observation
-    if !(left isa Symbol || left isa Expr) || Meta.isexpr(left, :vect)
+    if isliteral(left)
         return quote
             $(DynamicPPL.tilde_observe)(
                 __context__,
@@ -290,7 +299,7 @@ Generate the expression that replaces `left .~ right` in the model body.
 """
 function generate_dot_tilde(left, right)
     # If the LHS is a literal, it is always an observation
-    if !(left isa Symbol || left isa Expr) || Meta.isexpr(left, :vect)
+    if isliteral(left)
         return quote
             $(DynamicPPL.dot_tilde_observe)(
                 __context__,

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -21,7 +21,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 [compat]
 AbstractMCMC = "2.1, 3.0"
 AbstractPPL = "0.1.3"
-Bijectors = "0.8.2, 0.9"
+Bijectors = "0.9.5"
 Distributions = "0.24, 0.25"
 DistributionsAD = "0.6.3"
 Documenter = "0.26.1"

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -423,4 +423,23 @@ end
         x = [Laplace(), Normal(), MvNormal(3, 1.0)]
         @test DynamicPPL.check_tilde_rhs(x) === x
     end
+
+    @testset "array literals" begin
+        # Verify that we indeed can parse this.
+        @test @model(
+            function array_literal_model()
+            # `assume` and literal `observe`
+            m ~ MvNormal(2, 1.0)
+            [10.0, 10.0] ~ MvNormal(m, 0.5 * ones(2))
+            end
+        ) isa Function
+
+        @model function array_literal_model()
+            # `assume` and literal `observe`
+            m ~ MvNormal(2, 1.0)
+            [10.0, 10.0] ~ MvNormal(m, 0.5 * ones(2))
+        end
+
+        @test array_literal_model()() == [10.0, 10.0]
+    end
 end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -423,14 +423,13 @@ end
         x = [Laplace(), Normal(), MvNormal(3, 1.0)]
         @test DynamicPPL.check_tilde_rhs(x) === x
     end
-    
     @testset "isliteral" begin
-        @test DynamicPPL.isliteral(:([1.0, ]))
-        @test DynamicPPL.isliteral(:([[1.0,], 1.0]))
+        @test DynamicPPL.isliteral(:([1.0]))
+        @test DynamicPPL.isliteral(:([[1.0], 1.0]))
         @test !(DynamicPPL.isliteral(:((1.0, 1.0))))
 
-        @test !(DynamicPPL.isliteral(:([x, ])))
-        @test !(DynamicPPL.isliteral(:([[x,], 1.0])))
+        @test !(DynamicPPL.isliteral(:([x])))
+        @test !(DynamicPPL.isliteral(:([[x], 1.0])))
         @test !(DynamicPPL.isliteral(:((x, 1.0))))
     end
 

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -426,18 +426,16 @@ end
 
     @testset "array literals" begin
         # Verify that we indeed can parse this.
-        @test @model(
-            function array_literal_model()
+        @test @model(function array_literal_model()
             # `assume` and literal `observe`
             m ~ MvNormal(2, 1.0)
-            [10.0, 10.0] ~ MvNormal(m, 0.5 * ones(2))
-            end
-        ) isa Function
+            return [10.0, 10.0] ~ MvNormal(m, 0.5 * ones(2))
+        end) isa Function
 
         @model function array_literal_model()
             # `assume` and literal `observe`
             m ~ MvNormal(2, 1.0)
-            [10.0, 10.0] ~ MvNormal(m, 0.5 * ones(2))
+            return [10.0, 10.0] ~ MvNormal(m, 0.5 * ones(2))
         end
 
         @test array_literal_model()() == [10.0, 10.0]

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -423,6 +423,16 @@ end
         x = [Laplace(), Normal(), MvNormal(3, 1.0)]
         @test DynamicPPL.check_tilde_rhs(x) === x
     end
+    
+    @testset "isliteral" begin
+        @test DynamicPPL.isliteral(:([1.0, ]))
+        @test DynamicPPL.isliteral(:([[1.0,], 1.0]))
+        @test !(DynamicPPL.isliteral(:((1.0, 1.0))))
+
+        @test !(DynamicPPL.isliteral(:([x, ])))
+        @test !(DynamicPPL.isliteral(:([[x,], 1.0])))
+        @test !(DynamicPPL.isliteral(:((x, 1.0))))
+    end
 
     @testset "array literals" begin
         # Verify that we indeed can parse this.

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -426,7 +426,7 @@ end
     @testset "isliteral" begin
         @test DynamicPPL.isliteral(:([1.0]))
         @test DynamicPPL.isliteral(:([[1.0], 1.0]))
-        @test !(DynamicPPL.isliteral(:((1.0, 1.0))))
+        @test DynamicPPL.isliteral(:((1.0, 1.0)))
 
         @test !(DynamicPPL.isliteral(:([x])))
         @test !(DynamicPPL.isliteral(:([[x], 1.0])))


### PR DESCRIPTION
Currently:
```julia
julia> using DynamicPPL

julia> @model function gdemo6()
           # `assume` and literal `observe`
           m ~ MvNormal(2, 1.0)
           [10.0, 10.0] ~ MvNormal(m, 0.5 * ones(2))
       end
ERROR: LoadError: "Malformed variable name [10.0, 10.0]!"
Stacktrace:
  [1] varname(expr::Expr)
    @ AbstractPPL ~/.julia/packages/AbstractPPL/CyEC9/src/varname.jl:258
  [2] generate_tilde(left::Expr, right::Expr)
    @ DynamicPPL ~/.julia/packages/DynamicPPL/emAbx/src/compiler.jl:258
  [3] generate_mainbody!(mod::Module, found::Vector{Symbol}, expr::Expr, warn::Bool)
  ...
```

This also means that using variables in this manner on the LHS isn't allowed, e.g. observe on something `[x, x]`. 

Therefore, we might as well just treat it as literals. This also make it possible to write `[x, x] ~ ...` where `x` is an argument to the model.

This PR allows this by simply falling back to the literal observe whenever we have `Meta.isexpr(left, :vect)`.

Maybe also worth pointing out that there are docstrings lying about indicating that such a model would be valid: https://github.com/TuringLang/DynamicPPL.jl/blob/9083299db3f623136895cae80ef5f10d7fcf8d2c/src/context_implementations.jl#L377-L384. 