### PR TITLE
Added extension for MCMCChains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 .DS_Store
 Manifest.toml
+**.~undo-tree~

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.23.11"
+version = "0.23.12"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,9 @@ MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 [extensions]
 DynamicPPLMCMCChainsExt = ["MCMCChains"]
 
+[extras]
+MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
+
 [compat]
 AbstractMCMC = "2, 3.0, 4"
 AbstractPPL = "0.6"

--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,12 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
+[weakdeps]
+MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
+
+[extensions]
+DynamicPPLMCMCChainsExt = ["MCMCChains"]
+
 [compat]
 AbstractMCMC = "2, 3.0, 4"
 AbstractPPL = "0.6"
@@ -31,6 +37,7 @@ Distributions = "0.23.8, 0.24, 0.25"
 DocStringExtensions = "0.8, 0.9"
 LogDensityProblems = "2"
 MacroTools = "0.5.6"
+MCMCChains = "6"
 OrderedCollections = "1"
 Setfield = "0.7.1, 0.8, 1"
 ZygoteRules = "0.2"

--- a/ext/DynamicPPLMCMCChainsExt.jl
+++ b/ext/DynamicPPLMCMCChainsExt.jl
@@ -3,9 +3,7 @@ module DynamicPPLMCMCChainsExt
 using DynamicPPL: DynamicPPL
 using MCMCChains: MCMCChains
 
-function DynamicPPL.generated_quantities(
-    model::DynamicPPL.Model, chain::MCMCChains.Chains
-)
+function DynamicPPL.generated_quantities(model::DynamicPPL.Model, chain::MCMCChains.Chains)
     chain_parameters = MCMCChains.get_sections(chain, :parameters)
     varinfo = DynamicPPL.VarInfo(model)
     iters = Iterators.product(1:size(chain, 1), 1:size(chain, 3))

--- a/ext/DynamicPPLMCMCChainsExt.jl
+++ b/ext/DynamicPPLMCMCChainsExt.jl
@@ -1,0 +1,18 @@
+module DynamicPPLMCMCChainsExt
+
+using DynamicPPL: DynamicPPL
+using MCMCChains: MCMCChains
+
+function DynamicPPL.generated_quantities(
+    model::DynamicPPL.Model, chain::MCMCChains.Chains
+)
+    chain_parameters = MCMCChains.get_sections(chain, :parameters)
+    varinfo = DynamicPPL.VarInfo(model)
+    iters = Iterators.product(1:size(chain, 1), 1:size(chain, 3))
+    return map(iters) do (sample_idx, chain_idx)
+        DynamicPPL.setval_and_resample!(varinfo, chain_parameters, sample_idx, chain_idx)
+        model(varinfo)
+    end
+end
+
+end

--- a/test/ext/DynamicPPLMCMCChainsExt.jl
+++ b/test/ext/DynamicPPLMCMCChainsExt.jl
@@ -1,0 +1,9 @@
+@testset "DynamicPPLMCMCChainsExt" begin
+    @model demo() = x ~ Normal()
+    model = demo()
+
+    chain = MCMCChains.Chains(randn(1000, 2, 1), [:x, :y], Dict(:internals => [:y]))
+    chain_generated = @test_nowarn generated_quantities(model, chain)
+    @test size(chain_generated) == (1000, 1)
+    @test mean(chain_generated) ≈ 0 atol=0.1
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,6 +59,10 @@ include("test_util.jl")
             include(joinpath("compat", "ad.jl"))
         end
 
+        @testset "extensions" begin
+            include("ext/DynamicPPLMCMCChainsExt.jl")
+        end
+
         @testset "doctests" begin
             DocMeta.setdocmeta!(
                 DynamicPPL,


### PR DESCRIPTION
There is some functionality in DPPL that dispatches on `chain::AbstractChains` while we are in fact assuming the behavior of `chain::MCMCChains.Chains`.

This PR adds an extension for MCMCChains.jl so that we can specialize further when it makes sense.

In particular, in the case of `generated_quantities(model, chain)` we warn the user if some variables are present in `chain` but not in `model`. This makes sense if all the variables present in `chain` are _parameters_, but less so when we are also working with internal parameters; in such a scenario, the user end up seeing tons of warnings regarding unused variables (which are in fact internal variables of the sampler). In this scenario, it makes sense to specialize further on `MCMCChains.Chains` and call `get_sections(chain, :parameters)` before calling `setval_and_resample!`; this we can now do in the extension.

Note that this I'm not adding Requires.jl or a new dependency in this PR; the change mentioned above is just something that users on Julia 1.9 gets for free without any cost to the ones on Julia 1.8. We can discuss whether we should also add Requires.jl, etc. but I think for now this is an okay thing to do :shrug:

EDIT: Other methods that should eventually be moved is 
- `Turing.predict`: https://github.com/TuringLang/Turing.jl/blob/78b543847a4e8791ea06569de47a92c2b9a43151/src/inference/Inference.jl#L564-L596