### PR TITLE
Improved `varname_and_value_leaves` for `Cholesky`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.23.15"
+version = "0.23.16"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -936,15 +936,15 @@ julia> # `UpperTriangular`
 
 julia> # `Cholesky` with lower-triangular
        foreach(println, varname_and_value_leaves(@varname(x), Cholesky([1.0 0.0; 0.0 1.0], 'L', 0)))
-(x[1,1], 1.0)
-(x[2,1], 0.0)
-(x[2,2], 1.0)
+(x.L[1,1], 1.0)
+(x.L[2,1], 0.0)
+(x.L[2,2], 1.0)
 
 julia> # `Cholesky` with upper-triangular
        foreach(println, varname_and_value_leaves(@varname(x), Cholesky([1.0 0.0; 0.0 1.0], 'U', 0)))
-(x[1,1], 1.0)
-(x[1,2], 0.0)
-(x[2,2], 1.0)
+(x.U[1,1], 1.0)
+(x.U[1,2], 0.0)
+(x.U[2,2], 1.0)
 ```
 """
 function varname_and_value_leaves(vn::VarName, x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1019,7 +1019,11 @@ end
 # Special types.
 function varname_and_value_leaves_inner(vn::VarName, x::Cholesky)
     # TODO: Or do we use `PDMat` here?
-    return varname_and_value_leaves_inner(vn, x.UL)
+    return if x.uplo == 'L'
+        varname_and_value_leaves_inner(vn ∘ Setfield.PropertyLens{:L}(), x.L)
+    else
+        varname_and_value_leaves_inner(vn ∘ Setfield.PropertyLens{:U}(), x.U)
+    end
 end
 function varname_and_value_leaves_inner(vn::VarName, x::LinearAlgebra.LowerTriangular)
     return (


### PR DESCRIPTION
You can see the difference in the docstring I've edited.

This was suggested by @sethaxen  as an alternative, which I quite like:)

The alternative is to flatten the `PDMat` instead, i.e. we return the covariance / correlation matrix represented by the cholesky instead of the cholesky factor itself.

Related discussion: https://github.com/TuringLang/Turing.jl/pull/2071