### PR TITLE
[Merged by Bors] - Fix for #371

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.19.1"
+version = "0.19.2"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -387,7 +387,9 @@ function generate_tilde(left, right)
     # more selective with our escape. Until that's the case, we remove them all.
     return quote
         $dist = $right
-        $vn = $(DynamicPPL.resolve_varnames)($(AbstractPPL.drop_escape(varname(left))), $dist)
+        $vn = $(DynamicPPL.resolve_varnames)(
+            $(AbstractPPL.drop_escape(varname(left))), $dist
+        )
         $isassumption = $(DynamicPPL.isassumption(left, vn))
         if $isassumption
             $(generate_tilde_assume(left, dist, vn))
@@ -444,7 +446,9 @@ function generate_dot_tilde(left, right)
     # if the LHS represents an observation
     @gensym vn isassumption value
     return quote
-        $vn = $(DynamicPPL.resolve_varnames)($(AbstractPPL.drop_escape(varname(left))), right)
+        $vn = $(DynamicPPL.resolve_varnames)(
+            $(AbstractPPL.drop_escape(varname(left))), right
+        )
         $isassumption = $(DynamicPPL.isassumption(left, vn))
         if $isassumption
             $(generate_dot_tilde_assume(left, right, vn))

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -175,6 +175,9 @@ function unwrap_right_left_vns(
     return unwrap_right_left_vns(right, left, vns)
 end
 
+resolve_varnames(vn::VarName, _) = vn
+resolve_varnames(vn::VarName, dist::NamedDist) = dist.name
+
 #################
 # Main Compiler #
 #################
@@ -377,16 +380,17 @@ function generate_tilde(left, right)
 
     # Otherwise it is determined by the model or its value,
     # if the LHS represents an observation
-    @gensym vn isassumption value
+    @gensym vn isassumption value dist
 
     # HACK: Usage of `drop_escape` is unfortunate. It's a consequence of the fact
     # that in DynamicPPL we the entire function body. Instead we should be
     # more selective with our escape. Until that's the case, we remove them all.
     return quote
-        $vn = $(AbstractPPL.drop_escape(varname(left)))
+        $dist = $right
+        $vn = $(DynamicPPL.resolve_varnames)($(AbstractPPL.drop_escape(varname(left))), $dist)
         $isassumption = $(DynamicPPL.isassumption(left, vn))
         if $isassumption
-            $(generate_tilde_assume(left, right, vn))
+            $(generate_tilde_assume(left, dist, vn))
         else
             # If `vn` is not in `argnames`, we need to make sure that the variable is defined.
             if !$(DynamicPPL.inargnames)($vn, __model__)
@@ -395,7 +399,7 @@ function generate_tilde(left, right)
 
             $value, __varinfo__ = $(DynamicPPL.tilde_observe!!)(
                 __context__,
-                $(DynamicPPL.check_tilde_rhs)($right),
+                $(DynamicPPL.check_tilde_rhs)($dist),
                 $(maybe_view(left)),
                 $vn,
                 __varinfo__,
@@ -440,7 +444,7 @@ function generate_dot_tilde(left, right)
     # if the LHS represents an observation
     @gensym vn isassumption value
     return quote
-        $vn = $(AbstractPPL.drop_escape(varname(left)))
+        $vn = $(DynamicPPL.resolve_varnames)($(AbstractPPL.drop_escape(varname(left))), right)
         $isassumption = $(DynamicPPL.isassumption(left, vn))
         if $isassumption
             $(generate_dot_tilde_assume(left, right, vn))

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -449,7 +449,7 @@ function generate_dot_tilde(left, right)
     @gensym vn isassumption value
     return quote
         $vn = $(DynamicPPL.resolve_varnames)(
-            $(AbstractPPL.drop_escape(varname(left))), right
+            $(AbstractPPL.drop_escape(varname(left))), $right
         )
         $isassumption = $(DynamicPPL.isassumption(left, vn))
         if $isassumption

--- a/src/distribution_wrappers.jl
+++ b/src/distribution_wrappers.jl
@@ -13,10 +13,16 @@ end
 
 NamedDist(dist::Distribution, name::Symbol) = NamedDist(dist, VarName{name}())
 
-Distributions.logpdf(dist::NamedDist, x::Real)= Distributions.logpdf(dist.dist, x)
-Distributions.logpdf(dist::NamedDist, x::AbstractArray{<:Real})= Distributions.logpdf(dist.dist, x)
-Distributions.loglikelihood(dist::NamedDist, x::Real) = Distributions.loglikelihood(dist.dist, x)
-Distributions.loglikelihood(dist::NamedDist, x::AbstractArray{<:Real})= Distributions.loglikelihood(dist.dist, x)
+Distributions.logpdf(dist::NamedDist, x::Real) = Distributions.logpdf(dist.dist, x)
+function Distributions.logpdf(dist::NamedDist, x::AbstractArray{<:Real})
+    return Distributions.logpdf(dist.dist, x)
+end
+function Distributions.loglikelihood(dist::NamedDist, x::Real)
+    return Distributions.loglikelihood(dist.dist, x)
+end
+function Distributions.loglikelihood(dist::NamedDist, x::AbstractArray{<:Real})
+    return Distributions.loglikelihood(dist.dist, x)
+end
 
 struct NoDist{variate,support,Td<:Distribution{variate,support}} <:
        Distribution{variate,support}

--- a/src/distribution_wrappers.jl
+++ b/src/distribution_wrappers.jl
@@ -13,6 +13,11 @@ end
 
 NamedDist(dist::Distribution, name::Symbol) = NamedDist(dist, VarName{name}())
 
+Distributions.logpdf(dist::NamedDist, x::Real)= Distributions.logpdf(dist.dist, x)
+Distributions.logpdf(dist::NamedDist, x::AbstractArray{<:Real})= Distributions.logpdf(dist.dist, x)
+Distributions.loglikelihood(dist::NamedDist, x::Real) = Distributions.loglikelihood(dist.dist, x)
+Distributions.loglikelihood(dist::NamedDist, x::AbstractArray{<:Real})= Distributions.loglikelihood(dist.dist, x)
+
 struct NoDist{variate,support,Td<:Distribution{variate,support}} <:
        Distribution{variate,support}
     dist::Td

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -312,6 +312,18 @@ end
         @test vi2.metadata.y.vns[1] == @varname(y[2][:, 1])
         @test haskey(vi3.metadata, :y)
         @test vi3.metadata.y.vns[1] == @varname(y[1])
+
+        # Conditioning
+        f1_c = f1() | (y=1,)
+        f2_c = f2() | NamedTuple((Symbol(@varname(y[2][:, 1])) => 1,))
+        f3_c = f3() | NamedTuple((Symbol(@varname(y[1])) => 1,))
+        @test f1_c() == 1
+        # TODO(torfjelde): We need conditioning for `Dict`.
+        @test_broken f2_c() == 1
+        @test_broken f3_c() == 1
+        @test_broken getlogp(VarInfo(f1_c)) ==
+            getlogp(VarInfo(f2_c)) ==
+            getlogp(VarInfo(f3_c))
     end
     @testset "custom tilde" begin
         @model demo() = begin


### PR DESCRIPTION
This PR adds a method called `resolve_varnames(varname, dist)` and adds an additional generated variable for each `~` which now holds the RHS of `~`. 

It does address #371 but uncertain if this is the best way, so wouldn't recommend merging this just yet. But putting it here so we can colab on it.