### PR TITLE
Improvements to `@submodel` in #309

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -215,7 +215,7 @@ But one needs to be careful when prefixing variables in the nested models:
 
 ```jldoctest condition
 julia> @model function demo_outer_prefix()
-           @submodel inner m = demo_inner()
+           @submodel prefix="inner" m = demo_inner()
            return m
        end
 demo_outer_prefix (generic function with 2 methods)

--- a/src/submodel_macro.jl
+++ b/src/submodel_macro.jl
@@ -123,46 +123,53 @@ true
 
 ## Different ways of setting the prefix
 ```jldoctest submodel-prefix-alternatives; setup=:(using DynamicPPL, Distributions)
-julia> @model inner() = x ~ Normal();
+julia> @model inner() = x ~ Normal()
+inner (generic function with 2 methods)
 
 julia> # When `prefix` is unspecified, no prefix is used.
-       @model outer() = @submodel a = inner();
-       
+       @model outer() = @submodel a = inner()
+outer (generic function with 2 methods)
+
 julia> @varname(x) in keys(VarInfo(outer()))
 true
 
 julia> # Explicitely don't use any prefix.
-       @model outer() = @submodel prefix=false a = inner();
+       @model outer() = @submodel prefix=false a = inner()
+outer (generic function with 2 methods)
 
 julia> @varname(x) in keys(VarInfo(outer()))
 true
 
 julia> # Automatically determined from `a`.
-       @model outer() = @submodel prefix=true a = inner();
+       @model outer() = @submodel prefix=true a = inner()
+outer (generic function with 2 methods)
 
 julia> @varname(var"a.x") in keys(VarInfo(outer()))
 true
 
 julia> # Using a static string.
-       @model outer() = @submodel prefix="my prefix" a = inner();
+       @model outer() = @submodel prefix="my prefix" a = inner()
+outer (generic function with 2 methods)
 
 julia> @varname(var"my prefix.x") in keys(VarInfo(outer()))
 true
 
 julia> # Using string interpolation.
-       @model outer() = @submodel prefix="\$(inner().name)" a = inner();
+       @model outer() = @submodel prefix="\$(inner().name)" a = inner()
+outer (generic function with 2 methods)
 
 julia> @varname(var"inner.x") in keys(VarInfo(outer()))
-true
+false
 
 julia> # Or using some arbitrary expression.
-       @model outer() = @submodel prefix=1 + 2 a = inner();
+       @model outer() = @submodel prefix=1 + 2 a = inner()
+outer (generic function with 2 methods)
 
 julia> @varname(var"3.x") in keys(VarInfo(outer()))
 true
 
 julia> # (×) Automatic prefixing without a left-hand side expression does not work!
-       @model outer() = @submodel prefix=true inner();
+       @model outer() = @submodel prefix=true inner()
 ERROR: LoadError: LoadError: cannot automatically prefix with no left-hand side
 [...]
 ```

--- a/src/submodel_macro.jl
+++ b/src/submodel_macro.jl
@@ -125,7 +125,13 @@ true
 ```jldoctest submodel-prefix-alternatives; setup=:(using DynamicPPL, Distributions)
 julia> @model inner() = x ~ Normal();
 
-julia> # Don't use any prefix.
+julia> # When `prefix` is unspecified, no prefix is used.
+       @model outer() = @submodel a = inner();
+       
+julia> @varname(x) in keys(VarInfo(outer()))
+true
+
+julia> # Explicitely don't use any prefix.
        @model outer() = @submodel prefix=false a = inner();
 
 julia> @varname(x) in keys(VarInfo(outer()))

--- a/src/submodel_macro.jl
+++ b/src/submodel_macro.jl
@@ -170,7 +170,7 @@ true
 
 julia> # (×) Automatic prefixing without a left-hand side expression does not work!
        @model outer() = @submodel prefix=true inner()
-ERROR: LoadError: LoadError: cannot automatically prefix with no left-hand side
+ERROR: LoadError: cannot automatically prefix with no left-hand side
 [...]
 ```
 

--- a/src/submodel_macro.jl
+++ b/src/submodel_macro.jl
@@ -45,7 +45,7 @@ true
 ```
 """
 macro submodel(expr)
-    return submodel(:(prefix=false), expr)
+    return submodel(:(prefix = false), expr)
 end
 
 """
