### PR TITLE
Better init_theta size mismatch error

### DIFF
--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -145,10 +145,10 @@ function initialize_parameters!!(
     end
     theta = vi[spl]
     length(theta) == length(init_theta) ||
-        error("Provided initial value doesn't match the dimension of the model")
+        throw(DimensionMismatch("Provided initial value size ($(length(init_theta))) doesn't match the model size ($(length(theta)))"))
 
     # Update values that are provided.
-    for i in 1:length(init_theta)
+    for i in eachindex(init_theta)
         x = init_theta[i]
         if x !== missing
             theta[i] = x


### PR DESCRIPTION
Just a tiny tweak. Providing how exactly the sizes do not match helps debugging.