### PR TITLE
[Merged by Bors] - Always run CI 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,7 @@ on:
       - trying
       # Build the master branch.
       - master
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,8 @@ on:
       # Build the master branch.
       - master
   pull_request:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
I find the current `bors` workflow a bit tedious. Most of the time, I summon `bors` to see the CI results (see e.g. https://github.com/TuringLang/DynamicPPL.jl/pull/438). Given that most `CI` tests are quick (< 10mins), we can always run them by default. 

The most time-consuming `IntegrationTests` is still run by `bors` to avoid excessive CI runs. 