### PR TITLE
Fix test error with Turing >= 0.30

### DIFF
--- a/test/turing/Project.toml
+++ b/test/turing/Project.toml
@@ -6,6 +6,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
-DynamicPPL = "0.20, 0.21, 0.22, 0.23, 0.24"
-Turing = "0.21 - 0.30"
-julia = "1.6"
+DynamicPPL = "0.24"
+Turing = "0.30"
+julia = "1.7"

--- a/test/turing/compiler.jl
+++ b/test/turing/compiler.jl
@@ -110,7 +110,9 @@
         end
 
         chain = sample(
-            newinterface(obs), HMC{Turing.ForwardDiffAD{2}}(0.75, 3, :p, :x), 100
+            newinterface(obs),
+            HMC(0.75, 3, :p, :x; adtype = AutoForwardDiff(; chunksize = 2)),
+            100,
         )
     end
     @testset "no return" begin


### PR DESCRIPTION
The PR updates the Turing tests for the changes in version 0.30.

I expect that the LKJ tests still fail due to an unfortunate behaviour of LinearAlgebra in Julia 1.10:
```julia
julia> using LinearAlgebra

julia> X = convert(Matrix{Real}, rand(2, 2))
2×2 Matrix{Real}:
 0.550882  0.54726
 0.921542  0.647784

julia> typeof(X)
Matrix{Real} (alias for Array{Real, 2})

julia> UpperTriangular(X)' * UpperTriangular(X)
ERROR: InexactError: Int64(0.30147568734789565)
Stacktrace:
 [1] Int64
   @ Base ./float.jl:909 [inlined]
 [2] convert(::Type{Int64}, x::Float64)
   @ Base ./number.jl:7
 [3] setindex!
   @ ./array.jl:1024 [inlined]
 [4] generic_trimatmul!(C::Matrix{…}, uploc::Char, isunitc::Char, tfun::typeof(adjoint), A::Matrix{…}, B::UpperTriangular{…})
   @ LinearAlgebra ~/.asdf/installs/julia/1.10.0/share/julia/stdlib/v1.10/LinearAlgebra/src/triangular.jl:946
 [5] _trimul!
   @ LinearAlgebra ~/.asdf/installs/julia/1.10.0/share/julia/stdlib/v1.10/LinearAlgebra/src/triangular.jl:711 [inlined]
 [6] mul!
   @ LinearAlgebra ~/.asdf/installs/julia/1.10.0/share/julia/stdlib/v1.10/LinearAlgebra/src/triangular.jl:693 [inlined]
 [7] *(A::LowerTriangular{Real, Adjoint{Real, Matrix{Real}}}, B::UpperTriangular{Real, Matrix{Real}})
   @ LinearAlgebra ~/.asdf/installs/julia/1.10.0/share/julia/stdlib/v1.10/LinearAlgebra/src/triangular.jl:1463
 [8] top-level scope
   @ REPL[7]:1
Some type information was truncated. Use `show(err)` to see complete types.

julia> LowerTriangular(X) * LowerTriangular(X)'
ERROR: InexactError: Int64(0.5076607013553399)
Stacktrace:
 [1] Int64
   @ Base ./float.jl:909 [inlined]
 [2] convert(::Type{Int64}, x::Float64)
   @ Base ./number.jl:7
 [3] setindex!
   @ ./array.jl:1024 [inlined]
 [4] generic_trimatmul!(C::Matrix{Int64}, uploc::Char, isunitc::Char, tfun::typeof(identity), A::Matrix{Real}, B::UpperTriangular{Real, Adjoint{Real, Matrix{Real}}})
   @ LinearAlgebra ~/.asdf/installs/julia/1.10.0/share/julia/stdlib/v1.10/LinearAlgebra/src/triangular.jl:958
 [5] _trimul!
   @ LinearAlgebra ~/.asdf/installs/julia/1.10.0/share/julia/stdlib/v1.10/LinearAlgebra/src/triangular.jl:711 [inlined]
 [6] mul!
   @ LinearAlgebra ~/.asdf/installs/julia/1.10.0/share/julia/stdlib/v1.10/LinearAlgebra/src/triangular.jl:693 [inlined]
 [7] *(A::LowerTriangular{Real, Matrix{Real}}, B::UpperTriangular{Real, Adjoint{Real, Matrix{Real}}})
   @ LinearAlgebra ~/.asdf/installs/julia/1.10.0/share/julia/stdlib/v1.10/LinearAlgebra/src/triangular.jl:1463
 [8] top-level scope
   @ REPL[14]:1

julia> versioninfo()
Julia Version 1.10.0
Commit 3120989f39b (2023-12-25 18:01 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: macOS (arm64-apple-darwin22.4.0)
  CPU: 10 × Apple M2 Pro
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-15.0.7 (ORCJIT, apple-m1)
  Threads: 1 on 6 virtual cores
Environment:
  JULIA_PKG_USE_CLI_GIT = true
```

On  previous Julia versions this example worked:
```julia
julia> using LinearAlgebra

julia> X = convert(Matrix{Real}, rand(2, 2))
2×2 Matrix{Real}:
 0.811948  0.080013
 0.10377   0.688589

julia> UpperTriangular(X)' * UpperTriangular(X)
2×2 Matrix{Real}:
 0.659259   0.0649664
 0.0649664  0.480556

julia> LowerTriangular(X) * LowerTriangular(X)'
2×2 Matrix{Real}:
 0.659259   0.0842561
 0.0842561  0.484923

julia> versioninfo()
Julia Version 1.9.4
Commit 8e5136fa297 (2023-11-14 08:46 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: macOS (arm64-apple-darwin22.4.0)
  CPU: 10 × Apple M2 Pro
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, apple-m1)
  Threads: 1 on 6 virtual cores
Environment:
  JULIA_PKG_USE_CLI_GIT = true
```

On the Julia master branch the problem was fixed (maybe in https://github.com/JuliaLang/julia/pull/52464?) but I wonder if we could make the `Vector{Real}` that shows up in DynamicPPL and Bijectors in the first place to avoid this problem also on Julia 1.10. Alternatively, we could use `Bijectors.pd_upper(X) = collect(UpperTriangular(X)') * collect(UpperTriangular(X))` etc. on Julia 1.10.