### PR TITLE
[Merged by Bors] - Fix for type-instability in `findranges`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.12.1"
+version = "0.12.2"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -499,8 +499,13 @@ end
     length(exprs) == 0 && return :(NamedTuple())
     return :($(exprs...),)
 end
+
 @inline function findranges(f_ranges, f_idcs)
-    return mapreduce(i -> f_ranges[i], vcat, f_idcs; init=Int[])
+    results = Int[]
+    for i in f_idcs
+        append!(results, f_ranges[i])
+    end
+    return results
 end
 
 """


### PR DESCRIPTION
https://github.com/TuringLang/Turing.jl/issues/1661

With this PR:

```julia
julia> using Turing, DynamicPPL, ReverseDiff

julia> Turing.setadbackend(:reversediff);

julia> @model function demo(x, ::Type{TV} = Vector{Float64}) where {TV}
           m = TV(undef, length(x))
           m ~ MvNormal(length(x), 1.0)
           x ~ MvNormal(m, 1.0)
       end;

julia> m = demo(randn(2));

julia> spl = DynamicPPL.Sampler(NUTS(0.65))
Sampler{NUTS{Turing.Core.ReverseDiffAD{false}, (), AdvancedHMC.DiagEuclideanMetric}}(NUTS{Turing.Core.ReverseDiffAD{false}, (), AdvancedHMC.DiagEuclideanMetric}(-1, 0.65, 10, 1000.0, 0.0), DynamicPPL.Selector(0x000f976df8fc2a48, :default, false))

julia> vi = DynamicPPL.VarInfo(m);

julia> θ = vi[spl];

julia> new_vi = VarInfo(vi, spl, ReverseDiff.track(θ));

julia> eltype(new_vi, spl) # (✓) inference succeeds
ReverseDiff.TrackedReal{Float64, Float64, ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}}}

```