### PR TITLE
Remove unnecessary namespace qualifications

### DIFF
--- a/benchmarks/src/DynamicPPLBenchmarks.jl
+++ b/benchmarks/src/DynamicPPLBenchmarks.jl
@@ -8,6 +8,7 @@ using Markdown: Markdown
 
 using LibGit2: LibGit2
 using Pkg: Pkg
+using Random: Random
 
 export weave_benchmarks
 
@@ -33,9 +34,9 @@ function benchmark_typed_varinfo!(suite, m)
 end
 
 function typed_code(m, vi=VarInfo(m))
-    rng = DynamicPPL.Random.MersenneTwister(42)
-    spl = DynamicPPL.SampleFromPrior()
-    ctx = DynamicPPL.SamplingContext(rng, spl, DynamicPPL.DefaultContext())
+    rng = Random.MersenneTwister(42)
+    spl = SampleFromPrior()
+    ctx = SamplingContext(rng, spl, DefaultContext())
 
     results = code_typed(m.f, Base.typesof(m, vi, ctx, m.args...))
     return first(results)

--- a/src/model.jl
+++ b/src/model.jl
@@ -1091,7 +1091,7 @@ function logjoint(model::Model, chain::AbstractMCMC.AbstractChains)
                 values_from_chain(var_info, vn_parent, chain, chain_idx, iteration_idx) for
             vn_parent in keys(var_info)
         )
-        DynamicPPL.logjoint(model, argvals_dict)
+        logjoint(model, argvals_dict)
     end
 end
 
@@ -1138,7 +1138,7 @@ function logprior(model::Model, chain::AbstractMCMC.AbstractChains)
                 values_from_chain(var_info, vn_parent, chain, chain_idx, iteration_idx) for
             vn_parent in keys(var_info)
         )
-        DynamicPPL.logprior(model, argvals_dict)
+        logprior(model, argvals_dict)
     end
 end
 

--- a/src/model_utils.jl
+++ b/src/model_utils.jl
@@ -131,7 +131,7 @@ end
 Mutate `out` to map each variable name in `model`/`varinfo` to its value in
 `chain` at `chain_idx` and `iteration_idx`.
 """
-function values_from_chain!(model::DynamicPPL.Model, chain, chain_idx, iteration_idx, out)
+function values_from_chain!(model::Model, chain, chain_idx, iteration_idx, out)
     return values_from_chain(VarInfo(model), chain, chain_idx, iteration_idx, out)
 end
 
@@ -196,7 +196,7 @@ julia> conditioned_model()  # <= results in same values as the `first(iter)` abo
 (0.5805148626851955, 0.7393275279160691)
 ```
 """
-function value_iterator_from_chain(model::DynamicPPL.Model, chain)
+function value_iterator_from_chain(model::Model, chain)
     return value_iterator_from_chain(VarInfo(model), chain)
 end
 

