### PR TITLE
Improvements to TestUtils (follow-up from #360)

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -103,7 +103,7 @@ NamedDist
 DynamicPPL provides several demo models and helpers for testing samplers in the `DynamicPPL.TestUtils` submodule.
 
 ```@docs
-DynamicPPL.TestUtils.test_sampler_on_models
+DynamicPPL.TestUtils.test_sampler
 DynamicPPL.TestUtils.test_sampler_on_demo_models
 DynamicPPL.TestUtils.test_sampler_continuous
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -106,6 +106,7 @@ DynamicPPL provides several demo models and helpers for testing samplers in the 
 DynamicPPL.TestUtils.test_sampler
 DynamicPPL.TestUtils.test_sampler_on_demo_models
 DynamicPPL.TestUtils.test_sampler_continuous
+DynamicPPL.TestUtils.marginal_mean_of_samples
 ```
 
 ```@docs

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -132,7 +132,7 @@ Finally, the following methods can also be of use:
 ```@docs
 DynamicPPL.TestUtils.varnames
 DynamicPPL.TestUtils.example_values
-DynamicPPL.TestUtils.posterior_mean_values
+DynamicPPL.TestUtils.posterior_mean
 ```
 
 ## Advanced

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -103,8 +103,13 @@ NamedDist
 DynamicPPL provides several demo models and helpers for testing samplers in the `DynamicPPL.TestUtils` submodule.
 
 ```@docs
-DynamicPPL.TestUtils.test_sampler_demo_models
+DynamicPPL.TestUtils.test_sampler_on_models
+DynamicPPL.TestUtils.test_sampler_on_demo_models
 DynamicPPL.TestUtils.test_sampler_continuous
+```
+
+```@docs
+DynamicPPL.TestUtils.DEMO_MODELS
 ```
 
 For every demo model, one can define the true log prior, log likelihood, and log joint probabilities.
@@ -113,6 +118,21 @@ For every demo model, one can define the true log prior, log likelihood, and log
 DynamicPPL.TestUtils.logprior_true
 DynamicPPL.TestUtils.loglikelihood_true
 DynamicPPL.TestUtils.logjoint_true
+```
+
+And in the case where the model might include constrained variables, it can also be useful to define
+
+```@docs
+DynamicPPL.TestUtils.logprior_true_with_logabsdet_jacobian
+DynamicPPL.TestUtils.logjoint_true_with_logabsdet_jacobian
+```
+
+Finally, the following methods can also be of use:
+
+```@docs
+DynamicPPL.TestUtils.varnames
+DynamicPPL.TestUtils.example_values
+DynamicPPL.TestUtils.posterior_mean_values
 ```
 
 ## Advanced

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -131,7 +131,6 @@ Finally, the following methods can also be of use:
 
 ```@docs
 DynamicPPL.TestUtils.varnames
-DynamicPPL.TestUtils.example_values
 DynamicPPL.TestUtils.posterior_mean
 ```
 

--- a/src/distribution_wrappers.jl
+++ b/src/distribution_wrappers.jl
@@ -51,9 +51,21 @@ Distributions.logpdf(d::NoDist{<:Matrixvariate}, ::AbstractMatrix{<:Real}) = 0
 Distributions.minimum(d::NoDist) = minimum(d.dist)
 Distributions.maximum(d::NoDist) = maximum(d.dist)
 
-Bijectors.logpdf_with_trans(d::NoDist{<:Univariate}, ::Real) = 0
-Bijectors.logpdf_with_trans(d::NoDist{<:Multivariate}, ::AbstractVector{<:Real}) = 0
-function Bijectors.logpdf_with_trans(d::NoDist{<:Multivariate}, x::AbstractMatrix{<:Real})
+Bijectors.logpdf_with_trans(d::NoDist{<:Univariate}, ::Real, ::Bool) = 0
+function Bijectors.logpdf_with_trans(
+    d::NoDist{<:Multivariate}, ::AbstractVector{<:Real}, ::Bool
+)
+    return 0
+end
+function Bijectors.logpdf_with_trans(
+    d::NoDist{<:Multivariate}, x::AbstractMatrix{<:Real}, ::Bool
+)
     return zeros(Int, size(x, 2))
 end
-Bijectors.logpdf_with_trans(d::NoDist{<:Matrixvariate}, ::AbstractMatrix{<:Real}) = 0
+function Bijectors.logpdf_with_trans(
+    d::NoDist{<:Matrixvariate}, ::AbstractMatrix{<:Real}, ::Bool
+)
+    return 0
+end
+
+Bijectors.bijector(d::NoDist) = Bijectors.bijector(d.dist)

--- a/src/simple_varinfo.jl
+++ b/src/simple_varinfo.jl
@@ -312,9 +312,8 @@ end
 # HACK: Needed to disambiguiate.
 Base.getindex(vi::SimpleVarInfo, vns::Vector{<:VarName}) = map(Base.Fix1(getindex, vi), vns)
 
-Base.getindex(vi::SimpleVarInfo, ::Colon) = vi.values
-Base.getindex(vi::SimpleVarInfo, spl::SampleFromPrior) = vi[:]
-Base.getindex(vi::SimpleVarInfo, spl::SampleFromUniform) = vi[:]
+Base.getindex(vi::SimpleVarInfo, spl::SampleFromPrior) = vi.values
+Base.getindex(vi::SimpleVarInfo, spl::SampleFromUniform) = vi.values
 
 # TODO: Should we do better?
 Base.getindex(vi::SimpleVarInfo, spl::Sampler) = vi.values

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -645,18 +645,26 @@ const DEMO_MODELS = (
 )
 
 """
-    test_sampler(meanfunction, models, sampler, args...; kwargs...)
+    marginal_mean_of_samples(chain, varname)
+
+Return the mean of variable represented by `varname` in `chain`.
+"""
+marginal_mean_of_samples(chain, varname) = mean(Array(chain[Symbol(varname)]))
+
+"""
+    test_sampler(models, sampler, args...; kwargs...)
 
 Test that `sampler` produces correct marginal posterior means on each model in `models`.
 
 In short, this method iterates through `models`, calls `AbstractMCMC.sample` on the
-`model` and `sampler` to produce a `chain`, and then checks `meanfunction(chain, vn)`
+`model` and `sampler` to produce a `chain`, and then checks [`marginal_mean_of_samples(chain, vn)`](@ref)
 for every (leaf) varname `vn` against the corresponding value returned by
 [`posterior_mean`](@ref) for each model.
 
+To change how comparison is done for a particular `chain` type, one can overload
+[`marginal_mean_of_samples(chain, vn)`](@ref) for the corresponding type.
+
 # Arguments
-- `meanfunction`: A callable which computes the mean of the marginal means from the
-  chain resulting from the `sample` call.
 - `models`: A collection of instaces of [`DynamicPPL.Model`](@ref) to test on.
 - `sampler`: The `AbstractMCMC.AbstractSampler` to test.
 - `args...`: Arguments forwarded to `sample`.
@@ -667,7 +675,6 @@ for every (leaf) varname `vn` against the corresponding value returned by
 - `kwargs...`: Keyword arguments forwarded to `sample`.
 """
 function test_sampler(
-    meanfunction,
     models,
     sampler::AbstractMCMC.AbstractSampler,
     args...;
@@ -683,7 +690,7 @@ function test_sampler(
             # extracting the leaves of the `VarName` and the corresponding value.
             for vn_leaf in varname_leaves(vn, get(target_values, vn))
                 target_value = get(target_values, vn_leaf)
-                chain_mean_value = meanfunction(chain, vn_leaf)
+                chain_mean_value = marginal_mean_of_samples(chain, vn_leaf)
                 @test chain_mean_value ≈ target_value atol = atol rtol = rtol
             end
         end
@@ -698,30 +705,22 @@ Test `sampler` on every model in [`DEMO_MODELS`](@ref).
 This is just a proxy for `test_sampler(meanfunction, DEMO_MODELS, sampler, args...; kwargs...)`.
 """
 function test_sampler_on_demo_models(
-    meanfunction, sampler::AbstractMCMC.AbstractSampler, args...; kwargs...
+    sampler::AbstractMCMC.AbstractSampler, args...; kwargs...
 )
-    return test_sampler(meanfunction, DEMO_MODELS, sampler, args...; kwargs...)
+    return test_sampler(DEMO_MODELS, sampler, args...; kwargs...)
 end
 
 """
-    test_sampler_continuous([meanfunction, ]sampler, args...; kwargs...)
+    test_sampler_continuous(sampler, args...; kwargs...)
 
 Test that `sampler` produces the correct marginal posterior means on all models in `demo_models`.
 
 As of right now, this is just an alias for [`test_sampler_on_demo_models`](@ref).
 """
 function test_sampler_continuous(
-    meanfunction, sampler::AbstractMCMC.AbstractSampler, args...; kwargs...
+    sampler::AbstractMCMC.AbstractSampler, args...; kwargs...
 )
-    return test_sampler_on_demo_models(meanfunction, sampler, args...; kwargs...)
-end
-
-function test_sampler_continuous(sampler::AbstractMCMC.AbstractSampler, args...; kwargs...)
-    # Default for `MCMCChains.Chains`.
-    return test_sampler_continuous(sampler, args...; kwargs...) do chain, vn
-        # HACK(torfjelde): This assumes that we can index into `chain` with `Symbol(vn)`.
-        mean(Array(chain[Symbol(vn)]))
-    end
+    return test_sampler_on_demo_models(sampler, args...; kwargs...)
 end
 
 end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -700,7 +700,7 @@ function logprior_true_with_logabsdet_jacobian(
     return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
 end
 function varnames(model::Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)})
-    return [@varname(s[:, 1]), @varname(s[:, 2]), @varname(m[1]), @varname(m[2])]
+    return [@varname(s[:, 1]), @varname(s[:, 2]), @varname(m)]
 end
 function example_values(
     rng::Random.AbstractRNG, model::Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)}

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -665,8 +665,7 @@ const DemoModels = Union{
 }
 
 const UnivariateAssumeDemoModels = Union{
-    Model{typeof(demo_assume_dot_observe)},
-    Model{typeof(demo_assume_literal_dot_observe)},
+    Model{typeof(demo_assume_dot_observe)},Model{typeof(demo_assume_literal_dot_observe)}
 }
 function posterior_mean(model::UnivariateAssumeDemoModels)
     return (s=49 / 24, m=7 / 6)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -32,9 +32,9 @@ function varname_leaves(vn::VarName, val::AbstractArray)
 end
 
 """
-    logprior_true(model, θ)
+    logprior_true(model, args...)
 
-Return the `logprior` of `model` for `θ`.
+Return the `logprior` of `model` for `args...`.
 
 This should generally be implemented by hand for every specific `model`.
 
@@ -43,9 +43,9 @@ See also: [`logjoint_true`](@ref), [`loglikelihood_true`](@ref).
 function logprior_true end
 
 """
-    loglikelihood_true(model, θ)
+    loglikelihood_true(model, args...)
 
-Return the `loglikelihood` of `model` for `θ`.
+Return the `loglikelihood` of `model` for `args...`.
 
 This should generally be implemented by hand for every specific `model`.
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -166,12 +166,6 @@ end
 function varnames(model::Model{typeof(demo_dynamic_constraint)})
     return [@varname(m), @varname(x)]
 end
-function example_values(
-    rng::Random.AbstractRNG, model::Model{typeof(demo_dynamic_constraint)}
-)
-    m = rand(rng, Normal())
-    return (m=m, x=rand(rng, truncated(Normal(), m, Inf)))
-end
 function logprior_true_with_logabsdet_jacobian(
     model::Model{typeof(demo_dynamic_constraint)}, m, x
 )
@@ -215,17 +209,6 @@ end
 function varnames(model::Model{typeof(demo_dot_assume_dot_observe)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
 end
-function example_values(
-    rng::Random.AbstractRNG, model::Model{typeof(demo_dot_assume_dot_observe)}
-)
-    n = length(model.args.x)
-    s = rand(rng, InverseGamma(2, 3), n)
-    m = similar(s)
-    for i in eachindex(m, s)
-        m[i] = rand(rng, Normal(0, sqrt(s[i])))
-    end
-    return (s=s, m=m)
-end
 
 @model function demo_assume_index_observe(
     x=[1.5, 2.0], ::Type{TV}=Vector{Float64}
@@ -257,17 +240,6 @@ end
 function varnames(model::Model{typeof(demo_assume_index_observe)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
 end
-function example_values(
-    rng::Random.AbstractRNG, model::Model{typeof(demo_assume_index_observe)}
-)
-    n = length(model.args.x)
-    s = rand(rng, InverseGamma(2, 3), n)
-    m = similar(s)
-    for i in eachindex(m, s)
-        m[i] = rand(rng, Normal(0, sqrt(s[i])))
-    end
-    return (s=s, m=m)
-end
 
 @model function demo_assume_multivariate_observe(x=[1.5, 2.0])
     # Multivariate `assume` and `observe`
@@ -292,12 +264,6 @@ function logprior_true_with_logabsdet_jacobian(
 end
 function varnames(model::Model{typeof(demo_assume_multivariate_observe)})
     return [@varname(s), @varname(m)]
-end
-function example_values(
-    rng::Random.AbstractRNG, model::Model{typeof(demo_assume_multivariate_observe)}
-)
-    s = rand(rng, product_distribution([InverseGamma(2, 3), InverseGamma(2, 3)]))
-    return (s=s, m=rand(rng, MvNormal(zero(model.args.x), Diagonal(s))))
 end
 
 @model function demo_dot_assume_observe_index(
@@ -328,17 +294,6 @@ end
 function varnames(model::Model{typeof(demo_dot_assume_observe_index)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
 end
-function example_values(
-    rng::Random.AbstractRNG, model::Model{typeof(demo_dot_assume_observe_index)}
-)
-    n = length(model.args.x)
-    s = rand(rng, InverseGamma(2, 3), n)
-    m = similar(s)
-    for i in eachindex(m, s)
-        m[i] = rand(rng, Normal(0, sqrt(s[i])))
-    end
-    return (s=s, m=m)
-end
 
 # Using vector of `length` 1 here so the posterior of `m` is the same
 # as the others.
@@ -364,13 +319,6 @@ end
 function varnames(model::Model{typeof(demo_assume_dot_observe)})
     return [@varname(s), @varname(m)]
 end
-function example_values(
-    rng::Random.AbstractRNG, model::Model{typeof(demo_assume_dot_observe)}
-)
-    s = rand(rng, InverseGamma(2, 3))
-    m = rand(rng, Normal(0, sqrt(s)))
-    return (s=s, m=m)
-end
 
 @model function demo_assume_observe_literal()
     # `assume` and literal `observe`
@@ -395,12 +343,6 @@ function logprior_true_with_logabsdet_jacobian(
 end
 function varnames(model::Model{typeof(demo_assume_observe_literal)})
     return [@varname(s), @varname(m)]
-end
-function example_values(
-    rng::Random.AbstractRNG, model::Model{typeof(demo_assume_observe_literal)}
-)
-    s = rand(rng, product_distribution([InverseGamma(2, 3), InverseGamma(2, 3)]))
-    return (s=s, m=rand(rng, MvNormal(zeros(2), Diagonal(s))))
 end
 
 @model function demo_dot_assume_observe_index_literal(::Type{TV}=Vector{Float64}) where {TV}
@@ -431,17 +373,6 @@ end
 function varnames(model::Model{typeof(demo_dot_assume_observe_index_literal)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
 end
-function example_values(
-    rng::Random.AbstractRNG, model::Model{typeof(demo_dot_assume_observe_index_literal)}
-)
-    n = 2
-    s = rand(rng, InverseGamma(2, 3), n)
-    m = similar(s)
-    for i in eachindex(m, s)
-        m[i] = rand(rng, Normal(0, sqrt(s[i])))
-    end
-    return (s=s, m=m)
-end
 
 @model function demo_assume_literal_dot_observe()
     # `assume` and literal `dot_observe`
@@ -464,13 +395,6 @@ function logprior_true_with_logabsdet_jacobian(
 end
 function varnames(model::Model{typeof(demo_assume_literal_dot_observe)})
     return [@varname(s), @varname(m)]
-end
-function example_values(
-    rng::Random.AbstractRNG, model::Model{typeof(demo_assume_literal_dot_observe)}
-)
-    s = rand(rng, InverseGamma(2, 3))
-    m = rand(rng, Normal(0, sqrt(s)))
-    return (s=s, m=m)
 end
 
 @model function _prior_dot_assume(::Type{TV}=Vector{Float64}) where {TV}
@@ -508,18 +432,6 @@ end
 function varnames(model::Model{typeof(demo_assume_submodel_observe_index_literal)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
 end
-function example_values(
-    rng::Random.AbstractRNG,
-    model::Model{typeof(demo_assume_submodel_observe_index_literal)},
-)
-    n = 2
-    s = rand(rng, InverseGamma(2, 3), n)
-    m = similar(s)
-    for i in eachindex(m, s)
-        m[i] = rand(rng, Normal(0, sqrt(s[i])))
-    end
-    return (s=s, m=m)
-end
 
 @model function _likelihood_mltivariate_observe(s, m, x)
     return x ~ MvNormal(m, Diagonal(s))
@@ -552,17 +464,6 @@ end
 function varnames(model::Model{typeof(demo_dot_assume_observe_submodel)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
 end
-function example_values(
-    rng::Random.AbstractRNG, model::Model{typeof(demo_dot_assume_observe_submodel)}
-)
-    n = length(model.args.x)
-    s = rand(rng, InverseGamma(2, 3), n)
-    m = similar(s)
-    for i in eachindex(m, s)
-        m[i] = rand(rng, Normal(0, sqrt(s[i])))
-    end
-    return (s=s, m=m)
-end
 
 @model function demo_dot_assume_dot_observe_matrix(
     x=transpose([1.5 2.0;]), ::Type{TV}=Vector{Float64}
@@ -590,17 +491,6 @@ function logprior_true_with_logabsdet_jacobian(
 end
 function varnames(model::Model{typeof(demo_dot_assume_dot_observe_matrix)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
-end
-function example_values(
-    rng::Random.AbstractRNG, model::Model{typeof(demo_dot_assume_dot_observe_matrix)}
-)
-    n = length(model.args.x)
-    s = rand(rng, InverseGamma(2, 3), n)
-    m = similar(s)
-    for i in eachindex(m, s)
-        m[i] = rand(rng, Normal(0, sqrt(s[i])))
-    end
-    return (s=s, m=m)
 end
 
 @model function demo_dot_assume_matrix_dot_observe_matrix(
@@ -639,15 +529,6 @@ end
 function varnames(model::Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)})
     return [@varname(s[:, 1]), @varname(s[:, 2]), @varname(m)]
 end
-function example_values(
-    rng::Random.AbstractRNG, model::Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)}
-)
-    n = length(model.args.x)
-    d = n ÷ 2
-    s = rand(rng, product_distribution([InverseGamma(2, 3) for _ in 1:d]), 2)
-    m = rand(rng, MvNormal(zeros(n), Diagonal(vec(s))))
-    return (s=s, m=m)
-end
 
 const DemoModels = Union{
     Model{typeof(demo_dot_assume_dot_observe)},
@@ -669,6 +550,12 @@ const UnivariateAssumeDemoModels = Union{
 }
 function posterior_mean(model::UnivariateAssumeDemoModels)
     return (s=49 / 24, m=7 / 6)
+end
+function example_values(rng::Random.AbstractRNG, model::UnivariateAssumeDemoModels)
+    s = rand(rng, InverseGamma(2, 3))
+    m = rand(rng, Normal(0, sqrt(s)))
+
+    return (s=s, m=m)
 end
 
 const MultivariateAssumeDemoModels = Union{
@@ -692,6 +579,20 @@ function posterior_mean(model::MultivariateAssumeDemoModels)
 
     vals.s[2] = 8 / 3
     vals.m[2] = 1
+
+    return vals
+end
+function example_values(
+    rng::Random.AbstractRNG, model::MultivariateAssumeDemoModels
+)
+    # Get template values from `model`.
+    retval = model(rng)
+    vals = (s = retval.s, m = retval.m)
+    # Fill containers with realizations from prior.
+    for i in LinearIndices(vals.s)
+        vals.s[i] = rand(rng, InverseGamma(2, 3))
+        vals.m[i] = rand(rng, Normal(0, sqrt(vals.s[i])))
+    end
 
     return vals
 end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -185,7 +185,7 @@ end
 function _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
     b = Bijectors.bijector(InverseGamma(2, 3))
     s_unconstrained = b.(s)
-    Δlogp = sum(Base.Fix1(Bijectors.logabsdetjac, b).(s))
+    Δlogp = sum(Base.Fix1(Bijectors.logabsdetjac, b), s)
     return (s=s_unconstrained, m=m), logprior_true(model, s, m) - Δlogp
 end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -746,7 +746,7 @@ const DEMO_MODELS = (
 )
 
 """
-    test_sampler_on_models(meanfunction, models, sampler, args...; kwargs...)
+    test_sampler(meanfunction, models, sampler, args...; kwargs...)
 
 Test that `sampler` produces correct marginal posterior means on each model in `models`.
 
@@ -767,7 +767,7 @@ for every (leaf) varname `vn` against the corresponding value returned by
 - `rtol=1e-3`: Relative tolerance used in `@test`.
 - `kwargs...`: Keyword arguments forwarded to `sample`.
 """
-function test_sampler_on_models(
+function test_sampler(
     meanfunction,
     models,
     sampler::AbstractMCMC.AbstractSampler,
@@ -796,12 +796,12 @@ end
 
 Test `sampler` on every model in [`DEMO_MODELS`](@ref).
 
-This is just a proxy for `test_sampler_on_models(meanfunction, DEMO_MODELS, sampler, args...; kwargs...)`.
+This is just a proxy for `test_sampler(meanfunction, DEMO_MODELS, sampler, args...; kwargs...)`.
 """
 function test_sampler_on_demo_models(
     meanfunction, sampler::AbstractMCMC.AbstractSampler, args...; kwargs...
 )
-    return test_sampler_on_models(meanfunction, DEMO_MODELS, sampler, args...; kwargs...)
+    return test_sampler(meanfunction, DEMO_MODELS, sampler, args...; kwargs...)
 end
 
 """

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -722,8 +722,9 @@ const DEMO_MODELS = (
 Test that `sampler` produces the correct marginal posterior means on all models in `demo_models`.
 
 In short, this method iterators through `demo_models`, calls `AbstractMCMC.sample` on the
-`model` and `sampler` to produce a `chain`, and then checks `meanfunction(chain)` against `target`
-provided in `kwargs...`.
+`model` and `sampler` to produce a `chain`, and then checks `meanfunction(chain, vn)`
+for every (leaf) varname `vn` against the corresponding value returned by
+[`posterior_mean_values`](@ref) for each model.
 
 # Arguments
 - `meanfunction`: A callable which computes the mean of the marginal means from the
@@ -732,7 +733,6 @@ provided in `kwargs...`.
 - `args...`: Arguments forwarded to `sample`.
 
 # Keyword arguments
-- `target`: Value to compare result of `meanfunction(chain)` to.
 - `atol=1e-1`: Absolute tolerance used in `@test`.
 - `rtol=1e-3`: Relative tolerance used in `@test`.
 - `kwargs...`: Keyword arguments forwarded to `sample`.

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -455,7 +455,7 @@ function logprior_true(model::Model{typeof(demo_assume_literal_dot_observe)}, s,
     return logpdf(InverseGamma(2, 3), s) + logpdf(Normal(0, sqrt(s)), m)
 end
 function loglikelihood_true(model::Model{typeof(demo_assume_literal_dot_observe)}, s, m)
-    return logpdf(Normal(m, sqrt(s)), [1.5, 2.0])
+    return loglikelihood(Normal(m, sqrt(s)), [1.5, 2.0])
 end
 function logprior_true_with_logabsdet_jacobian(
     model::Model{typeof(demo_assume_literal_dot_observe)}, s, m
@@ -623,7 +623,8 @@ function logprior_true(
 )
     n = length(model.args.x)
     s_vec = vec(s)
-    return loglikelihood(InverseGamma(2, 3), s_vec) + logpdf(MvNormal(zeros(n), s_vec), m)
+    return loglikelihood(InverseGamma(2, 3), s_vec) +
+           logpdf(MvNormal(zeros(n), Diagonal(s_vec)), m)
 end
 function loglikelihood_true(
     model::Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)}, s, m

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -135,15 +135,15 @@ corresponding value using `get`, e.g. `get(example_values(model), varname)`.
 example_values(model::Model) = example_values(Random.GLOBAL_RNG, model)
 
 """
-    posterior_mean_values(model::Model)
+    posterior_mean(model::Model)
 
 Return a `NamedTuple` compatible with `varnames(model)` where the values represent
 the posterior mean under `model`.
 
 "Compatible" means that a `varname` from `varnames(model)` can be used to extract the
-corresponding value using `get`, e.g. `get(posterior_mean_values(model), varname)`.
+corresponding value using `get`, e.g. `get(posterior_mean(model), varname)`.
 """
-function posterior_mean_values end
+function posterior_mean end
 
 """
     demo_dynamic_constraint()
@@ -226,7 +226,7 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean_values(model::Model{typeof(demo_dot_assume_dot_observe)})
+function posterior_mean(model::Model{typeof(demo_dot_assume_dot_observe)})
     vals = example_values(model)
     vals.s .= 2.375
     vals.m .= 0.75
@@ -274,7 +274,7 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean_values(model::Model{typeof(demo_assume_index_observe)})
+function posterior_mean(model::Model{typeof(demo_assume_index_observe)})
     vals = example_values(model)
     vals.s .= 2.375
     vals.m .= 0.75
@@ -311,7 +311,7 @@ function example_values(
     s = rand(rng, product_distribution([InverseGamma(2, 3), InverseGamma(2, 3)]))
     return (s=s, m=rand(rng, MvNormal(zero(model.args.x), Diagonal(s))))
 end
-function posterior_mean_values(model::Model{typeof(demo_assume_multivariate_observe)})
+function posterior_mean(model::Model{typeof(demo_assume_multivariate_observe)})
     vals = example_values(model)
     vals.s .= 2.375
     vals.m .= 0.75
@@ -357,7 +357,7 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean_values(model::Model{typeof(demo_dot_assume_observe_index)})
+function posterior_mean(model::Model{typeof(demo_dot_assume_observe_index)})
     vals = example_values(model)
     vals.s .= 2.375
     vals.m .= 0.75
@@ -395,7 +395,7 @@ function example_values(
     m = rand(rng, Normal(0, sqrt(s)))
     return (s=s, m=m)
 end
-function posterior_mean_values(model::Model{typeof(demo_assume_dot_observe)})
+function posterior_mean(model::Model{typeof(demo_assume_dot_observe)})
     return (s=2.375, m=0.75)
 end
 
@@ -429,7 +429,7 @@ function example_values(
     s = rand(rng, product_distribution([InverseGamma(2, 3), InverseGamma(2, 3)]))
     return (s=s, m=rand(rng, MvNormal(zeros(2), Diagonal(s))))
 end
-function posterior_mean_values(model::Model{typeof(demo_assume_observe_literal)})
+function posterior_mean(model::Model{typeof(demo_assume_observe_literal)})
     vals = example_values(model)
     vals.s .= 2.375
     vals.m .= 0.75
@@ -476,7 +476,7 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean_values(model::Model{typeof(demo_dot_assume_observe_index_literal)})
+function posterior_mean(model::Model{typeof(demo_dot_assume_observe_index_literal)})
     vals = example_values(model)
     vals.s .= 2.375
     vals.m .= 0.75
@@ -512,7 +512,7 @@ function example_values(
     m = rand(rng, Normal(0, sqrt(s)))
     return (s=s, m=m)
 end
-function posterior_mean_values(model::Model{typeof(demo_assume_literal_dot_observe)})
+function posterior_mean(model::Model{typeof(demo_assume_literal_dot_observe)})
     return (s=2.375, m=0.75)
 end
 
@@ -564,7 +564,7 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean_values(
+function posterior_mean(
     model::Model{typeof(demo_assume_submodel_observe_index_literal)}
 )
     vals = example_values(model)
@@ -615,7 +615,7 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean_values(model::Model{typeof(demo_dot_assume_observe_submodel)})
+function posterior_mean(model::Model{typeof(demo_dot_assume_observe_submodel)})
     vals = example_values(model)
     vals.s .= 2.375
     vals.m .= 0.75
@@ -660,7 +660,7 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean_values(model::Model{typeof(demo_dot_assume_dot_observe_matrix)})
+function posterior_mean(model::Model{typeof(demo_dot_assume_dot_observe_matrix)})
     vals = example_values(model)
     vals.s .= 2.375
     vals.m .= 0.75
@@ -711,7 +711,7 @@ function example_values(
     m = rand(rng, MvNormal(zeros(n), Diagonal(vec(s))))
     return (s=s, m=m)
 end
-function posterior_mean_values(
+function posterior_mean(
     model::Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)}
 )
     vals = example_values(model)
@@ -758,7 +758,7 @@ Test that `sampler` produces correct marginal posterior means on each model in `
 In short, this method iterates through `models`, calls `AbstractMCMC.sample` on the
 `model` and `sampler` to produce a `chain`, and then checks `meanfunction(chain, vn)`
 for every (leaf) varname `vn` against the corresponding value returned by
-[`posterior_mean_values`](@ref) for each model.
+[`posterior_mean`](@ref) for each model.
 
 # Arguments
 - `meanfunction`: A callable which computes the mean of the marginal means from the
@@ -783,7 +783,7 @@ function test_sampler_on_models(
 )
     @testset "$(typeof(sampler)) on $(nameof(model))" for model in models
         chain = AbstractMCMC.sample(model, sampler, args...; kwargs...)
-        target_values = posterior_mean_values(model)
+        target_values = posterior_mean(model)
         for vn in varnames(model)
             # We want to compare elementwise which can be achieved by
             # extracting the leaves of the `VarName` and the corresponding value.

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -129,7 +129,7 @@ end
 
 Return a `NamedTuple` compatible with `varnames(model)` with values in support of `model`.
 
-Compatible means that a `varname` from `varnames(model)` can be used to extract the
+\"Compatible\" means that a `varname` from `varnames(model)` can be used to extract the
 corresponding value using the call `get(example_values(model), varname)`.
 """
 example_values(model::Model) = example_values(Random.GLOBAL_RNG, model)
@@ -140,7 +140,7 @@ example_values(model::Model) = example_values(Random.GLOBAL_RNG, model)
 Return a `NamedTuple` compatible with `varnames(model)` where the values represent
 the posterior mean under `model`.
 
-Compatible means that a `varname` from `varnames(model)` can be used to extract the
+\"Compatible\" means that a `varname` from `varnames(model)` can be used to extract the
 corresponding value using the call `get(posterior_mean_values(model), varname)`.
 """
 function posterior_mean_values end

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -190,7 +190,7 @@ function _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
 end
 
 @model function demo_dot_assume_dot_observe(
-    x=[1.5, 1.5], ::Type{TV}=Vector{Float64}
+    x=[1.5, 2.0], ::Type{TV}=Vector{Float64}
 ) where {TV}
     # `dot_assume` and `observe`
     s = TV(undef, length(x))
@@ -228,13 +228,18 @@ function example_values(
 end
 function posterior_mean(model::Model{typeof(demo_dot_assume_dot_observe)})
     vals = example_values(model)
-    vals.s .= 2.375
-    vals.m .= 0.75
+
+    vals.s[1] = 19 / 8
+    vals.m[1] = 3 / 4
+
+    vals.s[2] = 8 / 3
+    vals.m[2] = 1
+
     return vals
 end
 
 @model function demo_assume_index_observe(
-    x=[1.5, 1.5], ::Type{TV}=Vector{Float64}
+    x=[1.5, 2.0], ::Type{TV}=Vector{Float64}
 ) where {TV}
     # `assume` with indexing and `observe`
     s = TV(undef, length(x))
@@ -276,12 +281,17 @@ function example_values(
 end
 function posterior_mean(model::Model{typeof(demo_assume_index_observe)})
     vals = example_values(model)
-    vals.s .= 2.375
-    vals.m .= 0.75
+
+    vals.s[1] = 19 / 8
+    vals.m[1] = 3 / 4
+
+    vals.s[2] = 8 / 3
+    vals.m[2] = 1
+
     return vals
 end
 
-@model function demo_assume_multivariate_observe(x=[1.5, 1.5])
+@model function demo_assume_multivariate_observe(x=[1.5, 2.0])
     # Multivariate `assume` and `observe`
     s ~ product_distribution([InverseGamma(2, 3), InverseGamma(2, 3)])
     m ~ MvNormal(zero(x), Diagonal(s))
@@ -313,13 +323,18 @@ function example_values(
 end
 function posterior_mean(model::Model{typeof(demo_assume_multivariate_observe)})
     vals = example_values(model)
-    vals.s .= 2.375
-    vals.m .= 0.75
+
+    vals.s[1] = 19 / 8
+    vals.m[1] = 3 / 4
+
+    vals.s[2] = 8 / 3
+    vals.m[2] = 1
+
     return vals
 end
 
 @model function demo_dot_assume_observe_index(
-    x=[1.5, 1.5], ::Type{TV}=Vector{Float64}
+    x=[1.5, 2.0], ::Type{TV}=Vector{Float64}
 ) where {TV}
     # `dot_assume` and `observe` with indexing
     s = TV(undef, length(x))
@@ -359,14 +374,19 @@ function example_values(
 end
 function posterior_mean(model::Model{typeof(demo_dot_assume_observe_index)})
     vals = example_values(model)
-    vals.s .= 2.375
-    vals.m .= 0.75
+
+    vals.s[1] = 19 / 8
+    vals.m[1] = 3 / 4
+
+    vals.s[2] = 8 / 3
+    vals.m[2] = 1
+
     return vals
 end
 
 # Using vector of `length` 1 here so the posterior of `m` is the same
 # as the others.
-@model function demo_assume_dot_observe(x=[1.5])
+@model function demo_assume_dot_observe(x=[1.5, 2.0])
     # `assume` and `dot_observe`
     s ~ InverseGamma(2, 3)
     m ~ Normal(0, sqrt(s))
@@ -396,16 +416,16 @@ function example_values(
     return (s=s, m=m)
 end
 function posterior_mean(model::Model{typeof(demo_assume_dot_observe)})
-    return (s=2.375, m=0.75)
+    return (s=49 / 24, m=7 / 6)
 end
 
 @model function demo_assume_observe_literal()
     # `assume` and literal `observe`
     s ~ product_distribution([InverseGamma(2, 3), InverseGamma(2, 3)])
     m ~ MvNormal(zeros(2), Diagonal(s))
-    [1.5, 1.5] ~ MvNormal(m, Diagonal(s))
+    [1.5, 2.0] ~ MvNormal(m, Diagonal(s))
 
-    return (; s=s, m=m, x=[1.5, 1.5], logp=getlogp(__varinfo__))
+    return (; s=s, m=m, x=[1.5, 2.0], logp=getlogp(__varinfo__))
 end
 function logprior_true(model::Model{typeof(demo_assume_observe_literal)}, s, m)
     s_dist = product_distribution([InverseGamma(2, 3), InverseGamma(2, 3)])
@@ -413,7 +433,7 @@ function logprior_true(model::Model{typeof(demo_assume_observe_literal)}, s, m)
     return logpdf(s_dist, s) + logpdf(m_dist, m)
 end
 function loglikelihood_true(model::Model{typeof(demo_assume_observe_literal)}, s, m)
-    return logpdf(MvNormal(m, Diagonal(s)), [1.5, 1.5])
+    return logpdf(MvNormal(m, Diagonal(s)), [1.5, 2.0])
 end
 function logprior_true_with_logabsdet_jacobian(
     model::Model{typeof(demo_assume_observe_literal)}, s, m
@@ -431,8 +451,13 @@ function example_values(
 end
 function posterior_mean(model::Model{typeof(demo_assume_observe_literal)})
     vals = example_values(model)
-    vals.s .= 2.375
-    vals.m .= 0.75
+
+    vals.s[1] = 19 / 8
+    vals.m[1] = 3 / 4
+
+    vals.s[2] = 8 / 3
+    vals.m[2] = 1
+
     return vals
 end
 
@@ -443,11 +468,10 @@ end
     s .~ InverseGamma(2, 3)
     m .~ Normal.(0, sqrt.(s))
 
-    for i in eachindex(m)
-        1.5 ~ Normal(m[i], sqrt(s[i]))
-    end
+    1.5 ~ Normal(m[1], sqrt(s[1]))
+    2.0 ~ Normal(m[2], sqrt(s[2]))
 
-    return (; s=s, m=m, x=fill(1.5, length(m)), logp=getlogp(__varinfo__))
+    return (; s=s, m=m, x=[1.5, 2.0], logp=getlogp(__varinfo__))
 end
 function logprior_true(model::Model{typeof(demo_dot_assume_observe_index_literal)}, s, m)
     return loglikelihood(InverseGamma(2, 3), s) + sum(logpdf.(Normal.(0, sqrt.(s)), m))
@@ -455,7 +479,7 @@ end
 function loglikelihood_true(
     model::Model{typeof(demo_dot_assume_observe_index_literal)}, s, m
 )
-    return sum(logpdf.(Normal.(m, sqrt.(s)), fill(1.5, length(m))))
+    return sum(logpdf.(Normal.(m, sqrt.(s)), [1.5, 2.0]))
 end
 function logprior_true_with_logabsdet_jacobian(
     model::Model{typeof(demo_dot_assume_observe_index_literal)}, s, m
@@ -478,8 +502,13 @@ function example_values(
 end
 function posterior_mean(model::Model{typeof(demo_dot_assume_observe_index_literal)})
     vals = example_values(model)
-    vals.s .= 2.375
-    vals.m .= 0.75
+
+    vals.s[1] = 19 / 8
+    vals.m[1] = 3 / 4
+
+    vals.s[2] = 8 / 3
+    vals.m[2] = 1
+
     return vals
 end
 
@@ -487,15 +516,15 @@ end
     # `assume` and literal `dot_observe`
     s ~ InverseGamma(2, 3)
     m ~ Normal(0, sqrt(s))
-    [1.5] .~ Normal(m, sqrt(s))
+    [1.5, 2.0] .~ Normal(m, sqrt(s))
 
-    return (; s=s, m=m, x=[1.5], logp=getlogp(__varinfo__))
+    return (; s=s, m=m, x=[1.5, 2.0], logp=getlogp(__varinfo__))
 end
 function logprior_true(model::Model{typeof(demo_assume_literal_dot_observe)}, s, m)
     return logpdf(InverseGamma(2, 3), s) + logpdf(Normal(0, sqrt(s)), m)
 end
 function loglikelihood_true(model::Model{typeof(demo_assume_literal_dot_observe)}, s, m)
-    return logpdf(Normal(m, sqrt(s)), 1.5)
+    return logpdf(Normal(m, sqrt(s)), [1.5, 2.0])
 end
 function logprior_true_with_logabsdet_jacobian(
     model::Model{typeof(demo_assume_literal_dot_observe)}, s, m
@@ -513,7 +542,7 @@ function example_values(
     return (s=s, m=m)
 end
 function posterior_mean(model::Model{typeof(demo_assume_literal_dot_observe)})
-    return (s=2.375, m=0.75)
+    return (s=49 / 24, m=7 / 6)
 end
 
 @model function _prior_dot_assume(::Type{TV}=Vector{Float64}) where {TV}
@@ -528,11 +557,10 @@ end
 @model function demo_assume_submodel_observe_index_literal()
     # Submodel prior
     @submodel s, m = _prior_dot_assume()
-    for i in eachindex(m, s)
-        1.5 ~ Normal(m[i], sqrt(s[i]))
-    end
+    1.5 ~ Normal(m[1], sqrt(s[1]))
+    2.0 ~ Normal(m[2], sqrt(s[2]))
 
-    return (; s=s, m=m, x=[1.5, 1.5], logp=getlogp(__varinfo__))
+    return (; s=s, m=m, x=[1.5, 2.0], logp=getlogp(__varinfo__))
 end
 function logprior_true(
     model::Model{typeof(demo_assume_submodel_observe_index_literal)}, s, m
@@ -542,7 +570,7 @@ end
 function loglikelihood_true(
     model::Model{typeof(demo_assume_submodel_observe_index_literal)}, s, m
 )
-    return sum(logpdf.(Normal.(m, sqrt.(s)), 1.5))
+    return sum(logpdf.(Normal.(m, sqrt.(s)), [1.5, 2.0]))
 end
 function logprior_true_with_logabsdet_jacobian(
     model::Model{typeof(demo_assume_submodel_observe_index_literal)}, s, m
@@ -564,12 +592,15 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean(
-    model::Model{typeof(demo_assume_submodel_observe_index_literal)}
-)
+function posterior_mean(model::Model{typeof(demo_assume_submodel_observe_index_literal)})
     vals = example_values(model)
-    vals.s .= 2.375
-    vals.m .= 0.75
+
+    vals.s[1] = 19 / 8
+    vals.m[1] = 3 / 4
+
+    vals.s[2] = 8 / 3
+    vals.m[2] = 1
+
     return vals
 end
 
@@ -578,7 +609,7 @@ end
 end
 
 @model function demo_dot_assume_observe_submodel(
-    x=[1.5, 1.5], ::Type{TV}=Vector{Float64}
+    x=[1.5, 2.0], ::Type{TV}=Vector{Float64}
 ) where {TV}
     s = TV(undef, length(x))
     s .~ InverseGamma(2, 3)
@@ -617,13 +648,18 @@ function example_values(
 end
 function posterior_mean(model::Model{typeof(demo_dot_assume_observe_submodel)})
     vals = example_values(model)
-    vals.s .= 2.375
-    vals.m .= 0.75
+
+    vals.s[1] = 19 / 8
+    vals.m[1] = 3 / 4
+
+    vals.s[2] = 8 / 3
+    vals.m[2] = 1
+
     return vals
 end
 
 @model function demo_dot_assume_dot_observe_matrix(
-    x=fill(1.5, 2, 1), ::Type{TV}=Vector{Float64}
+    x=transpose([1.5 2.0;]), ::Type{TV}=Vector{Float64}
 ) where {TV}
     s = TV(undef, length(x))
     s .~ InverseGamma(2, 3)
@@ -662,13 +698,18 @@ function example_values(
 end
 function posterior_mean(model::Model{typeof(demo_dot_assume_dot_observe_matrix)})
     vals = example_values(model)
-    vals.s .= 2.375
-    vals.m .= 0.75
+
+    vals.s[1] = 19 / 8
+    vals.m[1] = 3 / 4
+
+    vals.s[2] = 8 / 3
+    vals.m[2] = 1
+
     return vals
 end
 
 @model function demo_dot_assume_matrix_dot_observe_matrix(
-    x=fill(1.5, 2, 1), ::Type{TV}=Array{Float64}
+    x=transpose([1.5 2.0;]), ::Type{TV}=Array{Float64}
 ) where {TV}
     n = length(x)
     d = length(x) ÷ 2
@@ -711,12 +752,15 @@ function example_values(
     m = rand(rng, MvNormal(zeros(n), Diagonal(vec(s))))
     return (s=s, m=m)
 end
-function posterior_mean(
-    model::Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)}
-)
+function posterior_mean(model::Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)})
     vals = example_values(model)
-    vals.s .= 2.375
-    vals.m .= 0.75
+
+    vals.s[1] = 19 / 8
+    vals.m[1] = 3 / 4
+
+    vals.s[2] = 8 / 3
+    vals.m[2] = 1
+
     return vals
 end
 
@@ -727,13 +771,32 @@ the generative process
     s ~ InverseGamma(2, 3)
     m ~ Normal(0, √s)
     1.5 ~ Normal(m, √s)
+    2.0 ~ Normal(m, √s)
 
-_or_ a product of such distributions.
+or by
 
-The posterior for both `s` and `m` here is known in closed form. In particular,
+    s[1] ~ InverseGamma(2, 3)
+    s[2] ~ InverseGamma(2, 3)
+    m[1] ~ Normal(0, √s)
+    m[2] ~ Normal(0, √s)
+    1.5 ~ Normal(m[1], √s[1])
+    2.0 ~ Normal(m[2], √s[2])
 
-    mean(s) == 19 / 8
-    mean(m) == 3 / 4
+These are examples of a Normal-InverseGamma conjugate prior with Normal likelihood,
+for which the posterior is known in closed form.
+
+In particular, for the univariate model (the former one):
+
+    mean(s) == 49 / 24
+    mean(m) == 7 / 6
+
+And for the multivariate one (the latter one):
+
+    mean(s[1]) == 19 / 8
+    mean(m[1]) == 3 / 4
+    mean(s[2]) == 8 / 3
+    mean(m[2]) == 1
+
 """
 const DEMO_MODELS = (
     demo_dot_assume_dot_observe(),

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -138,8 +138,15 @@ function logprior_true_with_logabsdet_jacobian(
     return (m=m, x=x_unconstrained), logprior_true(model, m, x) - Δlogp
 end
 
-# A collection of models for which the mean-of-means for the posterior should
-# be same.
+# A collection of models for which the posterior should be "similar".
+# Some utility methods for these.
+function _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
+    b = Bijectors.bijector(InverseGamma(2, 3))
+    s_unconstrained = b.(s)
+    Δlogp = sum(Base.Fix1(Bijectors.logabsdetjac, b).(s))
+    return (s=s_unconstrained, m=m), logprior_true(model, s, m) - Δlogp
+end
+
 @model function demo_dot_assume_dot_observe(
     x=[1.5, 1.5], ::Type{TV}=Vector{Float64}
 ) where {TV}
@@ -157,6 +164,11 @@ function logprior_true(model::Model{typeof(demo_dot_assume_dot_observe)}, s, m)
 end
 function loglikelihood_true(model::Model{typeof(demo_dot_assume_dot_observe)}, s, m)
     return loglikelihood(MvNormal(m, Diagonal(s)), model.args.x)
+end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_dot_assume_dot_observe)}, s, m
+)
+    return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
 end
 function Base.keys(model::Model{typeof(demo_dot_assume_dot_observe)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
@@ -201,6 +213,11 @@ end
 function loglikelihood_true(model::Model{typeof(demo_assume_index_observe)}, s, m)
     return logpdf(MvNormal(m, Diagonal(s)), model.args.x)
 end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_assume_index_observe)}, s, m
+)
+    return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
+end
 function Base.keys(model::Model{typeof(demo_assume_index_observe)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
 end
@@ -238,6 +255,11 @@ end
 function loglikelihood_true(model::Model{typeof(demo_assume_multivariate_observe)}, s, m)
     return logpdf(MvNormal(m, Diagonal(s)), model.args.x)
 end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_assume_multivariate_observe)}, s, m
+)
+    return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
+end
 function Base.keys(model::Model{typeof(demo_assume_multivariate_observe)})
     return [@varname(s), @varname(m)]
 end
@@ -273,6 +295,11 @@ function logprior_true(model::Model{typeof(demo_dot_assume_observe_index)}, s, m
 end
 function loglikelihood_true(model::Model{typeof(demo_dot_assume_observe_index)}, s, m)
     return sum(logpdf.(Normal.(m, sqrt.(s)), model.args.x))
+end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_dot_assume_observe_index)}, s, m
+)
+    return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
 end
 function Base.keys(model::Model{typeof(demo_dot_assume_observe_index)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
@@ -311,6 +338,11 @@ end
 function loglikelihood_true(model::Model{typeof(demo_assume_dot_observe)}, s, m)
     return sum(logpdf.(Normal.(m, sqrt.(s)), model.args.x))
 end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_assume_dot_observe)}, s, m
+)
+    return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
+end
 function Base.keys(model::Model{typeof(demo_assume_dot_observe)})
     return [@varname(s), @varname(m)]
 end
@@ -340,6 +372,11 @@ function logprior_true(model::Model{typeof(demo_assume_observe_literal)}, s, m)
 end
 function loglikelihood_true(model::Model{typeof(demo_assume_observe_literal)}, s, m)
     return logpdf(MvNormal(m, Diagonal(s)), [1.5, 1.5])
+end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_assume_observe_literal)}, s, m
+)
+    return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
 end
 function Base.keys(model::Model{typeof(demo_assume_observe_literal)})
     return [@varname(s), @varname(m)]
@@ -378,6 +415,11 @@ function loglikelihood_true(
 )
     return sum(logpdf.(Normal.(m, sqrt.(s)), fill(1.5, length(m))))
 end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_dot_assume_observe_index_literal)}, s, m
+)
+    return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
+end
 function Base.keys(model::Model{typeof(demo_dot_assume_observe_index_literal)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
 end
@@ -412,6 +454,11 @@ function logprior_true(model::Model{typeof(demo_assume_literal_dot_observe)}, s,
 end
 function loglikelihood_true(model::Model{typeof(demo_assume_literal_dot_observe)}, s, m)
     return logpdf(Normal(m, sqrt(s)), 1.5)
+end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_assume_literal_dot_observe)}, s, m
+)
+    return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
 end
 function Base.keys(model::Model{typeof(demo_assume_literal_dot_observe)})
     return [@varname(s), @varname(m)]
@@ -454,6 +501,11 @@ function loglikelihood_true(
     model::Model{typeof(demo_assume_submodel_observe_index_literal)}, s, m
 )
     return sum(logpdf.(Normal.(m, sqrt.(s)), 1.5))
+end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_assume_submodel_observe_index_literal)}, s, m
+)
+    return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
 end
 function Base.keys(model::Model{typeof(demo_assume_submodel_observe_index_literal)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
@@ -502,6 +554,11 @@ end
 function loglikelihood_true(model::Model{typeof(demo_dot_assume_observe_submodel)}, s, m)
     return logpdf(MvNormal(m, Diagonal(s)), model.args.x)
 end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_dot_assume_observe_submodel)}, s, m
+)
+    return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
+end
 function Base.keys(model::Model{typeof(demo_dot_assume_observe_submodel)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
 end
@@ -541,6 +598,11 @@ function logprior_true(model::Model{typeof(demo_dot_assume_dot_observe_matrix)},
 end
 function loglikelihood_true(model::Model{typeof(demo_dot_assume_dot_observe_matrix)}, s, m)
     return sum(logpdf.(Normal.(m, sqrt.(s)), model.args.x))
+end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_dot_assume_dot_observe_matrix)}, s, m
+)
+    return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
 end
 function Base.keys(model::Model{typeof(demo_dot_assume_dot_observe_matrix)})
     return [@varname(s[1]), @varname(s[2]), @varname(m[1]), @varname(m[2])]
@@ -586,6 +648,11 @@ function loglikelihood_true(
     model::Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)}, s, m
 )
     return loglikelihood(MvNormal(vec(m), Diagonal(vec(s))), model.args.x)
+end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)}, s, m
+)
+    return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
 end
 function Base.keys(model::Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)})
     return [@varname(s[:, 1]), @varname(s[:, 2]), @varname(m[:, 1]), @varname(m[:, 2])]

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -662,7 +662,6 @@ const DemoModels = Union{
     Model{typeof(demo_dot_assume_dot_observe_matrix)},
     Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)},
 }
-_observations(model::DemoModels) = [1.5, 2.0]
 
 const UnivariateAssumeDemoModels = Union{
     Model{typeof(demo_assume_dot_observe)},

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -657,12 +657,12 @@ marginal_mean_of_samples(chain, varname) = mean(Array(chain[Symbol(varname)]))
 Test that `sampler` produces correct marginal posterior means on each model in `models`.
 
 In short, this method iterates through `models`, calls `AbstractMCMC.sample` on the
-`model` and `sampler` to produce a `chain`, and then checks [`marginal_mean_of_samples(chain, vn)`](@ref)
+`model` and `sampler` to produce a `chain`, and then checks `marginal_mean_of_samples(chain, vn)`
 for every (leaf) varname `vn` against the corresponding value returned by
 [`posterior_mean`](@ref) for each model.
 
 To change how comparison is done for a particular `chain` type, one can overload
-[`marginal_mean_of_samples(chain, vn)`](@ref) for the corresponding type.
+[`marginal_mean_of_samples`](@ref) for the corresponding type.
 
 # Arguments
 - `models`: A collection of instaces of [`DynamicPPL.Model`](@ref) to test on.

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -226,17 +226,6 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean(model::Model{typeof(demo_dot_assume_dot_observe)})
-    vals = example_values(model)
-
-    vals.s[1] = 19 / 8
-    vals.m[1] = 3 / 4
-
-    vals.s[2] = 8 / 3
-    vals.m[2] = 1
-
-    return vals
-end
 
 @model function demo_assume_index_observe(
     x=[1.5, 2.0], ::Type{TV}=Vector{Float64}
@@ -279,17 +268,6 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean(model::Model{typeof(demo_assume_index_observe)})
-    vals = example_values(model)
-
-    vals.s[1] = 19 / 8
-    vals.m[1] = 3 / 4
-
-    vals.s[2] = 8 / 3
-    vals.m[2] = 1
-
-    return vals
-end
 
 @model function demo_assume_multivariate_observe(x=[1.5, 2.0])
     # Multivariate `assume` and `observe`
@@ -320,17 +298,6 @@ function example_values(
 )
     s = rand(rng, product_distribution([InverseGamma(2, 3), InverseGamma(2, 3)]))
     return (s=s, m=rand(rng, MvNormal(zero(model.args.x), Diagonal(s))))
-end
-function posterior_mean(model::Model{typeof(demo_assume_multivariate_observe)})
-    vals = example_values(model)
-
-    vals.s[1] = 19 / 8
-    vals.m[1] = 3 / 4
-
-    vals.s[2] = 8 / 3
-    vals.m[2] = 1
-
-    return vals
 end
 
 @model function demo_dot_assume_observe_index(
@@ -372,17 +339,6 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean(model::Model{typeof(demo_dot_assume_observe_index)})
-    vals = example_values(model)
-
-    vals.s[1] = 19 / 8
-    vals.m[1] = 3 / 4
-
-    vals.s[2] = 8 / 3
-    vals.m[2] = 1
-
-    return vals
-end
 
 # Using vector of `length` 1 here so the posterior of `m` is the same
 # as the others.
@@ -415,9 +371,6 @@ function example_values(
     m = rand(rng, Normal(0, sqrt(s)))
     return (s=s, m=m)
 end
-function posterior_mean(model::Model{typeof(demo_assume_dot_observe)})
-    return (s=49 / 24, m=7 / 6)
-end
 
 @model function demo_assume_observe_literal()
     # `assume` and literal `observe`
@@ -448,17 +401,6 @@ function example_values(
 )
     s = rand(rng, product_distribution([InverseGamma(2, 3), InverseGamma(2, 3)]))
     return (s=s, m=rand(rng, MvNormal(zeros(2), Diagonal(s))))
-end
-function posterior_mean(model::Model{typeof(demo_assume_observe_literal)})
-    vals = example_values(model)
-
-    vals.s[1] = 19 / 8
-    vals.m[1] = 3 / 4
-
-    vals.s[2] = 8 / 3
-    vals.m[2] = 1
-
-    return vals
 end
 
 @model function demo_dot_assume_observe_index_literal(::Type{TV}=Vector{Float64}) where {TV}
@@ -500,17 +442,6 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean(model::Model{typeof(demo_dot_assume_observe_index_literal)})
-    vals = example_values(model)
-
-    vals.s[1] = 19 / 8
-    vals.m[1] = 3 / 4
-
-    vals.s[2] = 8 / 3
-    vals.m[2] = 1
-
-    return vals
-end
 
 @model function demo_assume_literal_dot_observe()
     # `assume` and literal `dot_observe`
@@ -540,9 +471,6 @@ function example_values(
     s = rand(rng, InverseGamma(2, 3))
     m = rand(rng, Normal(0, sqrt(s)))
     return (s=s, m=m)
-end
-function posterior_mean(model::Model{typeof(demo_assume_literal_dot_observe)})
-    return (s=49 / 24, m=7 / 6)
 end
 
 @model function _prior_dot_assume(::Type{TV}=Vector{Float64}) where {TV}
@@ -592,17 +520,6 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean(model::Model{typeof(demo_assume_submodel_observe_index_literal)})
-    vals = example_values(model)
-
-    vals.s[1] = 19 / 8
-    vals.m[1] = 3 / 4
-
-    vals.s[2] = 8 / 3
-    vals.m[2] = 1
-
-    return vals
-end
 
 @model function _likelihood_mltivariate_observe(s, m, x)
     return x ~ MvNormal(m, Diagonal(s))
@@ -646,17 +563,6 @@ function example_values(
     end
     return (s=s, m=m)
 end
-function posterior_mean(model::Model{typeof(demo_dot_assume_observe_submodel)})
-    vals = example_values(model)
-
-    vals.s[1] = 19 / 8
-    vals.m[1] = 3 / 4
-
-    vals.s[2] = 8 / 3
-    vals.m[2] = 1
-
-    return vals
-end
 
 @model function demo_dot_assume_dot_observe_matrix(
     x=transpose([1.5 2.0;]), ::Type{TV}=Vector{Float64}
@@ -695,17 +601,6 @@ function example_values(
         m[i] = rand(rng, Normal(0, sqrt(s[i])))
     end
     return (s=s, m=m)
-end
-function posterior_mean(model::Model{typeof(demo_dot_assume_dot_observe_matrix)})
-    vals = example_values(model)
-
-    vals.s[1] = 19 / 8
-    vals.m[1] = 3 / 4
-
-    vals.s[2] = 8 / 3
-    vals.m[2] = 1
-
-    return vals
 end
 
 @model function demo_dot_assume_matrix_dot_observe_matrix(
@@ -752,7 +647,45 @@ function example_values(
     m = rand(rng, MvNormal(zeros(n), Diagonal(vec(s))))
     return (s=s, m=m)
 end
-function posterior_mean(model::Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)})
+
+const DemoModels = Union{
+    Model{typeof(demo_dot_assume_dot_observe)},
+    Model{typeof(demo_assume_index_observe)},
+    Model{typeof(demo_assume_multivariate_observe)},
+    Model{typeof(demo_dot_assume_observe_index)},
+    Model{typeof(demo_assume_dot_observe)},
+    Model{typeof(demo_assume_literal_dot_observe)},
+    Model{typeof(demo_assume_observe_literal)},
+    Model{typeof(demo_dot_assume_observe_index_literal)},
+    Model{typeof(demo_assume_submodel_observe_index_literal)},
+    Model{typeof(demo_dot_assume_observe_submodel)},
+    Model{typeof(demo_dot_assume_dot_observe_matrix)},
+    Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)},
+}
+_observations(model::DemoModels) = [1.5, 2.0]
+
+const UnivariateAssumeDemoModels = Union{
+    Model{typeof(demo_assume_dot_observe)},
+    Model{typeof(demo_assume_literal_dot_observe)},
+}
+function posterior_mean(model::UnivariateAssumeDemoModels)
+    return (s=49 / 24, m=7 / 6)
+end
+
+const MultivariateAssumeDemoModels = Union{
+    Model{typeof(demo_dot_assume_dot_observe)},
+    Model{typeof(demo_assume_index_observe)},
+    Model{typeof(demo_assume_multivariate_observe)},
+    Model{typeof(demo_dot_assume_observe_index)},
+    Model{typeof(demo_assume_observe_literal)},
+    Model{typeof(demo_dot_assume_observe_index_literal)},
+    Model{typeof(demo_assume_submodel_observe_index_literal)},
+    Model{typeof(demo_dot_assume_observe_submodel)},
+    Model{typeof(demo_dot_assume_dot_observe_matrix)},
+    Model{typeof(demo_dot_assume_matrix_dot_observe_matrix)},
+}
+function posterior_mean(model::MultivariateAssumeDemoModels)
+    # Get some containers to fill.
     vals = example_values(model)
 
     vals.s[1] = 19 / 8

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -720,6 +720,21 @@ function posterior_mean_values(
     return vals
 end
 
+"""
+A collection of models corresponding to the posterior distribution defined by
+the generative process
+
+    s ~ InverseGamma(2, 3)
+    m ~ Normal(0, √s)
+    1.5 ~ Normal(m, √s)
+
+_or_ a product of such distributions.
+
+The posterior for both `s` and `m` here is known in closed form. In particular,
+
+    mean(s) == 19 / 8
+    mean(m) == 3 / 4
+"""
 const DEMO_MODELS = (
     demo_dot_assume_dot_observe(),
     demo_assume_index_observe(),

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -34,7 +34,7 @@ end
 """
     logprior_true(model, args...)
 
-Return the `logprior` of `model` for `args...`.
+Return the `logprior` of `model` for `args`.
 
 This should generally be implemented by hand for every specific `model`.
 
@@ -45,7 +45,7 @@ function logprior_true end
 """
     loglikelihood_true(model, args...)
 
-Return the `loglikelihood` of `model` for `args...`.
+Return the `loglikelihood` of `model` for `args`.
 
 This should generally be implemented by hand for every specific `model`.
 
@@ -56,7 +56,7 @@ function loglikelihood_true end
 """
     logjoint_true(model, args...)
 
-Return the `logjoint` of `model` for `args...`.
+Return the `logjoint` of `model` for `args`.
 
 Defaults to `logprior_true(model, args...) + loglikelihood_true(model, args..)`.
 
@@ -77,7 +77,7 @@ end
 """
     logjoint_true_with_logabsdet_jacobian(model::Model, args...)
 
-Return a tuple `(args_unconstrained, logjoint)` of `model` for `args...`.
+Return a tuple `(args_unconstrained, logjoint)` of `model` for `args`.
 
 Unlike [`logjoint_true`](@ref), the returned logjoint computation includes the
 log-absdet-jacobian adjustment, thus computing logjoint for the unconstrained variables.

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -129,8 +129,8 @@ end
 
 Return a `NamedTuple` compatible with `varnames(model)` with values in support of `model`.
 
-\"Compatible\" means that a `varname` from `varnames(model)` can be used to extract the
-corresponding value using the call `get(example_values(model), varname)`.
+"Compatible" means that a `varname` from `varnames(model)` can be used to extract the
+corresponding value using `get`, e.g. `get(example_values(model), varname)`.
 """
 example_values(model::Model) = example_values(Random.GLOBAL_RNG, model)
 
@@ -140,8 +140,8 @@ example_values(model::Model) = example_values(Random.GLOBAL_RNG, model)
 Return a `NamedTuple` compatible with `varnames(model)` where the values represent
 the posterior mean under `model`.
 
-\"Compatible\" means that a `varname` from `varnames(model)` can be used to extract the
-corresponding value using the call `get(posterior_mean_values(model), varname)`.
+"Compatible" means that a `varname` from `varnames(model)` can be used to extract the
+corresponding value using `get`, e.g. `get(posterior_mean_values(model), varname)`.
 """
 function posterior_mean_values end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -582,12 +582,10 @@ function posterior_mean(model::MultivariateAssumeDemoModels)
 
     return vals
 end
-function example_values(
-    rng::Random.AbstractRNG, model::MultivariateAssumeDemoModels
-)
+function example_values(rng::Random.AbstractRNG, model::MultivariateAssumeDemoModels)
     # Get template values from `model`.
     retval = model(rng)
-    vals = (s = retval.s, m = retval.m)
+    vals = (s=retval.s, m=retval.m)
     # Fill containers with realizations from prior.
     for i in LinearIndices(vals.s)
         vals.s[i] = rand(rng, InverseGamma(2, 3))

--- a/test/contexts.jl
+++ b/test/contexts.jl
@@ -57,7 +57,6 @@ function remove_prefix(vn::VarName)
     )
 end
 
-
 @testset "contexts.jl" begin
     child_contexts = [DefaultContext(), PriorContext(), LikelihoodContext()]
 

--- a/test/contexts.jl
+++ b/test/contexts.jl
@@ -165,7 +165,8 @@ end
                     vn_without_prefix = remove_prefix(vn)
 
                     # Let's check elementwise.
-                    for vn_child in DynamicPPL.TestUtils.varnames(vn_without_prefix, val)
+                    for vn_child in
+                        DynamicPPL.TestUtils.varname_leaves(vn_without_prefix, val)
                         if get(val, getlens(vn_child)) === missing
                             @test contextual_isassumption(context, vn_child)
                         else
@@ -197,7 +198,8 @@ end
                     # `ConditionContext` with the conditioned variable.
                     vn_without_prefix = remove_prefix(vn)
 
-                    for vn_child in DynamicPPL.TestUtils.varnames(vn_without_prefix, val)
+                    for vn_child in
+                        DynamicPPL.TestUtils.varname_leaves(vn_without_prefix, val)
                         # `vn_child` should be in `context`.
                         @test hasvalue_nested(context, vn_child)
                         # Value should be the same as extracted above.

--- a/test/contexts.jl
+++ b/test/contexts.jl
@@ -57,25 +57,6 @@ function remove_prefix(vn::VarName)
     )
 end
 
-"""
-    varnames(vn::VarName, val)
-
-Return iterator over all varnames that are represented by `vn` on `val`,
-e.g. `varnames(@varname(x), rand(2))` results in an iterator over `[@varname(x[1]), @varname(x[2])]`.
-"""
-varnames(vn::VarName, val::Real) = [vn]
-function varnames(vn::VarName, val::AbstractArray{<:Union{Real,Missing}})
-    return (
-        VarName(vn, getlens(vn) ∘ Setfield.IndexLens(Tuple(I))) for
-        I in CartesianIndices(val)
-    )
-end
-function varnames(vn::VarName, val::AbstractArray)
-    return Iterators.flatten(
-        varnames(VarName(vn, getlens(vn) ∘ Setfield.IndexLens(Tuple(I))), val[I]) for
-        I in CartesianIndices(val)
-    )
-end
 
 @testset "contexts.jl" begin
     child_contexts = [DefaultContext(), PriorContext(), LikelihoodContext()]
@@ -185,7 +166,7 @@ end
                     vn_without_prefix = remove_prefix(vn)
 
                     # Let's check elementwise.
-                    for vn_child in varnames(vn_without_prefix, val)
+                    for vn_child in DynamicPPL.TestUtils.varnames(vn_without_prefix, val)
                         if get(val, getlens(vn_child)) === missing
                             @test contextual_isassumption(context, vn_child)
                         else
@@ -217,7 +198,7 @@ end
                     # `ConditionContext` with the conditioned variable.
                     vn_without_prefix = remove_prefix(vn)
 
-                    for vn_child in varnames(vn_without_prefix, val)
+                    for vn_child in DynamicPPL.TestUtils.varnames(vn_without_prefix, val)
                         # `vn_child` should be in `context`.
                         @test hasvalue_nested(context, vn_child)
                         # Value should be the same as extracted above.

--- a/test/loglikelihoods.jl
+++ b/test/loglikelihoods.jl
@@ -1,6 +1,6 @@
 @testset "loglikelihoods.jl" begin
     @testset "$(m.f)" for m in DynamicPPL.TestUtils.DEMO_MODELS
-        example_values = DynamicPPL.TestUtils.example_values(m)
+        example_values = rand(NamedTuple, m)
 
         # Instantiate a `VarInfo` with the example values.
         vi = VarInfo(m)

--- a/test/loglikelihoods.jl
+++ b/test/loglikelihoods.jl
@@ -1,15 +1,14 @@
 @testset "loglikelihoods.jl" begin
     @testset "$(m.f)" for m in DynamicPPL.TestUtils.DEMO_MODELS
-        vi = VarInfo(m)
+        example_values = DynamicPPL.TestUtils.example_values(m)
 
+        # Instantiate a `VarInfo` with the example values.
+        vi = VarInfo(m)
         for vn in DynamicPPL.TestUtils.varnames(m)
-            if vi[vn] isa Real
-                vi = DynamicPPL.setindex!!(vi, 1.0, vn)
-            else
-                vi = DynamicPPL.setindex!!(vi, ones(size(vi[vn])), vn)
-            end
+            vi = DynamicPPL.setindex!!(vi, get(example_values, vn), vn)
         end
 
+        # Compute the pointwise loglikelihoods.
         lls = pointwise_loglikelihoods(m, vi)
 
         if isempty(lls)
@@ -17,14 +16,9 @@
             continue
         end
 
-        loglikelihood = if length(keys(lls)) == 1 && length(m.args.x) == 1
-            # Only have one observation, so we need to double it
-            # for comparison with other models.
-            2 * sum(lls[first(keys(lls))])
-        else
-            sum(sum, values(lls))
-        end
+        loglikelihood = sum(sum, values(lls))
+        loglikelihood_true = DynamicPPL.TestUtils.loglikelihood_true(m, example_values...)
 
-        @test loglikelihood ≈ -324.45158270528947
+        @test loglikelihood ≈ loglikelihood_true
     end
 end

--- a/test/simple_varinfo.jl
+++ b/test/simple_varinfo.jl
@@ -80,7 +80,7 @@
             _, svi_new = DynamicPPL.evaluate!!(model, svi, SamplingContext())
 
             # Realization for `m` should be different wp. 1.
-            for vn in keys(model)
+            for vn in DynamicPPL.TestUtils.varnames(model)
                 @test svi_new[vn] != get(retval, vn)
             end
 
@@ -100,7 +100,7 @@
 
             # Update the realizations in `svi_new`.
             svi_eval = svi_new
-            for vn in keys(model)
+            for vn in DynamicPPL.TestUtils.varnames(model)
                 svi_eval = DynamicPPL.setindex!!(svi_eval, get(values_eval, vn), vn)
             end
 
@@ -111,7 +111,7 @@
             logπ = logjoint(model, svi_eval)
 
             # Values should not have changed.
-            for vn in keys(model)
+            for vn in DynamicPPL.TestUtils.varnames(model)
                 @test svi_eval[vn] == get(values_eval, vn)
             end
 
@@ -141,7 +141,7 @@
             )
 
             # Realizations from model should all be equal to the unconstrained realization.
-            for vn in keys(model)
+            for vn in DynamicPPL.TestUtils.varnames(model)
                 @test get(retval_unconstrained, vn) ≈ svi[vn] rtol = 1e-6
             end
 

--- a/test/simple_varinfo.jl
+++ b/test/simple_varinfo.jl
@@ -62,7 +62,7 @@
                                                      DynamicPPL.TestUtils.DEMO_MODELS
         # We might need to pre-allocate for the variable `m`, so we need
         # to see whether this is the case.
-        svi_nt = SimpleVarInfo(DynamicPPL.TestUtils.example_values(model))
+        svi_nt = SimpleVarInfo(rand(NamedTuple, model))
         svi_dict = SimpleVarInfo(VarInfo(model), Dict)
 
         @testset "$(nameof(typeof(DynamicPPL.values_as(svi))))" for svi in (
@@ -88,7 +88,7 @@
             @test getlogp(svi_new) != 0
 
             ### Evaluation ###
-            values_eval_constrained = DynamicPPL.TestUtils.example_values(model)
+            values_eval_constrained = rand(NamedTuple, model)
             if DynamicPPL.istrans(svi)
                 _values_prior, logpri_true = DynamicPPL.TestUtils.logprior_true_with_logabsdet_jacobian(
                     model, values_eval_constrained...

--- a/test/simple_varinfo.jl
+++ b/test/simple_varinfo.jl
@@ -125,8 +125,6 @@
             logpri = logprior(model, svi_eval)
             loglik = loglikelihood(model, svi_eval)
 
-            retval_svi, _ = DynamicPPL.evaluate!!(model, svi, LikelihoodContext())
-
             # Values should not have changed.
             for vn in DynamicPPL.TestUtils.varnames(model)
                 @test svi_eval[vn] == get(values_eval, vn)

--- a/test/simple_varinfo.jl
+++ b/test/simple_varinfo.jl
@@ -111,8 +111,10 @@
             end
 
             # Compute the true `logjoint` and compare.
-            logπ_true = DynamicPPL.TestUtils.logjoint_true(model, values_eval...)
-            @test logπ ≈ logπ_true
+            if !DynamicPPL.istrans(svi)
+                logπ_true = DynamicPPL.TestUtils.logjoint_true(model, values_eval...)
+                @test logπ ≈ logπ_true
+            end
         end
     end
 

--- a/test/simple_varinfo.jl
+++ b/test/simple_varinfo.jl
@@ -90,12 +90,15 @@
             ### Evaluation ###
             values_eval_constrained = DynamicPPL.TestUtils.example_values(model)
             if DynamicPPL.istrans(svi)
-                _, logpri_true = DynamicPPL.TestUtils.logprior_true_with_logabsdet_jacobian(
+                _values_prior, logpri_true = DynamicPPL.TestUtils.logprior_true_with_logabsdet_jacobian(
                     model, values_eval_constrained...
                 )
                 values_eval, logπ_true = DynamicPPL.TestUtils.logjoint_true_with_logabsdet_jacobian(
                     model, values_eval_constrained...
                 )
+                # Make sure that these two computation paths provide the same
+                # transformed values.
+                @test values_eval == _values_prior
             else
                 logpri_true = DynamicPPL.TestUtils.logprior_true(
                     model, values_eval_constrained...


### PR DESCRIPTION
When working on #360 I realized there were quite a few features we're not covering with the models provided in `DynamicPPL.TestUtils`, e.g. `link` and `invlink` are not covered since the current models do not include any constrained variables. This PR adds some additional methods in `DynamicPPL.TestUtils` which ought to be implemented for the models and a more general `test_sampler_on_models`.

EDIT: No need to review this until we've merged #360 but I wanted some of these tests for `SimpleVarInfo` to make sure it works properly.