### PR TITLE
`link` and `invlink` should correctly work with `Selector` and thus `Gibbs`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.23.18"
+version = "0.23.19"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ AbstractPPL = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
 BangBang = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
 Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -21,6 +22,12 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
+[weakdeps]
+MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
+
+[extensions]
+DynamicPPLMCMCChainsExt = ["MCMCChains"]
+
 [compat]
 AbstractMCMC = "2, 3.0, 4"
 AbstractPPL = "0.6"
@@ -28,6 +35,7 @@ BangBang = "0.3"
 Bijectors = "0.13"
 ChainRulesCore = "0.9.7, 0.10, 1"
 ConstructionBase = "1.5.4"
+Compat = "4"
 Distributions = "0.23.8, 0.24, 0.25"
 DocStringExtensions = "0.8, 0.9"
 LogDensityProblems = "2"
@@ -39,11 +47,5 @@ Setfield = "0.7.1, 0.8, 1"
 ZygoteRules = "0.2"
 julia = "1.6"
 
-[extensions]
-DynamicPPLMCMCChainsExt = ["MCMCChains"]
-
 [extras]
-MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
-
-[weakdeps]
 MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -3,6 +3,7 @@ module DynamicPPL
 using AbstractMCMC: AbstractSampler, AbstractChains
 using AbstractPPL
 using Bijectors
+using Compat
 using Distributions
 using OrderedCollections: OrderedDict
 

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -909,7 +909,7 @@ end
 function _link(varinfo::UntypedVarInfo, spl::AbstractSampler)
     varinfo = deepcopy(varinfo)
     return VarInfo(
-        _link_metadata!(varinfo, varinfo.metadata, _getvns(spl)),
+        _link_metadata!(varinfo, varinfo.metadata, _getvns(varinfo, spl)),
         Base.Ref(getlogp(varinfo)),
         Ref(get_num_produce(varinfo)),
     )
@@ -993,7 +993,7 @@ end
 function _invlink(varinfo::UntypedVarInfo, spl::AbstractSampler)
     varinfo = deepcopy(varinfo)
     return VarInfo(
-        _invlink_metadata!(varinfo, varinfo.metadata, _getvns(spl)),
+        _invlink_metadata!(varinfo, varinfo.metadata, _getvns(varinfo, spl)),
         Base.Ref(getlogp(varinfo)),
         Ref(get_num_produce(varinfo)),
     )

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -910,7 +910,7 @@ _getvns_link(varinfo::VarInfo, spl::AbstractSampler) = _getvns(varinfo, spl)
 _getvns_link(varinfo::UntypedVarInfo, spl::SampleFromPrior) = nothing
 _getvns_link(varinfo::TypedVarInfo, spl::SampleFromPrior) = map(
     Base.Returns(nothing),
-    _getvns(varinfo, spl)
+    varinfo.metadata
 )
 
 function link(::DynamicTransformation, varinfo::VarInfo, spl::AbstractSampler, model::Model)

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -1038,7 +1038,7 @@ function _invlink_metadata!(varinfo::VarInfo, metadata::Metadata, target_vns)
     # Construct the new transformed values, and keep track of their lengths.
     vals_new = map(vns) do vn
         # Return early if we're already in constrained space OR if we're not
-        # supposed to touch this `vn`.
+        # supposed to touch this `vn`, e.g. when `vn` does not belong to the current sampler. 
         # HACK: if `target_vns` is `nothing`, we ignore the `target_vns` check.
         if !istrans(varinfo, vn) || (target_vns !== nothing && vn ∉ target_vns)
             return metadata.vals[getrange(metadata, vn)]

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -917,23 +917,19 @@ end
 
 function _link(varinfo::TypedVarInfo, spl::AbstractSampler)
     varinfo = deepcopy(varinfo)
