### PR TITLE
Fix for `rand` + remove overloads of `rand` for testing models

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -1037,7 +1037,7 @@ function Base.rand(rng::Random.AbstractRNG, ::Type{T}, model::Model) where {T}
         evaluate!!(
             model,
             SimpleVarInfo{Float64}(OrderedDict()),
-            SamplingContext(rng, SampleFromPrior(), DefaultContext()),
+            SamplingContext(rng, SampleFromPrior(), model.context),
         ),
     )
     return values_as(x, T)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -252,7 +252,7 @@ function logprior_true_with_logabsdet_jacobian(
     return (x=x_unconstrained,), logprior_true(model, x) - Δlogp
 end
 
-function Random.rand(
+function rand_prior_true(
     rng::Random.AbstractRNG,
     ::Type{NamedTuple},
     model::Model{typeof(demo_one_variable_multiple_constraints)},
@@ -299,7 +299,7 @@ function logprior_true_with_logabsdet_jacobian(model::Model{typeof(demo_lkjchol)
     return (x=x_unconstrained,), logprior_true(model, x) - Δlogp
 end
 
-function Random.rand(
+function rand_prior_true(
     rng::Random.AbstractRNG, ::Type{NamedTuple}, model::Model{typeof(demo_lkjchol)}
 )
     x = rand(rng, LKJCholesky(model.args.d, 1.0))
@@ -715,7 +715,7 @@ const DemoModels = Union{
 
 # We require demo models to have explict impleentations of `rand` since we want
 # these to be considered as ground truth.
-function Random.rand(rng::Random.AbstractRNG, ::Type{NamedTuple}, model::DemoModels)
+function rand_prior_true(rng::Random.AbstractRNG, ::Type{NamedTuple}, model::DemoModels)
     return error("demo models requires explicit implementation of rand")
 end
 
@@ -732,7 +732,7 @@ function posterior_optima(::UnivariateAssumeDemoModels)
     # TODO: Figure out exact for `s`.
     return (s=0.907407, m=7 / 6)
 end
-function Random.rand(
+function rand_prior_true(
     rng::Random.AbstractRNG, ::Type{NamedTuple}, model::UnivariateAssumeDemoModels
 )
     s = rand(rng, InverseGamma(2, 3))
@@ -755,7 +755,7 @@ const MultivariateAssumeDemoModels = Union{
 }
 function posterior_mean(model::MultivariateAssumeDemoModels)
     # Get some containers to fill.
-    vals = Random.rand(model)
+    vals = rand_prior_true(model)
 
     vals.s[1] = 19 / 8
     vals.m[1] = 3 / 4
@@ -767,7 +767,7 @@ function posterior_mean(model::MultivariateAssumeDemoModels)
 end
 function likelihood_optima(model::MultivariateAssumeDemoModels)
     # Get some containers to fill.
-    vals = Random.rand(model)
+    vals = rand_prior_true(model)
 
     # NOTE: These are "as close to zero as we can get".
     vals.s[1] = 1e-32
@@ -780,7 +780,7 @@ function likelihood_optima(model::MultivariateAssumeDemoModels)
 end
 function posterior_optima(model::MultivariateAssumeDemoModels)
     # Get some containers to fill.
-    vals = Random.rand(model)
+    vals = rand_prior_true(model)
 
     # TODO: Figure out exact for `s[1]`.
     vals.s[1] = 0.890625
@@ -790,7 +790,7 @@ function posterior_optima(model::MultivariateAssumeDemoModels)
 
     return vals
 end
-function Random.rand(
+function rand_prior_true(
     rng::Random.AbstractRNG, ::Type{NamedTuple}, model::MultivariateAssumeDemoModels
 )
     # Get template values from `model`.
@@ -810,7 +810,7 @@ const MatrixvariateAssumeDemoModels = Union{
 }
 function posterior_mean(model::MatrixvariateAssumeDemoModels)
     # Get some containers to fill.
-    vals = Random.rand(model)
+    vals = rand_prior_true(model)
 
     vals.s[1, 1] = 19 / 8
     vals.m[1] = 3 / 4
@@ -822,7 +822,7 @@ function posterior_mean(model::MatrixvariateAssumeDemoModels)
 end
 function likelihood_optima(model::MatrixvariateAssumeDemoModels)
     # Get some containers to fill.
-    vals = Random.rand(model)
+    vals = rand_prior_true(model)
 
     # NOTE: These are "as close to zero as we can get".
     vals.s[1, 1] = 1e-32
@@ -835,7 +835,7 @@ function likelihood_optima(model::MatrixvariateAssumeDemoModels)
 end
 function posterior_optima(model::MatrixvariateAssumeDemoModels)
     # Get some containers to fill.
-    vals = Random.rand(model)
+    vals = rand_prior_true(model)
 
     # TODO: Figure out exact for `s[1]`.
     vals.s[1, 1] = 0.890625
@@ -845,7 +845,7 @@ function posterior_optima(model::MatrixvariateAssumeDemoModels)
 
     return vals
 end
-function Base.rand(
+function rand_prior_true(
     rng::Random.AbstractRNG, ::Type{NamedTuple}, model::MatrixvariateAssumeDemoModels
 )
     # Get template values from `model`.

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -169,6 +169,15 @@ corresponding value using `get`, e.g. `get(posterior_mean(model), varname)`.
 function posterior_mean end
 
 """
+    rand_prior_true([rng::AbstractRNG, ]model::DynamicPPL.Model)
+
+Return a `NamedTuple` of realizations from the prior of `model` compatible with `varnames(model)`.
+"""
+function rand_prior_true(model::DynamicPPL.Model)
+    return rand_prior_true(Random.default_rng(), model)
+end
+
+"""
     demo_dynamic_constraint()
 
 A model with variables `m` and `x` with `x` having support depending on `m`.
@@ -300,7 +309,7 @@ function logprior_true_with_logabsdet_jacobian(model::Model{typeof(demo_lkjchol)
 end
 
 function rand_prior_true(
-    rng::Random.AbstractRNG, ::Type{NamedTuple}, model::Model{typeof(demo_lkjchol)}
+    rng::Random.AbstractRNG, model::Model{typeof(demo_lkjchol)}
 )
     x = rand(rng, LKJCholesky(model.args.d, 1.0))
     return (x=x,)
@@ -715,7 +724,7 @@ const DemoModels = Union{
 
 # We require demo models to have explict impleentations of `rand` since we want
 # these to be considered as ground truth.
-function rand_prior_true(rng::Random.AbstractRNG, ::Type{NamedTuple}, model::DemoModels)
+function rand_prior_true(rng::Random.AbstractRNG, model::DemoModels)
     return error("demo models requires explicit implementation of rand")
 end
 
@@ -733,7 +742,7 @@ function posterior_optima(::UnivariateAssumeDemoModels)
     return (s=0.907407, m=7 / 6)
 end
 function rand_prior_true(
-    rng::Random.AbstractRNG, ::Type{NamedTuple}, model::UnivariateAssumeDemoModels
+    rng::Random.AbstractRNG, model::UnivariateAssumeDemoModels
 )
     s = rand(rng, InverseGamma(2, 3))
     m = rand(rng, Normal(0, sqrt(s)))
@@ -791,7 +800,7 @@ function posterior_optima(model::MultivariateAssumeDemoModels)
     return vals
 end
 function rand_prior_true(
-    rng::Random.AbstractRNG, ::Type{NamedTuple}, model::MultivariateAssumeDemoModels
+    rng::Random.AbstractRNG, model::MultivariateAssumeDemoModels
 )
     # Get template values from `model`.
     retval = model(rng)
@@ -846,7 +855,7 @@ function posterior_optima(model::MatrixvariateAssumeDemoModels)
     return vals
 end
 function rand_prior_true(
-    rng::Random.AbstractRNG, ::Type{NamedTuple}, model::MatrixvariateAssumeDemoModels
+    rng::Random.AbstractRNG, model::MatrixvariateAssumeDemoModels
 )
     # Get template values from `model`.
     retval = model(rng)

--- a/test/linking.jl
+++ b/test/linking.jl
@@ -72,7 +72,8 @@ end
         @model demo() = m ~ dist
         model = demo()
 
-        vis = DynamicPPL.TestUtils.setup_varinfos(model, rand(model), (@varname(m),))
+        example_values = DynamicPPL.TestUtils.rand_prior_true(model)
+        vis = DynamicPPL.TestUtils.setup_varinfos(model, example_values, (@varname(m),))
         @testset "$(short_varinfo_name(vi))" for vi in vis
             # Evaluate once to ensure we have `logp` value.
             vi = last(DynamicPPL.evaluate!!(model, vi, DefaultContext()))
@@ -105,7 +106,7 @@ end
             @testset "d=$d" for d in [2, 3, 5]
                 model = demo_lkj(d)
                 dist = LKJCholesky(d, 1.0, uplo)
-                values_original = rand(model)
+                values_original = DynamicPPL.TestUtils.rand_prior_true(model)
                 vis = DynamicPPL.TestUtils.setup_varinfos(
                     model, values_original, (@varname(x),)
                 )
@@ -146,7 +147,8 @@ end
         @model demo_dirichlet(d::Int) = x ~ Dirichlet(d, 1.0)
         @testset "d=$d" for d in [2, 3, 5]
             model = demo_dirichlet(d)
-            vis = DynamicPPL.TestUtils.setup_varinfos(model, rand(model), (@varname(x),))
+            example_values = DynamicPPL.TestUtils.rand_prior_true(model)
+            vis = DynamicPPL.TestUtils.setup_varinfos(model, example_values, (@varname(x),))
             @testset "$(short_varinfo_name(vi))" for vi in vis
                 lp = logpdf(Dirichlet(d, 1.0), vi[:])
                 @test length(vi[:]) == d

--- a/test/logdensityfunction.jl
+++ b/test/logdensityfunction.jl
@@ -2,7 +2,7 @@ using Test, DynamicPPL, LogDensityProblems
 
 @testset "LogDensityFunction" begin
     @testset "$(nameof(model))" for model in DynamicPPL.TestUtils.DEMO_MODELS
-        example_values = rand(NamedTuple, model)
+        example_values = DynamicPPL.TestUtils.rand_prior_true(model)
         vns = DynamicPPL.TestUtils.varnames(model)
         varinfos = DynamicPPL.TestUtils.setup_varinfos(model, example_values, vns)
 

--- a/test/loglikelihoods.jl
+++ b/test/loglikelihoods.jl
@@ -1,6 +1,6 @@
 @testset "loglikelihoods.jl" begin
     @testset "$(m.f)" for m in DynamicPPL.TestUtils.DEMO_MODELS
-        example_values = rand(NamedTuple, m)
+        example_values = DynamicPPL.TestUtils.rand_prior_true(m)
 
         # Instantiate a `VarInfo` with the example values.
         vi = VarInfo(m)

--- a/test/model.jl
+++ b/test/model.jl
@@ -218,7 +218,7 @@ end
         Random.seed!(1776)
         s, m = model()
         sample_namedtuple = (; s=s, m=m)
-        sample_dict = Dict(@varname(s) => s, @varname(m) => m)
+        sample_dict = OrderedDict(@varname(s) => s, @varname(m) => m)
 
         # With explicit RNG
         @test rand(Random.seed!(1776), model) == sample_namedtuple
@@ -231,7 +231,7 @@ end
         Random.seed!(1776)
         @test rand(NamedTuple, model) == sample_namedtuple
         Random.seed!(1776)
-        @test rand(Dict, model) == sample_dict
+        @test rand(OrderedDict, model) == sample_dict
     end
 
     @testset "default arguments" begin
@@ -259,7 +259,7 @@ end
 
     @testset "TestUtils" begin
         @testset "$(model.f)" for model in DynamicPPL.TestUtils.DEMO_MODELS
-            x = rand(model)
+            x = DynamicPPL.TestUtils.rand_prior_true(model)
             # Ensure log-probability computations are implemented.
             @test logprior(model, x) ≈ DynamicPPL.TestUtils.logprior_true(model, x...)
             @test loglikelihood(model, x) ≈

--- a/test/simple_varinfo.jl
+++ b/test/simple_varinfo.jl
@@ -60,7 +60,7 @@
 
     @testset "link!! & invlink!! on $(nameof(model))" for model in
                                                           DynamicPPL.TestUtils.DEMO_MODELS
-        values_constrained = rand(NamedTuple, model)
+        values_constrained = DynamicPPL.TestUtils.rand_prior_true(model)
         @testset "$(typeof(vi))" for vi in (
             SimpleVarInfo(Dict()), SimpleVarInfo(values_constrained), VarInfo(model)
         )
@@ -112,7 +112,7 @@
 
         # We might need to pre-allocate for the variable `m`, so we need
         # to see whether this is the case.
-        svi_nt = SimpleVarInfo(rand(NamedTuple, model))
+        svi_nt = SimpleVarInfo(DynamicPPL.TestUtils.rand_prior_true(model))
         svi_dict = SimpleVarInfo(VarInfo(model), Dict)
 
         @testset "$(nameof(typeof(DynamicPPL.values_as(svi))))" for svi in (
@@ -121,7 +121,7 @@
             DynamicPPL.settrans!!(svi_nt, true),
             DynamicPPL.settrans!!(svi_dict, true),
         )
-            # Random seed is set in each `@testset`, so we need to sample
+            # RandOM seed is set in each `@testset`, so we need to sample
             # a new realization for `m` here.
             retval = model()
 
@@ -138,7 +138,7 @@
             @test getlogp(svi_new) != 0
 
             ### Evaluation ###
-            values_eval_constrained = rand(NamedTuple, model)
+            values_eval_constrained = DynamicPPL.TestUtils.rand_prior_true(model)
             if DynamicPPL.istrans(svi)
                 _values_prior, logpri_true = DynamicPPL.TestUtils.logprior_true_with_logabsdet_jacobian(
                     model, values_eval_constrained...
@@ -225,7 +225,7 @@
         model = DynamicPPL.TestUtils.demo_static_transformation()
 
         varinfos = DynamicPPL.TestUtils.setup_varinfos(
-            model, rand(NamedTuple, model), [@varname(s), @varname(m)]
+            model, DynamicPPL.TestUtils.rand_prior_true(model), [@varname(s), @varname(m)]
         )
         @testset "$(short_varinfo_name(vi))" for vi in varinfos
             # Initialize varinfo and link.

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -318,7 +318,7 @@
 
     @testset "values_as" begin
         @testset "$(nameof(model))" for model in DynamicPPL.TestUtils.DEMO_MODELS
-            example_values = rand(NamedTuple, model)
+            example_values = DynamicPPL.TestUtils.rand_prior_true(model)
             vns = DynamicPPL.TestUtils.varnames(model)
 
             # Set up the different instances of `AbstractVarInfo` with the desired values.
@@ -363,7 +363,7 @@
             DynamicPPL.TestUtils.demo_lkjchol(),
         ]
             @testset "mutating=$mutating" for mutating in [false, true]
-                value_true = rand(model)
+                value_true = DynamicPPL.TestUtils.rand_prior_true(model)
                 varnames = DynamicPPL.TestUtils.varnames(model)
                 varinfos = DynamicPPL.TestUtils.setup_varinfos(model, value_true, varnames)
                 @testset "$(short_varinfo_name(varinfo))" for varinfo in varinfos


### PR DESCRIPTION
This PR does two things:
1. `rand(model)` and others now, correctly, makes use of the context already attached to `model`. If we don't, stuff like `condition` will be completely ignored.
2. Removes overloads of `rand(rng, NamedTuple, model)` in `TestUtils`. This has annoyed me for quite some while because it means that we can't use properly test `rand(model)` since all of our test-models have this explicitly implemented (this was originally `example_values` in the PR where `TestUtils` but we decided to change it to overloading `rand` somewhere along the way).

Technically we can put change (1) in a PR on its own, but without change (2) it's non-trivial to test properly, hence why I'm doing both together.

The question is: is this then a breaking PR? _Technically_ the existing `rand` implementations did exactly what they were supposed to do, i.e. when you called `rand`, you got back a `NamedTuple` of the variables as they appear in `model`, hence removing these implementations of `rand` (and thus hitting the default impl of `rand` for `Model`) _should_ not change the behavior, as seen from the callers. In effect, we're just adding another method `rand_prior_true` :shrug:

So maybe it's okay to just make this a patch-release? The "new" (i.e. now default) implementations of `rand` are also now tested to be the same as `rand_prior_true`.