### PR TITLE
Try to fix downstream tests with merge queue

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -6,6 +6,9 @@ on:
       - master
   merge_group:
     types: [checks_requested]
+  pull_request:
+    branches: [master]
+    types: [auto_merge_enabled]
 
 jobs:
   test:


### PR DESCRIPTION
Maybe these changes fix the Turing.jl/merge queue issues. At least I hope they imply that the downstream tests are run once "auto merge" is enabled, and hence after they are run successfully the PR can be added to the merge queue (which requires the downstream tests to pass). This means that the downstream tests run twice, once on the PR and once in the merge queue, but at least not every time a commit is added in a PR.