### PR TITLE
[Merged by Bors] - Remove deprecated internal names

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1,5 +1,4 @@
 const INTERNALNAMES = (:__model__, :__context__, :__varinfo__)
-const DEPRECATED_INTERNALNAMES = (:_model, :_context, :_varinfo)
 
 """
     isassumption(expr)
@@ -307,15 +306,6 @@ generate_mainbody(mod, expr, warn) = generate_mainbody!(mod, Symbol[], expr, war
 
 generate_mainbody!(mod, found, x, warn) = x
 function generate_mainbody!(mod, found, sym::Symbol, warn)
-    if sym in DEPRECATED_INTERNALNAMES
-        newsym = Symbol(:_, sym, :__)
-        Base.depwarn(
-            "internal variable `$sym` is deprecated, use `$newsym` instead.",
-            :generate_mainbody!,
-        )
-        return generate_mainbody!(mod, found, newsym, warn)
-    end
-
     if warn && sym in INTERNALNAMES && sym ∉ found
         @warn "you are using the internal variable `$sym`"
         push!(found, sym)


### PR DESCRIPTION
Maybe we could remove `DEPRECATED_INTERNALNAMES` before tagging a new release.