### PR TITLE
[Merged by Bors] - Replace GLOBAL_RNG with default_rng()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.22.1"
+version = "0.22.2"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -121,7 +121,7 @@ setleafcontext(::IsLeaf, ::IsLeaf, left, right) = right
 # Contexts
 """
     SamplingContext(
-            [rng::Random.AbstractRNG=Random.GLOBAL_RNG],
+            [rng::Random.AbstractRNG=Random.default_rng()],
             [sampler::AbstractSampler=SampleFromPrior()],
             [context::AbstractContext=DefaultContext()],
     )
@@ -138,7 +138,7 @@ struct SamplingContext{S<:AbstractSampler,C<:AbstractContext,R} <: AbstractConte
 end
 
 function SamplingContext(
-    rng::Random.AbstractRNG=Random.GLOBAL_RNG, sampler::AbstractSampler=SampleFromPrior()
+    rng::Random.AbstractRNG=Random.default_rng(), sampler::AbstractSampler=SampleFromPrior()
 )
     return SamplingContext(rng, sampler, DefaultContext())
 end
@@ -146,7 +146,7 @@ end
 function SamplingContext(
     sampler::AbstractSampler, context::AbstractContext=DefaultContext()
 )
-    return SamplingContext(Random.GLOBAL_RNG, sampler, context)
+    return SamplingContext(Random.default_rng(), sampler, context)
 end
 
 function SamplingContext(rng::Random.AbstractRNG, context::AbstractContext)
@@ -154,7 +154,7 @@ function SamplingContext(rng::Random.AbstractRNG, context::AbstractContext)
 end
 
 function SamplingContext(context::AbstractContext)
-    return SamplingContext(Random.GLOBAL_RNG, SampleFromPrior(), context)
+    return SamplingContext(Random.default_rng(), SampleFromPrior(), context)
 end
 
 NodeTrait(context::SamplingContext) = IsParent()

--- a/src/model.jl
+++ b/src/model.jl
@@ -520,7 +520,7 @@ function AbstractPPL.evaluate!!(model::Model, context::AbstractContext)
 end
 
 function AbstractPPL.evaluate!!(model::Model, args...)
-    return evaluate!!(model, Random.GLOBAL_RNG, args...)
+    return evaluate!!(model, Random.default_rng(), args...)
 end
 
 # without VarInfo
@@ -626,7 +626,7 @@ Base.nameof(model::Model) = Symbol(model.f)
 Base.nameof(model::Model{<:Function}) = nameof(model.f)
 
 """
