### PR TITLE
Run integration tests once the CI workflow finishes

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -1,9 +1,10 @@
 name: IntegrationTest
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: [CI]
+    types:
+      - completed
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
This PR makes it so that the integration workflows now runs once the CI tests completes successfully.

