### PR TITLE
[Merged by Bors] - Introduce traits for contexts

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -501,7 +501,13 @@ function matchingvalue(sampler::AbstractSampler, vi, value::FloatOrArrayType)
 end
 
 function matchingvalue(context::AbstractContext, vi, value)
+    return matchingvalue(NodeTrait(matchingvalue, context), context, vi, value)
+end
+function matchingvalue(::IsLeaf, context::AbstractContext, vi, value)
     return matchingvalue(SampleFromPrior(), vi, value)
+end
+function matchingvalue(::IsParent, context::AbstractContext, vi, value)
+    return matchingvalue(childcontext(context), vi, value)
 end
 function matchingvalue(context::SamplingContext, vi, value)
     return matchingvalue(context.sampler, vi, value)

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -48,7 +48,9 @@ end
 function tilde_assume(rng, context::AbstractContext, args...)
     return tilde_assume(NodeTrait(tilde_assume, context), rng, context, args...)
 end
-function tilde_assume(::IsLeaf, rng, context::AbstractContext, sampler, right, vn, vinds, vi)
+function tilde_assume(
+    ::IsLeaf, rng, context::AbstractContext, sampler, right, vn, vinds, vi
+)
     return assume(rng, sampler, right, vn, vi)
 end
 function tilde_assume(::IsParent, rng, context::AbstractContext, args...)
@@ -296,7 +298,9 @@ end
 function dot_tilde_assume(::IsLeaf, ::AbstractContext, right, left, vns, inds, vi)
     return dot_assume(right, left, vns, vi)
 end
-function dot_tilde_assume(::IsLeaf, rng, ::AbstractContext, sampler, right, left, vns, inds, vi)
+function dot_tilde_assume(
+    ::IsLeaf, rng, ::AbstractContext, sampler, right, left, vns, inds, vi
+)
     return dot_assume(rng, sampler, right, vns, left, vi)
 end
 

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -35,11 +35,24 @@ function tilde_assume(context::SamplingContext, right, vn, inds, vi)
 end
 
 # Leaf contexts
-tilde_assume(::DefaultContext, right, vn, inds, vi) = assume(right, vn, vi)
-function tilde_assume(
-    rng::Random.AbstractRNG, ::DefaultContext, sampler, right, vn, inds, vi
-)
+function tilde_assume(context::AbstractContext, args...)
+    return tilde_assume(NodeTrait(tilde_assume, context), context, args...)
+end
+function tilde_assume(::IsLeaf, context::AbstractContext, right, vn, vinds, vi)
+    return assume(right, vn, vi)
+end
+function tilde_assume(::IsParent, context::AbstractContext, args...)
+    return tilde_assume(childcontext(context), args...)
+end
+
+function tilde_assume(rng, context::AbstractContext, args...)
+    return tilde_assume(NodeTrait(tilde_assume, context), rng, context, args...)
+end
+function tilde_assume(::IsLeaf, rng, context::AbstractContext, sampler, right, vn, vinds, vi)
     return assume(rng, sampler, right, vn, vi)
+end
+function tilde_assume(::IsParent, rng, context::AbstractContext, args...)
+    return tilde_assume(rng, childcontext(context), args...)
 end
 
 function tilde_assume(context::PriorContext{<:NamedTuple}, right, vn, inds, vi)