-    md = _link_metadata_namedtuple!(varinfo, varinfo.metadata, _getvns(varinfo, spl), Val(getspace(spl)))
+    md = _link_metadata_namedtuple!(
+        varinfo, varinfo.metadata, _getvns(varinfo, spl), Val(getspace(spl))
+    )
     return VarInfo(md, Base.Ref(getlogp(varinfo)), Ref(get_num_produce(varinfo)))
 end
 
 @generated function _link_metadata_namedtuple!(
-    varinfo::VarInfo,
-    metadata::NamedTuple{names},
-    vns::NamedTuple,
-    ::Val{space}
+    varinfo::VarInfo, metadata::NamedTuple{names}, vns::NamedTuple, ::Val{space}
 ) where {names,space}
     vals = Expr(:tuple)
     for f in names
         if inspace(f, space) || length(space) == 0
-            push!(
-                vals.args,
-                :(_link_metadata!(varinfo, metadata.$f, vns.$f))
-            )
+            push!(vals.args, :(_link_metadata!(varinfo, metadata.$f, vns.$f)))
         else
             push!(vals.args, :(metadata.$f))
         end
@@ -1005,23 +1001,19 @@ end
 
 function _invlink(varinfo::TypedVarInfo, spl::AbstractSampler)
     varinfo = deepcopy(varinfo)
-    md = _invlink_metadata_namedtuple!(varinfo, varinfo.metadata, _getvns(varinfo, spl), Val(getspace(spl)))
+    md = _invlink_metadata_namedtuple!(
+        varinfo, varinfo.metadata, _getvns(varinfo, spl), Val(getspace(spl))
+    )
     return VarInfo(md, Base.Ref(getlogp(varinfo)), Ref(get_num_produce(varinfo)))
 end
 
 @generated function _invlink_metadata_namedtuple!(
-    varinfo::VarInfo,
-    metadata::NamedTuple{names},
-    vns::NamedTuple,
-    ::Val{space}
+    varinfo::VarInfo, metadata::NamedTuple{names}, vns::NamedTuple, ::Val{space}
 ) where {names,space}
     vals = Expr(:tuple)
     for f in names
         if inspace(f, space) || length(space) == 0
-            push!(
-                vals.args,
-                :(_invlink_metadata!(varinfo, metadata.$f, vns.$f))
-            )
+            push!(vals.args, :(_invlink_metadata!(varinfo, metadata.$f, vns.$f)))
         else
             push!(vals.args, :(metadata.$f))
         end

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -908,10 +908,9 @@ end
 # This is quite hacky, but seems safer than changing the behavior of `_getvns`.
 _getvns_link(varinfo::VarInfo, spl::AbstractSampler) = _getvns(varinfo, spl)
 _getvns_link(varinfo::UntypedVarInfo, spl::SampleFromPrior) = nothing
-_getvns_link(varinfo::TypedVarInfo, spl::SampleFromPrior) = map(
-    Base.Returns(nothing),
-    varinfo.metadata
-)
+function _getvns_link(varinfo::TypedVarInfo, spl::SampleFromPrior)
+    return map(Base.Returns(nothing), varinfo.metadata)
+end
 
 function link(::DynamicTransformation, varinfo::VarInfo, spl::AbstractSampler, model::Model)
     return _link(varinfo, spl)

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -909,7 +909,7 @@ end
 _getvns_link(varinfo::VarInfo, spl::AbstractSampler) = _getvns(varinfo, spl)
 _getvns_link(varinfo::UntypedVarInfo, spl::SampleFromPrior) = nothing
 function _getvns_link(varinfo::TypedVarInfo, spl::SampleFromPrior)
-    return map(Base.Returns(nothing), varinfo.metadata)
+    return map(Returns(nothing), varinfo.metadata)
 end
 
 function link(::DynamicTransformation, varinfo::VarInfo, spl::AbstractSampler, model::Model)


### PR DESCRIPTION
https://github.com/TuringLang/Turing.jl/pull/2096 is failing because the current implementations of `link` and `invlink` ignore the "space" of the sampler.

This PR makes it so that `link` and `invlink` now more closely replicates the behavior of `link!!` and `invlink!!`.

I saw "more closely" because they are still different. The "immutable" versions supports changing the sizes of the underlying storage (which is necessary when we're working with distribution whose dimensionality changes when linking, e.g. `Dirichlet`).