### PR TITLE
[Merged by Bors] - Fixed a bug in replace returns

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.17.0"
+version = "0.17.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -548,7 +548,7 @@ end
     @testset "return value" begin
         # Make sure that a return-value of `x = 1` isn't combined into
         # an attempt at a `NamedTuple` of the form `(x = 1, __varinfo__)`.
-        @model empty_model() = begin x = 1; end
+        @model empty_model() = return x = 1;
         empty_vi = VarInfo()
         retval_and_vi = DynamicPPL.evaluate!!(empty_model(), empty_vi, SamplingContext())
         @test retval_and_vi isa Tuple{Int,typeof(empty_vi)}

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -548,7 +548,7 @@ end
     @testset "return value" begin
         # Make sure that a return-value of `x = 1` isn't combined into
         # an attempt at a `NamedTuple` of the form `(x = 1, __varinfo__)`.
-        @model empty_model() = return x = 1;
+        @model empty_model() = return x = 1
         empty_vi = VarInfo()
         retval_and_vi = DynamicPPL.evaluate!!(empty_model(), empty_vi, SamplingContext())
         @test retval_and_vi isa Tuple{Int,typeof(empty_vi)}

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -546,6 +546,13 @@ end
     end
 
     @testset "return value" begin
+        # Make sure that a return-value of `x = 1` isn't combined into
+        # an attempt at a `NamedTuple` of the form `(x = 1, __varinfo__)`.
+        @model empty_model() = begin x = 1; end
+        empty_vi = VarInfo()
+        retval_and_vi = DynamicPPL.evaluate!!(empty_model(), empty_vi, SamplingContext())
+        @test retval_and_vi isa Tuple{Int,typeof(empty_vi)}
+
         # Even if the return-value is `AbstractVarInfo`, we should return
         # a `Tuple` with `AbstractVarInfo` in the second component too.
         @model demo() = return __varinfo__


### PR DESCRIPTION
On master we have the following behavior for a test-case in Turing.jl:

```julia
julia> @macroexpand @model empty_model() = begin x = 1; end
quote
    function empty_model(__model__::DynamicPPL.Model, __varinfo__::DynamicPPL.AbstractVarInfo, __context__::DynamicPPL.AbstractContext; )
        #= REPL[5]:1 =#
        begin
            #= REPL[5]:1 =#
            #= REPL[5]:1 =#
            return (x = 1, __varinfo__)
        end
    end
    begin
        $(Expr(:meta, :doc))
        function empty_model(; )
            #= REPL[5]:1 =#
            return (DynamicPPL.Model)(:empty_model, empty_model, NamedTuple(), NamedTuple())
        end
    end
end
```

Notice the `return` statement: it converted the statement `x = 1` which returns `1` into an attempt at a `NamedTuple{(:x, :__varinfo__)}`. On Julia 1.6 we don't really notice much of difference, because `first` and `last` will have the same behavior, but on Julia 1.3 the tests would fail in https://github.com/TuringLang/Turing.jl/pull/1726 since "implicit" names in construction of `NamedTuple` isn't supported.

This PR addresses this issue by simply capturing the return-value in separate variable, which is then combined with `__varinfo__` in a `Tuple` at the end. This should both fail and succeed whenever standard Julia code would.