### PR TITLE
Fixes for SimpleVarInfo with `Ref`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.23.14"
+version = "0.23.15"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/simple_varinfo.jl
+++ b/src/simple_varinfo.jl
@@ -264,14 +264,6 @@ getlogp(vi::SimpleVarInfo{<:Any,<:Ref}) = vi.logp[]
 setlogp!!(vi::SimpleVarInfo, logp) = Setfield.@set vi.logp = logp
 acclogp!!(vi::SimpleVarInfo, logp) = Setfield.@set vi.logp = getlogp(vi) + logp
 
-"""
-    keys(vi::SimpleVarInfo)
-
-Return an iterator of keys present in `vi`.
-"""
-Base.keys(vi::SimpleVarInfo) = keys(vi.values)
-Base.keys(vi::SimpleVarInfo{<:NamedTuple}) = map(k -> VarName{k}(), keys(vi.values))
-
 function setlogp!!(vi::SimpleVarInfo{<:Any,<:Ref}, logp)
     vi.logp[] = logp
     return vi
@@ -281,6 +273,14 @@ function acclogp!!(vi::SimpleVarInfo{<:Any,<:Ref}, logp)
     vi.logp[] += logp
     return vi
 end
+
+"""
+    keys(vi::SimpleVarInfo)
+
+Return an iterator of keys present in `vi`.
+"""
+Base.keys(vi::SimpleVarInfo) = keys(vi.values)
+Base.keys(vi::SimpleVarInfo{<:NamedTuple}) = map(k -> VarName{k}(), keys(vi.values))
 
 function Base.show(io::IO, ::MIME"text/plain", svi::SimpleVarInfo)
     if !(svi.transformation isa NoTransformation)

--- a/src/simple_varinfo.jl
+++ b/src/simple_varinfo.jl
@@ -259,6 +259,8 @@ end
 Base.isempty(vi::SimpleVarInfo) = isempty(vi.values)
 
 getlogp(vi::SimpleVarInfo) = vi.logp
+getlogp(vi::SimpleVarInfo{<:Any,<:Ref}) = vi.logp[]
+
 setlogp!!(vi::SimpleVarInfo, logp) = Setfield.@set vi.logp = logp
 acclogp!!(vi::SimpleVarInfo, logp) = Setfield.@set vi.logp = getlogp(vi) + logp
 


### PR DESCRIPTION
`VarInfo` uses `Ref` for its logp-field, partially because it makes us compatible with Zygote.jl; Zygote.jl does support differentiating through mutations of `Ref`, though it's _slow_: https://github.com/FluxML/Zygote.jl/issues/999

By default, `SimpleVarInfo` does not mutate its `logp` field, and so it uses a simple `Real` instead of a `RefValue{<:Real}`. This then works fine with Zygote because no mutation occurs, _until_ we start using threads, in which case we're working with a `Vector{<:Real}` instead of `Vector{<:RefValue{<:Real}}`, as is done by default with `VarInfo`.

This can cause some issues when Julia is started with threads, e.g. https://discourse.julialang.org/t/error-running-museinference-jl-example/103360/4.

This PR adds more testing for `SimpleVarInfo` with `Ref` + a fix allowing proper usage with threads.