### PR TITLE
Updated prob-interface.md

### DIFF
--- a/docs/src/tutorials/prob-interface.md
+++ b/docs/src/tutorials/prob-interface.md
@@ -119,7 +119,8 @@ logjoint(model, [sample_nt])
 We can build similar interfaces for the two temporary functions to accept sample in the format of `OrderedDict`.
 
 ```@example probinterface
-logjoint(model, [sample_nt])[1] ≈ loglikelihood(model, sample_nt) + logprior(model, [sample_nt])[1]
+logjoint(model, [sample_nt])[1] ≈
+loglikelihood(model, sample_nt) + logprior(model, [sample_nt])[1]
 ```
 
 ## Example: Cross-validation

--- a/docs/src/tutorials/prob-interface.md
+++ b/docs/src/tutorials/prob-interface.md
@@ -115,6 +115,7 @@ function logprior(model_instance, nt_arr)
 end
 logjoint(model, [sample_nt])
 ```
+
 We can build similar interfaces for the two temporary functions to accept sample in the format of `OrderedDict`.
 
 ```@example probinterface

--- a/docs/src/tutorials/prob-interface.md
+++ b/docs/src/tutorials/prob-interface.md
@@ -107,7 +107,7 @@ logprior(model, [x1])
 
 function logprior(model_instance, nt_arr)
     lls = Array{Float64}(undef, size(nt_arr, 1)) # initialize a matrix to store the evaluated log posterior
-    for param_idx = 1:size(nt_arr, 1)
+    for param_idx in 1:size(nt_arr, 1)
         # Compute and store.
         lls[param_idx] = DynamicPPL.logprior(model_instance, nt_arr[param_idx])
     end

--- a/docs/src/tutorials/prob-interface.md
+++ b/docs/src/tutorials/prob-interface.md
@@ -95,7 +95,7 @@ The prior probability and the likelihood of a set of samples (in the format `Nae
 # Here we build two loosen/temporary helper functions which accept a model and a vector of named tuples (therefore a single NamedTuple needs to be square bracketed to be made a vector) as arguments, and output a vector of logjoints.
 function logjoint(model_instance, nt_arr)
     lls = Array{Float64}(undef, size(nt_arr, 1)) # initialize a matrix to store the evaluated log posterior
-    for param_idx = 1:size(nt_arr, 1)
+    for param_idx in 1:size(nt_arr, 1)
         # Compute and store.
         lls[param_idx] =
             Distributions.loglikelihood(model_instance, nt_arr[param_idx]) +

--- a/docs/src/tutorials/prob-interface.md
+++ b/docs/src/tutorials/prob-interface.md
@@ -89,10 +89,12 @@ sample_dict = rand(OrderedDict, model)
 ```
 
 Here we work with sample in the format of `NamedTuple`.
-The prior probability and the likelihood of a set of samples (in the format `NaedTuple`) can be calculated with the following helper functions:
+The prior probability and the likelihood of a set of samples (in the format `NamedTuple`) can be calculated with the following helper functions:
 
 ```julia
-# Here we build two loosen/temporary helper functions which accept a model and a vector of named tuples (therefore a single NamedTuple needs to be square bracketed to be made a vector) as arguments, and output a vector of logjoints.
+# Here we build two loosen/temporary helper functions which:
+    # accept: a model and a vector of named tuples (therefore a single NamedTuple needs to be square bracketed to be made a vector) as arguments, and 
+    # output: a vector of log posteriors.
 function logjoint(model_instance, nt_arr)
     lls = Array{Float64}(undef, size(nt_arr, 1)) # initialize a matrix to store the evaluated log posterior
     for param_idx in 1:size(nt_arr, 1)

--- a/docs/src/tutorials/prob-interface.md
+++ b/docs/src/tutorials/prob-interface.md
@@ -13,10 +13,10 @@ using LinearAlgebra
 using Random
 
 @model function gdemo(n)
-   μ ~ Normal(0, 1)
-   σ=1
-   x ~ MvNormal(Fill(μ, n), σ*I)
-   return nothing
+    μ ~ Normal(0, 1)
+    σ = 1
+    x ~ MvNormal(Fill(μ, n), σ * I)
+    return nothing
 end
 nothing # hide
 ```

--- a/docs/src/tutorials/prob-interface.md
+++ b/docs/src/tutorials/prob-interface.md
@@ -93,8 +93,8 @@ The prior probability and the likelihood of a set of samples (in the format `Nam
 
 ```julia
 # Here we build two loosen/temporary helper functions which:
-    # accept: a model and a vector of named tuples (therefore a single NamedTuple needs to be square bracketed to be made a vector) as arguments, and 
-    # output: a vector of log posteriors.
+# accept: a model and a vector of named tuples (therefore a single NamedTuple needs to be square bracketed to be made a vector) as arguments, and 
+# output: a vector of log posteriors.
 function logjoint(model_instance, nt_arr)
     lls = Array{Float64}(undef, size(nt_arr, 1)) # initialize a matrix to store the evaluated log posterior
     for param_idx in 1:size(nt_arr, 1)

--- a/docs/src/tutorials/prob-interface.md
+++ b/docs/src/tutorials/prob-interface.md
@@ -155,7 +155,7 @@ function cross_val(
         # Evaluation on the validation set.
         validation_model = gdemo(length(validation)) | (x=validation,)
         loss += sum(samples) do sample
-            logjoint(validation_model, [(μ=sample,)])
+            logjoint(validation_model, [sample])
         end
     end
 

--- a/docs/src/tutorials/prob-interface.md
+++ b/docs/src/tutorials/prob-interface.md
@@ -150,7 +150,7 @@ function cross_val(
         # For normally-distributed data, the posterior can be computed in closed form.
         # For general models, however, typically samples will be generated using MCMC with Turing.
         posterior = Normal(mean(train), 1)
-        samples = rand(rng, posterior, nsamples)
+        samples = NamedTuple{(:μ,)}.(rand(rng, posterior, nsamples))
 
         # Evaluation on the validation set.
         validation_model = gdemo(length(validation)) | (x=validation,)


### PR DESCRIPTION
1. fixed the invalid `logprior` and `logjoint` functions;
2. added `σ=1` to the demo model as it's described in the context but missing in the original version;
3. fixed `cross_val` accordingly.

NB: as the `logprior` and `logjoint` methods are still in development. here we temporarily built them without strict signatures.