@@ -201,7 +201,6 @@ function submodel(prefix_expr, expr, ctx=esc(:__context__))
     if prefix_left !== :prefix
         error("$(prefix_left) is not a valid kwarg")
     end
-    
     # `prefix=false` => don't prefix, i.e. do nothing to `ctx`.
     # `prefix=true` => automatically determine prefix.
     # `prefix=...` => use it.
@@ -220,7 +219,9 @@ function submodel(prefix_expr, expr, ctx=esc(:__context__))
         try
             ctx = prefix_submodel_context(prefix, L, ctx)
         catch e
-            error("failed to determine prefix from $(L); please specify prefix using the `@submodel prefix=\"your prefix\" ...` syntax")
+            error(
+                "failed to determine prefix from $(L); please specify prefix using the `@submodel prefix=\"your prefix\" ...` syntax",
+            )
         end
         quote
             $(esc(L)), $(esc(:__varinfo__)) = $(DynamicPPL._evaluate!!)(

--- a/src/submodel_macro.jl
+++ b/src/submodel_macro.jl
@@ -122,7 +122,9 @@ true
 ```
 
 ## Different ways of setting the prefix
-```julia
+```jldoctest submodel-prefix; setup=:(using DynamicPPL, Distributions)
+julia> @model inner() = x ~ Normal();
+
 julia> # Don't use any prefix.
        @model outer() = @submodel prefix=false a = inner();
 

--- a/src/submodel_macro.jl
+++ b/src/submodel_macro.jl
@@ -122,7 +122,7 @@ true
 ```
 
 ## Different ways of setting the prefix
-```jldoctest submodel-prefix; setup=:(using DynamicPPL, Distributions)
+```jldoctest submodel-prefix-alternatives; setup=:(using DynamicPPL, Distributions)
 julia> @model inner() = x ~ Normal();
 
 julia> # Don't use any prefix.
@@ -144,7 +144,7 @@ julia> @varname(var"my prefix.x") in keys(VarInfo(outer()))
 true
 
 julia> # Using string interpolation.
-       @model outer() = @submodel prefix="$(inner().name)" a = inner();
+       @model outer() = @submodel prefix="\$(inner().name)" a = inner();
 
 julia> @varname(var"inner.x") in keys(VarInfo(outer()))
 true

--- a/src/submodel_macro.jl
+++ b/src/submodel_macro.jl
@@ -159,6 +159,7 @@ julia> # Or using some arbitrary expression.
        @model outer() = @submodel prefix=1 + 2 a = inner();
 
 julia> @varname(var"3.x") in keys(VarInfo(outer()))
+true
 
 julia> # (×) Automatic prefixing without a left-hand side expression does not work!
        @model outer() = @submodel prefix=true inner();

--- a/src/submodel_macro.jl
+++ b/src/submodel_macro.jl
@@ -159,7 +159,7 @@ julia> # Using string interpolation.
 outer (generic function with 2 methods)
 
 julia> @varname(var"inner.x") in keys(VarInfo(outer()))
-false
+true
 
 julia> # Or using some arbitrary expression.
        @model outer() = @submodel prefix=1 + 2 a = inner()

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -455,7 +455,7 @@ end
             num_steps = length(y[1])
             num_obs = length(y)
             @inbounds for i in 1:num_obs
-                @submodel prefix="ar1_$i" x = AR1(num_steps, α, μ, σ)
+                @submodel prefix = "ar1_$i" x = AR1(num_steps, α, μ, σ)
                 y[i] ~ MvNormal(x, 0.1)
             end
         end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -455,7 +455,7 @@ end
             num_steps = length(y[1])
             num_obs = length(y)
             @inbounds for i in 1:num_obs
-                @submodel $(Symbol("ar1_$i")) x = AR1(num_steps, α, μ, σ)
+                @submodel prefix="ar1_$i" x = AR1(num_steps, α, μ, σ)
                 y[i] ~ MvNormal(x, 0.1)
             end
         end


### PR DESCRIPTION
This PR is a follow-up on the following discussion: https://github.com/TuringLang/DynamicPPL.jl/pull/309/files#r760070684.

I made a separate PR for this as I felt the discussion regarding this particular change was a bit hidden in all the other changes in that PR + it's not strictly _required_ for #309 to go through.