@@ -63,12 +76,6 @@ function tilde_assume(
         settrans!(vi, false, vn)
     end
     return tilde_assume(rng, PriorContext(), sampler, right, vn, inds, vi)
-end
-function tilde_assume(::PriorContext, right, vn, inds, vi)
-    return assume(right, vn, vi)
-end
-function tilde_assume(rng::Random.AbstractRNG, ::PriorContext, sampler, right, vn, inds, vi)
-    return assume(rng, sampler, right, vn, vi)
 end
 
 function tilde_assume(context::LikelihoodContext{<:NamedTuple}, right, vn, inds, vi)
@@ -102,18 +109,9 @@ function tilde_assume(
     return assume(rng, sampler, NoDist(right), vn, vi)
 end
 
-function tilde_assume(context::MiniBatchContext, right, vn, inds, vi)
-    return tilde_assume(context.context, right, vn, inds, vi)
-end
-
-function tilde_assume(rng, context::MiniBatchContext, sampler, right, vn, inds, vi)
-    return tilde_assume(rng, context.context, sampler, right, vn, inds, vi)
-end
-
 function tilde_assume(context::PrefixContext, right, vn, inds, vi)
     return tilde_assume(context.context, right, prefix(context, vn), inds, vi)
 end
-
 function tilde_assume(rng, context::PrefixContext, sampler, right, vn, inds, vi)
     return tilde_assume(rng, context.context, sampler, right, prefix(context, vn), inds, vi)
 end
@@ -162,16 +160,16 @@ function tilde_observe(context::SamplingContext, right, left, vi)
 end
 
 # Leaf contexts
-tilde_observe(::DefaultContext, right, left, vi) = observe(right, left, vi)
-function tilde_observe(::DefaultContext, sampler, right, left, vi)
-    return observe(sampler, right, left, vi)
+function tilde_observe(context::AbstractContext, args...)
+    return tilde_observe(NodeTrait(tilde_observe, context), context, args...)
 end
+tilde_observe(::IsLeaf, context::AbstractContext, args...) = observe(args...)
+function tilde_observe(::IsParent, context::AbstractContext, args...)
+    return tilde_observe(childcontext(context), args...)
+end
+
 tilde_observe(::PriorContext, right, left, vi) = 0
 tilde_observe(::PriorContext, sampler, right, left, vi) = 0
-tilde_observe(::LikelihoodContext, right, left, vi) = observe(right, left, vi)
-function tilde_observe(::LikelihoodContext, sampler, right, left, vi)
-    return observe(sampler, right, left, vi)
-end
 
 # `MiniBatchContext`
 function tilde_observe(context::MiniBatchContext, right, left, vi)
@@ -184,9 +182,6 @@ end
 # `PrefixContext`
 function tilde_observe(context::PrefixContext, right, left, vname, vi)
     return tilde_observe(context.context, right, left, prefix(context, vname), vi)
-end
-function tilde_observe(context::PrefixContext, right, left, vi)
-    return tilde_observe(context.context, right, left, vi)
 end
 
 """
@@ -291,8 +286,25 @@ function dot_tilde_assume(context::SamplingContext, right, left, vn, inds, vi)
 end
 
 # `DefaultContext`
-function dot_tilde_assume(::DefaultContext, right, left, vns, inds, vi)
+function dot_tilde_assume(context::AbstractContext, args...)
+    return dot_tilde_assume(NodeTrait(dot_tilde_assume, context), context, args...)
+end
+function dot_tilde_assume(rng, context::AbstractContext, args...)
+    return dot_tilde_assume(rng, NodeTrait(dot_tilde_assume, context), context, args...)
+end
+
+function dot_tilde_assume(::IsLeaf, ::AbstractContext, right, left, vns, inds, vi)
     return dot_assume(right, left, vns, vi)
+end
+function dot_tilde_assume(::IsLeaf, rng, ::AbstractContext, sampler, right, left, vns, inds, vi)
+    return dot_assume(rng, sampler, right, vns, left, vi)
+end
+
+function dot_tilde_assume(::IsParent, context::AbstractContext, args...)
+    return dot_tilde_assume(childcontext(context), args...)
+end
+function dot_tilde_assume(rng, ::IsParent, context::AbstractContext, args...)
+    return dot_tilde_assume(rng, childcontext(context), args...)
 end
 
 function dot_tilde_assume(rng, ::DefaultContext, sampler, right, left, vns, inds, vi)
@@ -373,25 +385,6 @@ function dot_tilde_assume(
     else
         dot_tilde_assume(rng, PriorContext(), sampler, right, left, vn, inds, vi)
     end
-end
-function dot_tilde_assume(context::PriorContext, right, left, vn, inds, vi)
-    return dot_assume(right, left, vn, vi)
-end
-function dot_tilde_assume(
-    rng::Random.AbstractRNG, context::PriorContext, sampler, right, left, vn, inds, vi
-)
-    return dot_assume(rng, sampler, right, vn, left, vi)
-end
-
-# `MiniBatchContext`
-function dot_tilde_assume(context::MiniBatchContext, right, left, vn, inds, vi)
-    return dot_tilde_assume(context.context, right, left, vn, inds, vi)
-end
-
-function dot_tilde_assume(
-    rng, context::MiniBatchContext, sampler, right, left, vn, inds, vi
-)
-    return dot_tilde_assume(rng, context.context, sampler, right, left, vn, inds, vi)
 end
 
 # `PrefixContext`
@@ -588,18 +581,13 @@ function dot_tilde_observe(context::SamplingContext, right, left, vi)
 end
 
 # Leaf contexts
-dot_tilde_observe(::DefaultContext, right, left, vi) = dot_observe(right, left, vi)
-function dot_tilde_observe(::DefaultContext, sampler, right, left, vi)
-    return dot_observe(sampler, right, left, vi)
+dot_tilde_observe(::IsLeaf, ::AbstractContext, args...) = dot_observe(args...)
+function dot_tilde_observe(::IsParent, context::AbstractContext, args...)
+    return dot_tilde_observe(childcontext(context), args...)
 end
+
 dot_tilde_observe(::PriorContext, right, left, vi) = 0
 dot_tilde_observe(::PriorContext, sampler, right, left, vi) = 0
-function dot_tilde_observe(context::LikelihoodContext, right, left, vi)
-    return dot_observe(right, left, vi)
-end
-function dot_tilde_observe(context::LikelihoodContext, sampler, right, left, vi)
-    return dot_observe(sampler, right, left, vi)
-end
 
 # `MiniBatchContext`
 function dot_tilde_observe(context::MiniBatchContext, right, left, vi)

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -583,6 +583,9 @@ function dot_tilde_observe(context::SamplingContext, right, left, vi)
 end
 
 # Leaf contexts
+function dot_tilde_observe(context::AbstractContext, args...)
+    return dot_tilde_observe(NodeTrait(tilde_observe, context), context, args...)
+end
 dot_tilde_observe(::IsLeaf, ::AbstractContext, args...) = dot_observe(args...)
 function dot_tilde_observe(::IsParent, context::AbstractContext, args...)
     return dot_tilde_observe(childcontext(context), args...)

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -1,7 +1,5 @@
 # Fallback traits
 # TODO: Should this instead be `NoChildren()`, `HasChild()`, etc. so we allow plural too, e.g. `HasChildren()`?
-struct IsLeaf end
-struct IsParent end
 
 """
     NodeTrait(context)
@@ -16,7 +14,21 @@ The officially supported traits are:
   - [`childcontext`](@ref)
   - [`setchildcontext`](@ref)
 """
+abstract type NodeTrait end
 NodeTrait(_, context) = NodeTrait(context)
+
+"""
+    IsLeaf
+
+Specifies that the context is a leaf in the context-tree.
+"""
+struct IsLeaf <: NodeTrait end
+"""
+    IsParent
+
+Specifies that the context is a parent in the context-tree.
+"""
+struct IsParent <: NodeTrait end
 
 """
     childcontext(context)

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -1,3 +1,11 @@
+# Fallback traits
+# TODO: Should this instead be `NoChildren()`, `HasChild()`, etc. so we allow plural too, e.g. `HasChildren()`?
+struct IsLeaf end
+struct IsParent end
+
+NodeTrait(::Any, context) = NodeTrait(context)
+
+# Contexts
 """
     SamplingContext(rng, sampler, context)
 
@@ -11,6 +19,7 @@ struct SamplingContext{S<:AbstractSampler,C<:AbstractContext,R} <: AbstractConte
     sampler::S
     context::C
 end
+NodeTrait(context::SamplingContext) = IsParent()
 
 """
     struct DefaultContext <: AbstractContext end
@@ -19,6 +28,7 @@ The `DefaultContext` is used by default to compute log the joint probability of 
 and parameters when running the model.
 """
 struct DefaultContext <: AbstractContext end
+NodeTrait(context::DefaultContext) = IsLeaf()
 
 """
     struct PriorContext{Tvars} <: AbstractContext
@@ -32,6 +42,7 @@ struct PriorContext{Tvars} <: AbstractContext
     vars::Tvars
 end
 PriorContext() = PriorContext(nothing)
+NodeTrait(context::PriorContext) = IsLeaf()
 
 """
     struct LikelihoodContext{Tvars} <: AbstractContext
@@ -46,6 +57,7 @@ struct LikelihoodContext{Tvars} <: AbstractContext
     vars::Tvars
 end
 LikelihoodContext() = LikelihoodContext(nothing)
+NodeTrait(context::LikelihoodContext) = IsLeaf()
 
 """
     struct MiniBatchContext{Tctx, T} <: AbstractContext
@@ -66,6 +78,7 @@ end
 function MiniBatchContext(context=DefaultContext(); batch_size, npoints)
     return MiniBatchContext(context, npoints / batch_size)
 end
+NodeTrait(context::MiniBatchContext) = IsParent()
 
 """
     PrefixContext{Prefix}(context)

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -94,10 +94,7 @@ ParentContext(ParentContext(ParentContext(DefaultContext())))
 """
 function setleafcontext(left, right)
     return setleafcontext(
-        NodeTrait(setleafcontext, left),
-        NodeTrait(setleafcontext, right),
-        left,
-        right
+        NodeTrait(setleafcontext, left), NodeTrait(setleafcontext, right), left, right
     )
 end
 function setleafcontext(::IsParent, ::IsParent, left, right)

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -3,7 +3,13 @@
 struct IsLeaf end
 struct IsParent end
 
-NodeTrait(::Any, context) = NodeTrait(context)
+"""
+    NodeTrait(context)
+    NodeTrait(f, context)
+
+Specifies the role of `context` in the context-tree.
+"""
+NodeTrait(_, context) = NodeTrait(context)
 
 # Contexts
 """
@@ -20,6 +26,7 @@ struct SamplingContext{S<:AbstractSampler,C<:AbstractContext,R} <: AbstractConte
     context::C
 end
 NodeTrait(context::SamplingContext) = IsParent()
+childcontext(context::SamplingContext) = context.context
 
 """
     struct DefaultContext <: AbstractContext end
@@ -79,6 +86,7 @@ function MiniBatchContext(context=DefaultContext(); batch_size, npoints)
     return MiniBatchContext(context, npoints / batch_size)
 end
 NodeTrait(context::MiniBatchContext) = IsParent()
+childcontext(context::MiniBatchContext) = context.context
 
 """
     PrefixContext{Prefix}(context)
@@ -97,6 +105,9 @@ end
 function PrefixContext{Prefix}(context::AbstractContext) where {Prefix}
     return PrefixContext{Prefix,typeof(context)}(context)
 end
+
+NodeTrait(context::PrefixContext) = IsParent()
+childcontext(context::PrefixContext) = context.context
 
 const PREFIX_SEPARATOR = Symbol(".")
 

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -66,9 +66,9 @@ original leaf context of `left`.
 
 # Examples
 ```jldoctest
-julia> using DynamicPPL: leafcontext, setleafcontext, childcontext, setchildcontext
+julia> using DynamicPPL: leafcontext, setleafcontext, childcontext, setchildcontext, AbstractContext
 
-julia> struct ParentContext{C}
+julia> struct ParentContext{C} <: AbstractContext
            context::C
        end
 

--- a/src/loglikelihoods.jl
+++ b/src/loglikelihoods.jl
@@ -13,6 +13,12 @@ function PointwiseLikelihoodContext(
     )
 end
 
+NodeTrait(::PointwiseLikelihoodContext) = IsParent()
+childcontext(context::PointwiseLikelihoodContext) = context.context
+function setchildcontext(context::PointwiseLikelihoodContext, child)
+    return PointwiseLikelihoodContext(context.loglikelihoods, child)
+end
+
 function Base.push!(
     context::PointwiseLikelihoodContext{Dict{VarName,Vector{Float64}}},
     vn::VarName,
@@ -59,14 +65,6 @@ function Base.push!(
     context::PointwiseLikelihoodContext{Dict{String,Float64}}, vn::String, logp::Real
 )
     return context.loglikelihoods[vn] = logp
-end
-
-function tilde_assume(context::PointwiseLikelihoodContext, right, vn, inds, vi)
-    return tilde_assume(context.context, right, vn, inds, vi)
-end
-
-function dot_tilde_assume(context::PointwiseLikelihoodContext, right, left, vn, inds, vi)
-    return dot_tilde_assume(context.context, right, left, vn, inds, vi)
 end
 
 function tilde_observe!(context::PointwiseLikelihoodContext, right, left, vi)

--- a/test/contexts.jl
+++ b/test/contexts.jl
@@ -1,4 +1,98 @@
+using Test, DynamicPPL
+using DynamicPPL: leafcontext, setleafcontext, childcontext, setchildcontext, AbstractContext, NodeTrait, IsLeaf, IsParent, PointwiseLikelihoodContext
+
+struct ParentContext{C<:AbstractContext} <: AbstractContext
+    context::C
+end
+ParentContext() = ParentContext(DefaultContext())
+DynamicPPL.NodeTrait(::ParentContext) = DynamicPPL.IsParent()
+DynamicPPL.childcontext(context::ParentContext) = context.context
+DynamicPPL.setchildcontext(::ParentContext, child) = ParentContext(child)
+Base.show(io::IO, c::ParentContext) = print(io, "ParentContext(", childcontext(c), ")")
+
 @testset "contexts.jl" begin
+    child_contexts = [
+        DefaultContext(),
+        PriorContext(),
+        LikelihoodContext(),
+    ]
+
+    parent_contexts = [
+        ParentContext(DefaultContext()),
+        SamplingContext(),
+        MiniBatchContext(DefaultContext(), 0.0),
+        PrefixContext{:x}(DefaultContext()),
+        PointwiseLikelihoodContext()
+    ]
+
+    contexts = vcat(child_contexts, parent_contexts)
+
+    @testset "NodeTrait" begin
+        @testset "$context" for context in contexts
+            # Every `context` should have a `NodeTrait`.
+            @test NodeTrait(context) isa NodeTrait
+        end
+    end
+
+    @testset "leafcontext" begin
+        @testset "$context" for context in child_contexts
+            @test leafcontext(context) === context
+        end
+
+        @testset "$context" for context in parent_contexts
+            @test NodeTrait(leafcontext(context)) isa IsLeaf
+        end
+    end
+
+    @testset "setleafcontext" begin
+        @testset "$context" for context in child_contexts
+            # Setting to itself should return itself.
+            @test setleafcontext(context, context) === context
+
+            # Setting to a different context should return that context.
+            new_leaf = context isa DefaultContext ? PriorContext() : DefaultContext()
+            @test setleafcontext(context, new_leaf) === new_leaf
+
+            # Also works for parent contexts.
+            new_leaf = ParentContext(context)
+            @test setleafcontext(context, new_leaf) === new_leaf
+        end
+
+        @testset "$context" for context in parent_contexts
+            # Leaf contexts.
+            new_leaf = leafcontext(context) isa DefaultContext ? PriorContext() : DefaultContext()
+            @test leafcontext(setleafcontext(context, new_leaf)) === new_leaf
+
+            # Setting parent contexts as "leaf" means that the new leaf should be
+            # the leaf of the parent context we just set as the leaf.
+            new_leaf = ParentContext((leafcontext(context) isa DefaultContext ? PriorContext() : DefaultContext()))
+            @test leafcontext(setleafcontext(context, new_leaf)) === leafcontext(new_leaf)
+        end
+    end
+
+    # `IsParent` interface.
+    @testset "childcontext" begin        
+        @testset "$context" for context in parent_contexts
+            @test childcontext(context) isa AbstractContext
+        end
+    end
+
+    @testset "setchildcontext" begin
+        @testset "nested contexts" begin
+            # Both of the following should result in the same context.
+            context1 = ParentContext(ParentContext(ParentContext()))
+            context2 = setchildcontext(ParentContext(), setchildcontext(ParentContext(), ParentContext()))
+            @test context1 === context2
+        end
+
+        @testset "$context" for context in parent_contexts
+            # Setting the child context to a leaf should now change the `leafcontext` accordingly.
+            new_leaf = leafcontext(context) isa DefaultContext ? PriorContext() : DefaultContext()
+            new_context = setchildcontext(context, new_leaf)
+            @test childcontext(new_context) === leafcontext(new_context) === new_leaf
+        end
+    end
+
     @testset "PrefixContext" begin
         ctx = @inferred PrefixContext{:f}(
             PrefixContext{:e}(

--- a/test/contexts.jl
+++ b/test/contexts.jl
@@ -1,5 +1,14 @@
 using Test, DynamicPPL
-using DynamicPPL: leafcontext, setleafcontext, childcontext, setchildcontext, AbstractContext, NodeTrait, IsLeaf, IsParent, PointwiseLikelihoodContext
+using DynamicPPL:
+    leafcontext,
+    setleafcontext,
+    childcontext,
+    setchildcontext,
+    AbstractContext,
+    NodeTrait,
+    IsLeaf,
+    IsParent,
+    PointwiseLikelihoodContext
 
 struct ParentContext{C<:AbstractContext} <: AbstractContext
     context::C
@@ -11,18 +20,14 @@ DynamicPPL.setchildcontext(::ParentContext, child) = ParentContext(child)
 Base.show(io::IO, c::ParentContext) = print(io, "ParentContext(", childcontext(c), ")")
 
 @testset "contexts.jl" begin
-    child_contexts = [
-        DefaultContext(),
-        PriorContext(),
-        LikelihoodContext(),
-    ]
+    child_contexts = [DefaultContext(), PriorContext(), LikelihoodContext()]
 
     parent_contexts = [
         ParentContext(DefaultContext()),
         SamplingContext(),
         MiniBatchContext(DefaultContext(), 0.0),
         PrefixContext{:x}(DefaultContext()),
-        PointwiseLikelihoodContext()
+        PointwiseLikelihoodContext(),
     ]
 
     contexts = vcat(child_contexts, parent_contexts)
@@ -60,18 +65,21 @@ Base.show(io::IO, c::ParentContext) = print(io, "ParentContext(", childcontext(c
 
         @testset "$context" for context in parent_contexts
             # Leaf contexts.
-            new_leaf = leafcontext(context) isa DefaultContext ? PriorContext() : DefaultContext()
+            new_leaf =
+                leafcontext(context) isa DefaultContext ? PriorContext() : DefaultContext()
             @test leafcontext(setleafcontext(context, new_leaf)) === new_leaf
 
             # Setting parent contexts as "leaf" means that the new leaf should be
             # the leaf of the parent context we just set as the leaf.
-            new_leaf = ParentContext((leafcontext(context) isa DefaultContext ? PriorContext() : DefaultContext()))
+            new_leaf = ParentContext((
+                leafcontext(context) isa DefaultContext ? PriorContext() : DefaultContext()
+            ))
             @test leafcontext(setleafcontext(context, new_leaf)) === leafcontext(new_leaf)
         end
     end
 
     # `IsParent` interface.
-    @testset "childcontext" begin        
+    @testset "childcontext" begin
         @testset "$context" for context in parent_contexts
             @test childcontext(context) isa AbstractContext
         end
@@ -81,13 +89,16 @@ Base.show(io::IO, c::ParentContext) = print(io, "ParentContext(", childcontext(c
         @testset "nested contexts" begin
             # Both of the following should result in the same context.
             context1 = ParentContext(ParentContext(ParentContext()))
-            context2 = setchildcontext(ParentContext(), setchildcontext(ParentContext(), ParentContext()))
+            context2 = setchildcontext(
+                ParentContext(), setchildcontext(ParentContext(), ParentContext())
+            )
             @test context1 === context2
         end
 
         @testset "$context" for context in parent_contexts
             # Setting the child context to a leaf should now change the `leafcontext` accordingly.
-            new_leaf = leafcontext(context) isa DefaultContext ? PriorContext() : DefaultContext()
+            new_leaf =
+                leafcontext(context) isa DefaultContext ? PriorContext() : DefaultContext()
             new_context = setchildcontext(context, new_leaf)
             @test childcontext(new_context) === leafcontext(new_context) === new_leaf
         end

--- a/test/turing/Project.toml
+++ b/test/turing/Project.toml
@@ -6,5 +6,5 @@ Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
 DynamicPPL = "0.13"
-Turing = "0.15, 0.16"
+Turing = "0.17"
 julia = "1.3"


### PR DESCRIPTION
This is motivated by the potential introduction of more contexts, e.g. #278, and has been brought up as an alternative (and better) approach to achieve parts of what we want to achieve in #254 .

(I hope you're proud of me @devmotion )

## Current state of things
Currently, if one wants to implement a new `AbstractContext` one _at least_ has to implement the following methods:

```julia
tilde_assume(...)
tilde_observe(...)
dot_tilde_assume(...)
dot_tilde_observe(...)
```

But there are also other methods that _should_ be implemented but generally aren't properly handled, e.g. `matchingvalue`. And there might be more methods in the future, e.g. `contextual_isassumption` in #254.

## This sucks
This means that:
1. Implementing a new behavior for `AbstractContext`, e.g. `contextual_isassumption`, requires you to:
   1. Find all implementations of `AbstractContext`, which is non-trivial! Most are here in DPPL, but some are in Turing.jl, and eventually we also want packages outside of the Turing.jl-umbrella to extend DPPL using contexts.
   2. Implement the method for that particular context.
2. Implementing a new `AbstractContext`, e.g. `Turing.OptimizationContext`, requires you to find all the methods to implement and then do so. Again, non-trivial.

This combinatorial blow up essentially means that we're super-reluctant to introduce new behaviors or new contexts, for good reasons.

And the stupid thing is that in most cases a context is only trying to modify maybe one or two "behaviors", e.g. `MiniBatchContext` only wants to change the `*tilde_observe` methods, and otherwise just defer to whatever implementation is available for its "childcontext" `minibatchcontext.context`. 

## Goal
A new `AbstractContext` should only (up to an additive factor) have to implement the behavior it _wants to change_, not _all_ behaviors. E.g. `MiniBatchContext` should really only have to overload `*tilde_observe`.

## Solution (this PR)
The above was the motivation for #254, but there we wanted a rather strict separation between certain types of contexts which we're reluctant to add due to its restrictive nature (in particular given how "recently" contexts where introduced).

This PR takes are more extensible and less restrictive approach of introducing some traits for `AbstractContext`.

As a starter I've just introduced a couple of traits to allow code-sharing between "parent contexts", e.g. `MiniBatchContext` and `ConditionContext` (from #278), and "leaf-contexts", e.g. `DefaultContext` and `PriorContext` (which IMO should have been a wrapper-context itself). Ideally we'd also define a promotion-system, e.g. what do we do if we're asked to combine a `MiniBatchContext` and `DefaultContext`? Well in that case we could either
1. replace `minibatchcontext.context` with `DefaultContext()`, or
2. recursively "rewrap" `DefaultContext()` in `minibatch.context`.

(1) has the issue that `MiniBatchContext` might be wrapping another context, e.g. `PrefixContext`, and so just replacing `.context` is dangerous. (2) seems like a better idea since `DefaultContext` should always be at the end of the stack, i.e. a "leaf", since it always exists the tilde-callstack (e.g. in `tilde_assume` we call `assume`, etc.).

Such a promotion system will require some thought though, but this PR will allow us to experiment with this (on top of providing a good approach to code-sharing).

## Examples

### `GeneratedQuantitiesContext`

In DPPL we have the `generated_quantities` but it sort of sucks because often these quantities are not relevant for sampling, thus we're adding unnecessary computation to the sampling process. One might want want to introduce a `@generated_quantities` macro that will only be executed when called from `generated_quantities`. This can easily be achieved with contexts:

```julia
using DynamicPPL, Distributions, Random
using DynamicPPL: AbstractContext, IsLeaf, IsParent, childcontext

struct GeneratedQuantitiesContext{Ctx} <: AbstractContext
    context::Ctx
end
GeneratedQuantitiesContext() = GeneratedQuantitiesContext(DefaultContext())

# Define the `NodeTrait` for `GeneratedQuantitiesContext`.
DynamicPPL.NodeTrait(context::GeneratedQuantitiesContext) = IsParent()
DynamicPPL.childcontext(context::GeneratedQuantitiesContext) = context.context

"""
    isgeneratedquantities(context)

Return `true` if `context` wants evaluation of model to execute
the `@generatedquantities` block.
"""
function isgeneratedquantities(context::AbstractContext)
    return isgeneratedquantities(DynamicPPL.NodeTrait(isgeneratedquantities, context), context)
end

# Define the behavior for the different `NodeType`s.
isgeneratedquantities(::IsLeaf, context::AbstractContext) = false
function isgeneratedquantities(::IsParent, context::AbstractContext)
    return isgeneratedquantities(childcontext(context))
end

# Specific implementations of `isgeneratedquantities`.
isgeneratedquantities(context::GeneratedQuantitiesContext) = true

"""
    @generatedquantities f(x)

Specify that `f(x)` should only if the model is run using `GeneratedQuantitiesContext`.
"""
macro generated_quantities(expr)
    return esc(generated_quantities_expr(expr))
end

function generated_quantities_expr(expr)
    return quote
        if isgeneratedquantities(__context__)
            $expr
        end
    end
end
```

And usage would be as follows:

```julia
julia> @model function demo(x)
           @generated_quantities a = []
           m ~ Normal()

           # "Expensive" piece of code that we don't want to compute
           # unless we're computing the generated quantities.
           @generated_quantities for i = 1:100
               push!(a, m + randn())
           end

           # Observe.
           x ~ Normal(m, 1.0)

           # Return additional fields if we're computing the generated quantities.
           @generated_quantities return (; x, m, logp = getlogp(__varinfo__), a)

           return nothing
       end
demo (generic function with 1 method)

julia> m = demo(1.0); var_info = VarInfo(m);

julia> m(var_info) # (✓) returns nothing

julia> m(var_info, GeneratedQuantitiesContext()) # (✓) returns everything
(x = 1.0, m = 0.7451107426181028, logp = -2.147956342556143, a = Any[0.929285513523637, 0.5979631005709274, 3.1944251790696794, -0.611727924858586, 1.0561547812845788, 0.9694358994096283, 0.9130715096769692, 0.018196803783751103, 0.919216919507385, 0.5382931170515716  …  0.24049636440948963, 0.7868300598622132, 0.18210113151764207, 1.9568444848346909, 0.4512687443970105, 0.5155449377942058, 0.32900420588898294, 1.4274186203915957, 0.5599167955770905, -0.5351355146677438])

julia> m(Random.GLOBAL_RNG, GeneratedQuantitiesContext()) # (✓) just works even when wrapped in `SamplingContext`
(x = 1.0, m = -0.7568553457880578, logp = -3.6675624266453637, a = Any[-0.4715652454870858, 2.0553700887015776, -0.6055293756513751, -1.6153963580018202, -0.6316036328835652, -0.9694585645577235, -1.234406947321252, 0.47075652867281415, -2.0403875768252187, -1.332736944079995  …  -1.123179524380186, -0.4445013585772502, -1.2366853403014721, -0.2726171409415225, 0.050910231154342234, -1.937702826603367, -2.109933658872988, -0.8300603173278494, 0.076480161355589, -1.2666452596129179])
```

This would also _just work_ for submodels, etc. This "conditional execution" could of course be generalized too. Such a conditional execution is very useful when you also want to work with Zygote, e.g. you don't want mutations in the model but for the post-processing steps, e.g. `predict` and `generated_quantities`, you do need it.

But whether or not we want this particular `@generatedquantities` macro in DPPL is not the point; the point is that we _can_ implement such a thing. Even more importantly, I can easily implement this from the "outside", no needing to touch DPPL to do it. 

### `ConditionContext`
See #278.