### PR TITLE
Dispatch `reconstruct` for `Inverse{PDVecBijector}`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -243,6 +243,12 @@ function reconstruct(
     return copy(val)
 end
 
+function reconstruct(
+    ::Inverse{Bijectors.PDVecBijector}, ::MatrixDistribution, val::AbstractVector
+)
+    return copy(val)
+end
+
 # TODO: Implement no-op `reconstruct` for general array variates.
 
 reconstruct(d::Distribution, val::AbstractVector) = reconstruct(size(d), val)


### PR DESCRIPTION
Similar to what we did for `Inverse{VecCholeskyBijector}` in #485 .

Fixes some test failures in https://github.com/TuringLang/Turing.jl/pull/2018 .