### PR TITLE
[Merged by Bors] - Fixed fallback for observe

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -645,8 +645,6 @@ function dot_observe(
 end
 function dot_observe(dist::MultivariateDistribution, value::AbstractMatrix, vi)
     increment_num_produce!(vi)
-    @debug "dist = $dist"
-    @debug "value = $value"
     return Distributions.loglikelihood(dist, value)
 end
 function dot_observe(

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -657,8 +657,6 @@ function dot_observe(
 end
 function dot_observe(dists::Distribution, value::AbstractArray, vi)
     increment_num_produce!(vi)
-    @debug "dists = $dists"
-    @debug "value = $value"
     return Distributions.loglikelihood(dists, value)
 end
 function dot_observe(
@@ -671,7 +669,5 @@ function dot_observe(
 end
 function dot_observe(dists::AbstractArray{<:Distribution}, value::AbstractArray, vi)
     increment_num_produce!(vi)
-    @debug "dists = $dists"
-    @debug "value = $value"
     return sum(Distributions.loglikelihood.(dists, value))
 end

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -163,11 +163,11 @@ end
 
 # Leaf contexts
 tilde_observe(::DefaultContext, right, left, vi) = observe(right, left, vi)
-tilde_observe(::DefaultContext, sampler, right, left, vi) = observe(right, left, vi)
+tilde_observe(::DefaultContext, sampler, right, left, vi) = observe(sampler, right, left, vi)
 tilde_observe(::PriorContext, right, left, vi) = 0
 tilde_observe(::PriorContext, sampler, right, left, vi) = 0
 tilde_observe(::LikelihoodContext, right, left, vi) = observe(right, left, vi)
-tilde_observe(::LikelihoodContext, sampler, right, left, vi) = observe(right, left, vi)
+tilde_observe(::LikelihoodContext, sampler, right, left, vi) = observe(sampler, right, left, vi)
 
 # `MiniBatchContext`
 function tilde_observe(context::MiniBatchContext, right, left, vi)
@@ -259,6 +259,7 @@ function assume(
 end
 
 # default fallback (used e.g. by `SampleFromPrior` and `SampleUniform`)
+observe(sampler::AbstractSampler, right, left, vi) = observe(right, left, vi)
 function observe(right::Distribution, left, vi)
     increment_num_produce!(vi)
     return Distributions.loglikelihood(right, left)

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -634,38 +634,17 @@ function dot_tilde_observe!(context, right, left, vi)
     return left
 end
 
-# Ambiguity error when not sure to use Distributions convention or Julia broadcasting semantics
-function dot_observe(
-    ::Union{SampleFromPrior,SampleFromUniform},
-    dist::MultivariateDistribution,
-    value::AbstractMatrix,
-    vi,
-)
+# Falls back to non-sampler definition.
+function dot_observe(::AbstractSampler, dist, value, vi)
     return dot_observe(dist, value, vi)
 end
 function dot_observe(dist::MultivariateDistribution, value::AbstractMatrix, vi)
     increment_num_produce!(vi)
     return Distributions.loglikelihood(dist, value)
 end
-function dot_observe(
-    ::Union{SampleFromPrior,SampleFromUniform},
-    dists::Distribution,
-    value::AbstractArray,
-    vi,
-)
-    return dot_observe(dists, value, vi)
-end
 function dot_observe(dists::Distribution, value::AbstractArray, vi)
     increment_num_produce!(vi)
     return Distributions.loglikelihood(dists, value)
-end
-function dot_observe(
-    ::Union{SampleFromPrior,SampleFromUniform},
-    dists::AbstractArray{<:Distribution},
-    value::AbstractArray,
-    vi,
-)
-    return dot_observe(dists, value, vi)
 end
 function dot_observe(dists::AbstractArray{<:Distribution}, value::AbstractArray, vi)
     increment_num_produce!(vi)


### PR DESCRIPTION
In the recent breaking release we mistakenly removed the call to `observe(::AbstractSampler, right left, vi)` as a fallback for `DefaultContext`, leading to certain sampler breaking in Turing (https://github.com/TuringLang/Turing.jl/pull/1636). 

This PR adds back a proper fallback, making overloads such as https://github.com/TuringLang/Turing.jl/blob/tor%2Fdppl-update/src/inference/AdvancedSMC.jl#L353-L356 work as before 0.11.