### PR TITLE
[Merged by Bors] - Overload AbstractPPL.condition and AbstractPPL.decondition

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.16.0"
+version = "0.16.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/model.jl
+++ b/src/model.jl
@@ -254,8 +254,8 @@ From this we can tell what the correct way to condition `m` within `demo_inner`
 is in the two different models.
 
 """
-condition(model::Model; values...) = condition(model, NamedTuple(values))
-function condition(model::Model, values)
+AbstractPPL.condition(model::Model; values...) = condition(model, NamedTuple(values))
+function AbstractPPL.condition(model::Model, values)
     return contextualize(model, condition(model.context, values))
 end
 
@@ -307,7 +307,7 @@ julia> model(rng)
 (m = 0.683947930996541, x = 10.0)
 ```
 """
-function decondition(model::Model, syms...)
+function AbstractPPL.decondition(model::Model, syms...)
     return contextualize(model, decondition(model.context, syms...))
 end
 

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -534,7 +534,7 @@ end
 
         # Ensure we can specialize on arguments.
         @model demo(x) = x ~ Normal()
-        length(methods(demo))
+        @test length(methods(demo)) == 4
         @test f(demo(1.0))
         f(::Model{typeof(demo),(:x,)}) = false
         @test !f(demo(1.0))

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -43,7 +43,12 @@ function test_model_ad(model, logp_manual)
 
     y, back = Zygote.pullback(logp_model, x)
     @test y ≈ lp
-    @test_broken back(1)[1] ≈ grad
+    # will be fixed by https://github.com/FluxML/Zygote.jl/pull/1104
+    if Threads.nthreads() > 1
+        @test_broken back(1)[1] ≈ grad
+    else
+        @test back(1)[1] ≈ grad
+    end
 end
 
 """

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -43,7 +43,7 @@ function test_model_ad(model, logp_manual)
 
     y, back = Zygote.pullback(logp_model, x)
     @test y ≈ lp
-    @test back(1)[1] ≈ grad
+    @test_broken back(1)[1] ≈ grad
 end
 
 """


### PR DESCRIPTION
Fixes https://github.com/TuringLang/DynamicPPL.jl/issues/336.

Tests will fail until the Zygote bug is fixed... Maybe we should just mark them as broken so we can merge and release some PRs?