### PR TITLE
Make evaluator a method of the model function

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -121,7 +121,7 @@ julia> @model function demo()
            x ~ Normal(m, 1)
            return (; m=m, x=x)
        end
-demo (generic function with 1 method)
+demo (generic function with 2 methods)
 
 julia> model = demo();
 
@@ -161,7 +161,7 @@ julia> @model function demo_mv(::Type{TV}=Float64) where {TV}
            m[2] ~ Normal()
            return m
        end
-demo_mv (generic function with 2 methods)
+demo_mv (generic function with 3 methods)
 
 julia> model = demo_mv();
 
@@ -192,13 +192,13 @@ the use of [`@submodel`](@ref).
 
 ```jldoctest condition
 julia> @model demo_inner() = m ~ Normal()
-demo_inner (generic function with 1 method)
+demo_inner (generic function with 2 methods)
 
 julia> @model function demo_outer()
            m = @submodel demo_inner()
            return m
        end
-demo_outer (generic function with 1 method)
+demo_outer (generic function with 2 methods)
 
 julia> model = demo_outer();
 
@@ -218,7 +218,7 @@ julia> @model function demo_outer_prefix()
            m = @submodel inner demo_inner()
            return m
        end
-demo_outer_prefix (generic function with 1 method)
+demo_outer_prefix (generic function with 2 methods)
 
 julia> # This doesn't work now!
        conditioned_model = demo_outer_prefix() | (m = 1.0, );
@@ -279,7 +279,7 @@ julia> @model function demo()
            x ~ Normal(m, 1)
            return (; m=m, x=x)
        end
-demo (generic function with 1 method)
+demo (generic function with 2 methods)
 
 julia> conditioned_model = condition(demo(), m = 1.0, x = 10.0);
 
@@ -333,7 +333,7 @@ julia> @model function demo()
            m ~ Normal()
            x ~ Normal(m, 1)
        end
-demo (generic function with 1 method)
+demo (generic function with 2 methods)
 
 julia> m = demo();
 
@@ -613,7 +613,7 @@ julia> @model function demo(xs)
            end
            return (m, )
        end
-demo (generic function with 1 method)
+demo (generic function with 2 methods)
 
 julia> model = demo(randn(10));
 


### PR DESCRIPTION
This PR implements the idea in https://github.com/TuringLang/DynamicPPL.jl/pull/314/files#r693968700. All DynamicPPL tests pass, I only had to update the doctests (since the number of methods that are created by `@model` changed from 1 to 2).

It allows to do the following:
```julia
julia> using DynamicPPL, Distributions

julia> @macroexpand @model demo() = x ~ Normal()
quote
    function demo(__model__::Model, __varinfo__::AbstractVarInfo, __context__::DynamicPPL.AbstractContext; )
        #= REPL[4]:1 =#
        begin
            var"##vn#257" = (VarName){:x}()
            var"##inds#258" = ()
            var"##isassumption#259" = begin
                    let var"##vn#260" = (VarName){:x}()
                        if (DynamicPPL.contextual_isassumption)(__context__, var"##vn#260")
                            if !((DynamicPPL.inargnames)(var"##vn#260", __model__)) || (DynamicPPL.inmissings)(var"##vn#260", __model__)
                                true
                            else
                                x === missing
                            end
                        else
                            false
                        end
                    end
                end
            if var"##isassumption#259"
                x = (DynamicPPL.tilde_assume!)(__context__, (DynamicPPL.unwrap_right_vn)((DynamicPPL.check_tilde_rhs)(Normal()), var"##vn#257")..., var"##inds#258", __varinfo__)
            else
                if !((DynamicPPL.inargnames)(var"##vn#257", __model__))
                    x = (DynamicPPL.getvalue_nested)(__context__, var"##vn#257")
                end
                (DynamicPPL.tilde_observe!)(__context__, (DynamicPPL.check_tilde_rhs)(Normal()), x, var"##vn#257", var"##inds#258", __varinfo__)
            end
        end
    end
    begin
        $(Expr(:meta, :doc))
        function demo(; )
            #= REPL[4]:1 =#
            return (Model)(:demo, demo, NamedTuple(), NamedTuple())
        end
    end
end

julia> @model demo() = x ~ Normal()
demo (generic function with 2 methods)

julia> f(x) = false
f (generic function with 1 method)

julia> f(::Model{typeof(demo)}) = true
f (generic function with 2 methods)

julia> f(demo())
true

julia> demo() isa Model{typeof(demo)}
true
```