### PR TITLE
[Merged by Bors] - Removes redundant `maybe_unwrap_view` method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.14.1"
+version = "0.14.2"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -85,13 +85,7 @@ isassumption(expr) = :(false)
 
 # If we're working with, say, a `Symbol`, then we're not going to `view`.
 maybe_view(x) = x
-maybe_view(x::Expr) = :($(DynamicPPL.maybe_unwrap_view)(@view($x)))
-
-# If the result of a `view` is a zero-dim array then it's just a
-# single element. Likely the rest is expecting type `eltype(x)`, hence
-# we extract the value rather than passing the array.
-maybe_unwrap_view(x) = x
-maybe_unwrap_view(x::SubArray{<:Any,0}) = x[1]
+maybe_view(x::Expr) = :(@views($x))
 
 """
     isliteral(expr)


### PR DESCRIPTION
`@views` uses `Base.maybeview` under the hood which will return non-view if we're indexing a single element, as we want, hence making `maybe_unwrap_view` redundant.