### PR TITLE
Drop unnecessary `depwarn` + fix Turing tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.21.2"
+version = "0.21.3"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -759,10 +759,6 @@ function _link!(vi::UntypedVarInfo, spl::Sampler)
     end
 end
 function _link!(vi::TypedVarInfo, spl::AbstractSampler)
-    Base.depwarn(
-        "`link!(varinfo, sampler)` is deprecated, use `link!!(varinfo, sampler, model)` instead.",
-        :link!,
-    )
     return _link!(vi, spl, Val(getspace(spl)))
 end
 function _link!(vi::TypedVarInfo, spl::AbstractSampler, spaceval::Val)


### PR DESCRIPTION
This PR fixes the performance regressions seen for `Emcee` in https://github.com/TuringLang/Turing.jl/pull/1900.

@yebai @devmotion This should be an easy merge.