### PR TITLE
Fix name collision

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.23.18"
+version = "0.23.19"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -21,6 +21,9 @@ using DocStringExtensions
 
 using Random: Random
 
+# TODO: Remove these when it's possible.
+import Bijectors: link, invlink
+
 import Base:
     Symbol,
     ==,


### PR DESCRIPTION
We're currently defining our own `link` and `invlink` even though these exist in Bijectors.jl, hence causing a lot of warning messages downstream.

As a hotfix, let's just overload the `link` and `invlink` from Bijectors.jl.

Long term we should probably either rename one of these, drop the ones from Bijectors.jl (AFAIK they aren't used?), or stop exporting one or both of them.