### PR TITLE
Also pass in `context` as an argument to `acclogp!!`

### DIFF
--- a/src/abstract_varinfo.jl
+++ b/src/abstract_varinfo.jl
@@ -107,12 +107,20 @@ Set the log of the joint probability of the observed data and parameters sampled
 function setlogp!! end
 
 """
-    acclogp!!(vi::AbstractVarInfo, logp)
+    acclogp!!([context::AbstractContext, ]vi::AbstractVarInfo, logp)
 
 Add `logp` to the value of the log of the joint probability of the observed data and
 parameters sampled in `vi`, mutating if it makes sense.
 """
-function acclogp!! end
+function acclogp!!(context::AbstractContext, vi::AbstractVarInfo, logp)
+    return acclogp!!(NodeTrait(context), context, vi, logp)
+end
+function acclogp!!(::IsLeaf, context::AbstractContext, vi::AbstractVarInfo, logp)
+    return acclogp!!(vi, logp)
+end
+function acclogp!!(::IsParent, context::AbstractContext, vi::AbstractVarInfo, logp)
+    return acclogp!!(childcontext(context), vi, logp)
+end
 
 """
     resetlogp!!(vi::AbstractVarInfo)

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -115,7 +115,7 @@ probability of `vi` with the returned value.
 """
 function tilde_assume!!(context, right, vn, vi)
     value, logp, vi = tilde_assume(context, right, vn, vi)
-    return value, acclogp!!(vi, logp)
+    return value, acclogp!!(context, vi, logp)
 end
 
 # observe
@@ -181,7 +181,7 @@ probability of `vi` with the returned value.
 """
 function tilde_observe!!(context, right, left, vi)
     logp, vi = tilde_observe(context, right, left, vi)
-    return left, acclogp!!(vi, logp)
+    return left, acclogp!!(context, vi, logp)
 end
 
 function assume(rng, spl::Sampler, dist)
@@ -383,7 +383,7 @@ Falls back to `dot_tilde_assume(context, right, left, vn, vi)`.
 """
 function dot_tilde_assume!!(context, right, left, vn, vi)
     value, logp, vi = dot_tilde_assume(context, right, left, vn, vi)
-    return value, acclogp!!(vi, logp), vi
+    return value, acclogp!!(context, vi, logp), vi
 end
 
 # `dot_assume`
@@ -634,7 +634,7 @@ Falls back to `dot_tilde_observe(context, right, left, vi)`.
 """
 function dot_tilde_observe!!(context, right, left, vi)
     logp, vi = dot_tilde_observe(context, right, left, vi)
-    return left, acclogp!!(vi, logp)
+    return left, acclogp!!(context, vi, logp)
 end
 
 # Falls back to non-sampler definition.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -70,7 +70,7 @@ true
 """
 macro addlogprob!(ex)
     return quote
-        $(esc(:(__varinfo__))) = acclogp!!($(esc(:(__varinfo__))), $(esc(ex)))
+        $(esc(:(__varinfo__))) = acclogp!!($(esc(:(__context__))), $(esc(:(__varinfo__))), $(esc(ex)))
     end
 end
 


### PR DESCRIPTION
Some samplers have very specific ways of accumulating log-probabilities which they do through overloading of the tilde-pipeline, e.g. `PG` in Turing overloads both `assume` and `observe` because it needs to accumulate the log-probabilities in the _task local_ `varinfo` rather than the "global" `varinfo`.

But this means that, in certain scenarios, e.g. `PG`, usage of `@acclogprob!!` in a model will (silently) result in target the incorrect model!

One way we can fix this is to also pass in the `context` to `@acclogprob!!` (and `acclogp!!`), which can then alter how the log-probs are accumualted.

A few examples where this is useful:
- Particle samplers from AdvancedPS.jl, e.g. `PG` in Turing.jl, can then correctly handle `@addlogprob!!` by accumulating the log-probabilities in the task-local `varinfo` rather than the "global" `varinfo`.
- We can remove some hacks used in particle samplers that break composability with other contexts; in particular, instead of accumulating log-probs in the `assume` and returning 0 instead of the actual `logp` value (as is done here: https://github.com/TuringLang/Turing.jl/blob/6649f10c48917a27531214f02777408d2ab82928/src/mcmc/particle_mcmc.jl#L376), we can simply return the `logp` value as we do in all other implementations of `assume` and let the `acclogp!!` call in `tilde_assume` handle the accumulation to the task-local `varinfo`. This would then make particle samplers compatible with stuff like re-weighting of log-probabilities, e.g. using `MiniBatchContext` or the `GibbsContext` in https://github.com/TuringLang/Turing.jl/pull/2099 which overrides the `assume` statements to instead return a conditioned value + its logprob, while avoiding hitting the `observe`.