### PR TITLE
Remove `__rng__` and `__sampler__` from `INTERNALNAMES`

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1,5 +1,5 @@
-const INTERNALNAMES = (:__model__, :__sampler__, :__context__, :__varinfo__, :__rng__)
-const DEPRECATED_INTERNALNAMES = (:_model, :_sampler, :_context, :_varinfo, :_rng)
+const INTERNALNAMES = (:__model__, :__context__, :__varinfo__)
+const DEPRECATED_INTERNALNAMES = Tuple(Symbol(string(name)[2:end-2]) for name in INTERNALNAMES)
 
 """
     isassumption(expr)


### PR DESCRIPTION
Cf. [this discussion](https://github.com/TuringLang/DynamicPPL.jl/pull/253#discussion_r642866886).  Also, derive deprecated names automatically.

In the next breaking release we could completely get rid of `DEPRECATED_INTERNALNAMES`.