### PR TITLE
Make `initial_state` as a keyword argument 

### DIFF
--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -87,9 +87,9 @@ function AbstractMCMC.sample(
     N::Integer;
     chain_type=default_chain_type(sampler),
     resume_from=nothing,
+    initial_state = loadstate(resume_from),
     kwargs...,
 )
-    initial_state = loadstate(resume_from)
     return AbstractMCMC.mcmcsample(
         rng, model, sampler, N; chain_type, initial_state, kwargs...
     )


### PR DESCRIPTION
@devmotion, maybe this will do the trick? The advantage is it allows one to override the `initial_state` argument while keeping it backwards compatible for now. We can remove `resume_from` in the next breaking release. 