--- a/src/prob_macro.jl
+++ b/src/prob_macro.jl
@@ -149,7 +149,7 @@ function logprior(
         @assert n in keys(left) "Variable $n is not defined."
     end
     return getlogp(
-        last(DynamicPPL.evaluate!!(model, vi, SampleFromPrior(), PriorContext(left)))
+        last(evaluate!!(model, vi, SampleFromPrior(), PriorContext(left)))
     )
 end
 

--- a/src/simple_varinfo.jl
+++ b/src/simple_varinfo.jl
@@ -490,7 +490,7 @@ end
 function tonamedtuple(vi::SimpleOrThreadSafeSimple{<:NamedTuple{names}}) where {names}
     nt_vals = map(keys(vi)) do vn
         val = vi[vn]
-        vns = collect(DynamicPPL.TestUtils.varname_leaves(vn, val))
+        vns = collect(TestUtils.varname_leaves(vn, val))
         vals = map(copy ∘ Base.Fix1(getindex, vi), vns)
         (vals, map(string, vns))
     end
@@ -503,7 +503,7 @@ function tonamedtuple(vi::SimpleOrThreadSafeSimple{<:Dict})
     for vn in keys(vi)
         # Extract the leaf varnames and values.
         val = vi[vn]
-        vns = collect(DynamicPPL.TestUtils.varname_leaves(vn, val))
+        vns = collect(TestUtils.varname_leaves(vn, val))
         vals = map(copy ∘ Base.Fix1(getindex, vi), vns)
 
         # Determine the corresponding symbol.

--- a/src/submodel_macro.jl
+++ b/src/submodel_macro.jl
@@ -191,12 +191,12 @@ end
 prefix_submodel_context(prefix, left, ctx) = prefix_submodel_context(prefix, ctx)
 function prefix_submodel_context(prefix, ctx)
     # E.g. `prefix="asd[$i]"` or `prefix=asd` with `asd` to be evaluated.
-    return :($(DynamicPPL.PrefixContext){$(Symbol)($(esc(prefix)))}($ctx))
+    return :($(PrefixContext){$(Symbol)($(esc(prefix)))}($ctx))
 end
 
 function prefix_submodel_context(prefix::Union{AbstractString,Symbol}, ctx)
     # E.g. `prefix="asd"`.
-    return :($(DynamicPPL.PrefixContext){$(esc(Meta.quot(Symbol(prefix))))}($ctx))
+    return :($(PrefixContext){$(esc(Meta.quot(Symbol(prefix))))}($ctx))
 end
 
 function prefix_submodel_context(prefix::Bool, ctx)
@@ -225,7 +225,7 @@ function submodel(prefix_expr, expr, ctx=esc(:__context__))
     return if args_assign === nothing
         ctx = prefix_submodel_context(prefix, ctx)
         quote
-            $retval, $(esc(:__varinfo__)) = $(DynamicPPL._evaluate!!)(
+            $retval, $(esc(:__varinfo__)) = $(_evaluate!!)(
                 $(esc(expr)), $(esc(:__varinfo__)), $(ctx)
             )
             $retval
@@ -241,7 +241,7 @@ function submodel(prefix_expr, expr, ctx=esc(:__context__))
             )
         end
         quote
-            $retval, $(esc(:__varinfo__)) = $(DynamicPPL._evaluate!!)(
+            $retval, $(esc(:__varinfo__)) = $(_evaluate!!)(
                 $(esc(R)), $(esc(:__varinfo__)), $(ctx)
             )
             $(esc(L)) = $retval

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -609,10 +609,10 @@ const UnivariateAssumeDemoModels = Union{
 function posterior_mean(model::UnivariateAssumeDemoModels)
     return (s=49 / 24, m=7 / 6)
 end
-function likelihood_optima(::DynamicPPL.TestUtils.UnivariateAssumeDemoModels)
+function likelihood_optima(::UnivariateAssumeDemoModels)
     return (s=1 / 16, m=7 / 4)
 end
-function posterior_optima(::DynamicPPL.TestUtils.UnivariateAssumeDemoModels)
+function posterior_optima(::UnivariateAssumeDemoModels)
     # TODO: Figure out exact for `s`.
     return (s=0.907407, m=7 / 6)
 end
@@ -649,7 +649,7 @@ function posterior_mean(model::MultivariateAssumeDemoModels)
 
     return vals
 end
-function likelihood_optima(model::DynamicPPL.TestUtils.MultivariateAssumeDemoModels)
+function likelihood_optima(model::MultivariateAssumeDemoModels)
     # Get some containers to fill.
     vals = Random.rand(model)
 
@@ -662,7 +662,7 @@ function likelihood_optima(model::DynamicPPL.TestUtils.MultivariateAssumeDemoMod
 
     return vals
 end
-function posterior_optima(model::DynamicPPL.TestUtils.MultivariateAssumeDemoModels)
+function posterior_optima(model::MultivariateAssumeDemoModels)
     # Get some containers to fill.
     vals = Random.rand(model)
 
@@ -704,7 +704,7 @@ function posterior_mean(model::MatrixvariateAssumeDemoModels)
 
     return vals
 end
-function likelihood_optima(model::DynamicPPL.TestUtils.MatrixvariateAssumeDemoModels)
+function likelihood_optima(model::MatrixvariateAssumeDemoModels)
     # Get some containers to fill.
     vals = Random.rand(model)
 
@@ -717,7 +717,7 @@ function likelihood_optima(model::DynamicPPL.TestUtils.MatrixvariateAssumeDemoMo
 
     return vals
 end
-function posterior_optima(model::DynamicPPL.TestUtils.MatrixvariateAssumeDemoModels)
+function posterior_optima(model::MatrixvariateAssumeDemoModels)
     # Get some containers to fill.
     vals = Random.rand(model)
 

--- a/src/transforming.jl
+++ b/src/transforming.jl
@@ -74,7 +74,7 @@ function dot_tilde_assume(
     for (vn, ri) in zip(vns, eachcol(r))
         # Only transform if `!isinverse` since `vi[vn, right]`
         # already performs the inverse transformation if it's transformed.
-        vi = DynamicPPL.setindex!!(vi, isinverse ? ri : b(ri), vn)
+        vi = setindex!!(vi, isinverse ? ri : b(ri), vn)
     end
 
     return r, lp, vi

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -855,7 +855,7 @@ function varname_leaves(vn::VarName, val::AbstractArray)
         I in CartesianIndices(val)
     )
 end
-function varname_leaves(vn::DynamicPPL.VarName, val::NamedTuple)
+function varname_leaves(vn::VarName, val::NamedTuple)
     iter = Iterators.map(keys(val)) do sym
         lens = Setfield.PropertyLens{sym}()
         varname_leaves(vn ∘ lens, get(val, lens))


### PR DESCRIPTION
It seems there are quite a few examples of unnecessary namespace qualifications in DynamicPPL. This PR fixes a few of them.