-    rand([rng=Random.GLOBAL_RNG], [T=NamedTuple], model::Model)
+    rand([rng=Random.default_rng()], [T=NamedTuple], model::Model)
 
 Generate a sample of type `T` from the prior distribution of the `model`.
 """
@@ -643,8 +643,8 @@ end
 
 # Default RNG and type
 Base.rand(rng::Random.AbstractRNG, model::Model) = rand(rng, NamedTuple, model)
-Base.rand(::Type{T}, model::Model) where {T} = rand(Random.GLOBAL_RNG, T, model)
-Base.rand(model::Model) = rand(Random.GLOBAL_RNG, NamedTuple, model)
+Base.rand(::Type{T}, model::Model) where {T} = rand(Random.default_rng(), T, model)
+Base.rand(model::Model) = rand(Random.default_rng(), NamedTuple, model)
 
 """
     logjoint(model::Model, varinfo::AbstractVarInfo)

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -135,7 +135,7 @@ function VarInfo(
     model(rng, varinfo, sampler, context)
     return TypedVarInfo(varinfo)
 end
-VarInfo(model::Model, args...) = VarInfo(Random.GLOBAL_RNG, model, args...)
+VarInfo(model::Model, args...) = VarInfo(Random.default_rng(), model, args...)
 
 unflatten(vi::VarInfo, x::AbstractVector) = unflatten(vi, SampleFromPrior(), x)
 

--- a/test/contexts.jl
+++ b/test/contexts.jl
@@ -240,16 +240,16 @@ end
     end
 
     @testset "SamplingContext" begin
-        context = SamplingContext(Random.GLOBAL_RNG, SampleFromPrior(), DefaultContext())
+        context = SamplingContext(Random.default_rng(), SampleFromPrior(), DefaultContext())
         @test context isa SamplingContext
 
         # convenience constructors
         @test SamplingContext() == context
-        @test SamplingContext(Random.GLOBAL_RNG) == context
+        @test SamplingContext(Random.default_rng()) == context
         @test SamplingContext(SampleFromPrior()) == context
         @test SamplingContext(DefaultContext()) == context
-        @test SamplingContext(Random.GLOBAL_RNG, SampleFromPrior()) == context
-        @test SamplingContext(Random.GLOBAL_RNG, DefaultContext()) == context
+        @test SamplingContext(Random.default_rng(), SampleFromPrior()) == context
+        @test SamplingContext(Random.default_rng(), DefaultContext()) == context
         @test SamplingContext(SampleFromPrior(), DefaultContext()) == context
         @test SamplingContext(SampleFromPrior(), DefaultContext()) == context
     end

--- a/test/model.jl
+++ b/test/model.jl
@@ -45,12 +45,12 @@ end
             for i in 1:10
                 Random.seed!(100 + i)
                 vi = VarInfo()
-                model(Random.GLOBAL_RNG, vi, sampler)
+                model(Random.default_rng(), vi, sampler)
                 vals = DynamicPPL.getall(vi)
 
                 Random.seed!(100 + i)
                 vi = VarInfo()
-                model(Random.GLOBAL_RNG, vi, sampler)
+                model(Random.default_rng(), vi, sampler)
                 @test DynamicPPL.getall(vi) == vals
             end
         end
@@ -63,7 +63,7 @@ end
         s, m = model()
 
         Random.seed!(100)
-        @test model(Random.GLOBAL_RNG) == (s, m)
+        @test model(Random.default_rng()) == (s, m)
     end
 
     @testset "nameof" begin

--- a/test/threadsafe.jl
+++ b/test/threadsafe.jl
@@ -63,7 +63,7 @@
         DynamicPPL.evaluate_threadsafe!!(
             wthreads(x),
             vi,
-            SamplingContext(Random.GLOBAL_RNG, SampleFromPrior(), DefaultContext()),
+            SamplingContext(Random.default_rng(), SampleFromPrior(), DefaultContext()),
         )
         @test getlogp(vi) ≈ lp_w_threads
         @test vi_ isa DynamicPPL.ThreadSafeVarInfo
@@ -72,7 +72,7 @@
         @time DynamicPPL.evaluate_threadsafe!!(
             wthreads(x),
             vi,
-            SamplingContext(Random.GLOBAL_RNG, SampleFromPrior(), DefaultContext()),
+            SamplingContext(Random.default_rng(), SampleFromPrior(), DefaultContext()),
         )
 
         @model function wothreads(x)
@@ -102,7 +102,7 @@
         DynamicPPL.evaluate_threadunsafe!!(
             wothreads(x),
             vi,
-            SamplingContext(Random.GLOBAL_RNG, SampleFromPrior(), DefaultContext()),
+            SamplingContext(Random.default_rng(), SampleFromPrior(), DefaultContext()),
         )
         @test getlogp(vi) ≈ lp_w_threads
         @test vi_ isa VarInfo
@@ -111,7 +111,7 @@
         @time DynamicPPL.evaluate_threadunsafe!!(
             wothreads(x),
             vi,
-            SamplingContext(Random.GLOBAL_RNG, SampleFromPrior(), DefaultContext()),
+            SamplingContext(Random.default_rng(), SampleFromPrior(), DefaultContext()),
         )
     end
 end

--- a/test/turing/varinfo.jl
+++ b/test/turing/varinfo.jl
@@ -285,7 +285,7 @@
         #= g = Sampler(Gibbs(PG(10, :x, :y, :z), HMC(0.4, 8, :w, :u)), g_demo_f)
         vi = VarInfo()
         g_demo_f(vi, SampleFromPrior())
-        _, state = @inferred AbstractMCMC.step(Random.GLOBAL_RNG, g_demo_f, g)
+        _, state = @inferred AbstractMCMC.step(Random.default_rng(), g_demo_f, g)
         pg, hmc = state.states
         @test pg isa TypedVarInfo
         @test hmc isa Turing.Inference.HMCState
@@ -302,7 +302,7 @@
         vi = empty!!(TypedVarInfo(vi))
         @inferred g_demo_f(vi, SampleFromPrior())
         pg.state.vi = vi
-        step!(Random.GLOBAL_RNG, g_demo_f, pg, 1)
+        step!(Random.default_rng(), g_demo_f, pg, 1)
         vi = pg.state.vi
         @inferred g_demo_f(vi, hmc)
         @test vi.metadata.x.gids[1] == Set([pg.selector])


### PR DESCRIPTION
I just noticed that we still use `GLOBAL_RNG` in a few places instead of `default_rng()` (see e.g. https://github.com/JuliaStats/Distributions.jl/pull/1679 and references therein why the newer default_rng() has advantages over GLOBAL_RNG).