### PR TITLE
Fix for default `AutoForwardDiff`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.24.7"
+version = "0.24.8"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/DynamicPPLForwardDiffExt.jl
+++ b/ext/DynamicPPLForwardDiffExt.jl
@@ -26,7 +26,7 @@ function LogDensityProblemsAD.ADgradient(
         ForwardDiff.Tag(f, eltype(θ))
     end
     chunk_size = getchunksize(ad)
-    chunk = if chunk_size == 0
+    chunk = if chunk_size == 0 || chunk_size === nothing
         ForwardDiff.Chunk(θ)
     else
         ForwardDiff.Chunk(length(θ), chunk_size)

--- a/test/ext/DynamicPPLForwardDiffExt.jl
+++ b/test/ext/DynamicPPLForwardDiffExt.jl
@@ -1,5 +1,5 @@
 @testset "tag" begin
-    for chunksize in (0, 1, 10)
+    for chunksize in (nothing, 0, 1, 10)
         ad = ADTypes.AutoForwardDiff(; chunksize=chunksize)
         standardtag = if !isdefined(Base, :get_extension)
             DynamicPPL.DynamicPPLForwardDiffExt.standardtag


### PR DESCRIPTION
By default, `AutoForwardDiff()` results in `chunksize` being `nothing`, not `0`.

This then breaks our `LogDensityProblemsAD.ADgradient` constructor.