### PR TITLE
Fix for #511

### DIFF
--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -599,6 +599,24 @@ end
         # With assignment.
         @model outer() = @submodel x = inner()
         @test outer()() isa Real
+
+        # Edge-cases.
+        # `return` in the last statement.
+        # Ref: issue #511.
+        @model function demo_ret_in_last_stmt(x::Bool)
+            # Two different values not supporting `iterate`.
+            if x
+                return nothing
+            else
+                return missing
+            end
+        end
+
+        model_true = demo_ret_in_last_stmt(true)
+        @test model_true() === nothing
+
+        model_false = demo_ret_in_last_stmt(false)
+        @test model_false() === missing
     end
 
     @testset "issue #368: hasmissing dispatch" begin


### PR DESCRIPTION
Because we add a `return` to the last statement in the model body _before_ replacing returns + we don't recursively call `replace_returns!` on the args to the `return` statement, we run into issues when the last statement in the body itself contains `return` (as in #511).

This PR addresses this issue.