### PR TITLE
[Merged by Bors] - Fix for bug in MiniBatchContext

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -144,22 +144,6 @@ end
 
 # observe
 """
-    tilde_observe(context::SamplingContext, right, left, vname, vinds, vi)
-
-Handle observed variables with a `context` associated with a sampler.
-
-Falls back to
-```julia
-tilde_observe(context.rng, context.context, context.sampler, right, left, vname, vinds, vi)
-```
-"""
-function tilde_observe(context::SamplingContext, right, left, vname, vinds, vi)
-    return tilde_observe(
-        context.rng, context.context, context.sampler, right, left, vname, vinds, vi
-    )
-end
-
-"""
     tilde_observe(context::SamplingContext, right, left, vi)
 
 Handle observed constants with a `context` associated with a sampler.
@@ -187,8 +171,7 @@ function tilde_observe(context::MiniBatchContext, right, left, vi)
     return context.loglike_scalar * tilde_observe(context.context, right, left, vi)
 end
 function tilde_observe(context::MiniBatchContext, sampler, right, left, vi)
-    return context.loglike_scalar *
-           tilde_observe(context.context, sampler, right, left, vname, vi)
+    return context.loglike_scalar * tilde_observe(context.context, sampler, right, left, vi)
 end
 
 # `PrefixContext`

--- a/test/contexts.jl
+++ b/test/contexts.jl
@@ -226,6 +226,13 @@ end
         end
     end
 
+    @testset "Evaluation" begin
+        @testset "$context" for context in contexts
+            # Just making sure that we can actually sample with each of the contexts.
+            @test (gdemo_default(SamplingContext(context)); true)
+        end
+    end
+
     @testset "PrefixContext" begin
         ctx = @inferred PrefixContext{:f}(
             PrefixContext{:e}(


### PR DESCRIPTION
One of my previous PRs introduced a bug for `MiniBatchContext`; this fixes said bug. It also removes a redundant impl of `tilde_observe` for `SamplingContext`.