### PR TITLE
Use `subsumes` in `subset`

### DIFF
--- a/src/simple_varinfo.jl
+++ b/src/simple_varinfo.jl
@@ -430,18 +430,21 @@ function subset(varinfo::SimpleVarInfo, vns::AbstractVector{<:VarName})
 end
 
 function _subset(x::AbstractDict, vns)
-    # NOTE: This requires `vns` to be explicitly present in `x`.
-    if any(!Base.Fix1(haskey, x), vns)
+    vns_present = collect(keys(x))
+    vns_found = mapreduce(vcat, vns) do vn
+        return map(Base.Fix1(subsumes, vn), vs_present)
+    end
+
+    # NOTE: This `vns` to be subsume varnames explicitly present in `x`.
+    if isempty(vns_found)
         throw(
             ArgumentError(
-                "Cannot subset `AbstractDict` with `VarName` that is not an explicit key. " *
-                "For example, if `keys(x) == [@varname(x[1])]`, then subsetting with " *
-                "`@varname(x[1])` is allowed, but subsetting with `@varname(x)` is not.",
+                "Cannot subset `AbstractDict` with `VarName` which does not subsume any keys.",
             ),
         )
     end
     C = ConstructionBase.constructorof(typeof(x))
-    return C(vn => x[vn] for vn in vns)
+    return C(vn => x[vn] for vn in vns_found)
 end
 
 function _subset(x::NamedTuple, vns)

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -264,8 +264,12 @@ function subset(varinfo::TypedVarInfo, vns::AbstractVector{<:VarName})
     return VarInfo(NamedTuple{syms}(metadatas), varinfo.logp, varinfo.num_produce)
 end
 
-function subset(metadata::Metadata, vns::AbstractVector{<:VarName})
+function subset(metadata::Metadata, vns_given::AbstractVector{<:VarName})
     # TODO: Should we error if `vns` contains a variable that is not in `metadata`?
+    # For each `vn` in `vns`, get the variables subsumed by `vn`.
+    vns = mapreduce(vcat, vns_given) do vn
+        filter(Base.Fix1(subsumes, vn), metadata.vns)
+    end
     indices_for_vns = map(Base.Fix1(getindex, metadata.idcs), vns)
     indices = Dict(vn => i for (i, vn) in enumerate(vns))
     # Construct new `vals` and `ranges`.

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -483,7 +483,14 @@ DynamicPPL.getspace(::DynamicPPL.Sampler{MySAlg}) = (:s,)
             [@varname(s), @varname(m), @varname(x[2])],
             [@varname(s), @varname(x[1]), @varname(x[2])],
             [@varname(m), @varname(x[1]), @varname(x[2])],
-            [@varname(s), @varname(m), @varname(x[1]), @varname(x[2])],
+        ]
+
+        # Patterns requiring `subsumes`.
+        vns_supported_with_subsumes = [
+            [@varname(s), @varname(x)] => [@varname(s), @varname(x[1]), @varname(x[2])],
+            [@varname(m), @varname(x)] => [@varname(m), @varname(x[1]), @varname(x[2])],
+            [@varname(s), @varname(m), @varname(x)] =>
+                [@varname(s), @varname(m), @varname(x[1]), @varname(x[2])],
         ]
 
         # `SimpleaVarInfo` only supports subsetting using the varnames as they appear
@@ -507,6 +514,24 @@ DynamicPPL.getspace(::DynamicPPL.Sampler{MySAlg}) = (:s,)
                 check_varinfo_keys(varinfo_subset, vns_subset)
                 # Values should be the same.
                 @test [varinfo_subset[vn] for vn in vns_subset] == [varinfo[vn] for vn in vns_subset]
+
+                # `merge` with the original.
+                varinfo_merged = merge(varinfo, varinfo_subset)
+                vns_merged = keys(varinfo_merged)
+                # Should be equivalent.
+                check_varinfo_keys(varinfo_merged, vns)
+                # Values should be the same.
+                @test [varinfo_merged[vn] for vn in vns] == [varinfo[vn] for vn in vns]
+            end
+
+            @testset "$(convert(Vector{VarName}, vns_subset))" for (
+                vns_subset, vns_target
+            ) in vns_supported_with_subsumes
+                varinfo_subset = subset(varinfo, vns_subset)
+                # Should now only contain the variables in `vns_subset`.
+                check_varinfo_keys(varinfo_subset, vns_target)
+                # Values should be the same.
+                @test [varinfo_subset[vn] for vn in vns_target] == [varinfo[vn] for vn in vns_target]
 
                 # `merge` with the original.
                 varinfo_merged = merge(varinfo, varinfo_subset)


### PR DESCRIPTION
I was using the new (experimental) Gibbs sampler in Turing.jl (https://github.com/TuringLang/Turing.jl/pull/2099) I realized that there the current `subset` functionality, which enables the new Gibbs sampler, is not _quite_ flexible enough to handle all the cases that the current Gibbs sampler can.

In particular, we need to use `subsumes` in `subset` rather than require explicit presence of the `VarName` we're interested in.

The reason for this is to support models where the size of the support might be changing. For example:

``` julia
julia> using Distributions, DynamicPPL

julia> @model function demo()
           n ~ Categorical(10)
           x = Vector{Float64}(undef, n)
           for i = 1:n
               x[i] ~ Normal()
           end
       end
demo (generic function with 2 methods)

julia> model = demo();

julia> varinfo = VarInfo();

julia> DynamicPPL.evaluate!!(model, varinfo)
```

Suppose I now want to do:

``` julia
subset(varinfo, @varname(x))
```

That is currently not possible since we only allow passing varnames that are *explicit* present in the `varinfo`. And so we have to manually call `subsumes`, and so on. It seems to me that it's worth just using `subsumes` already in the impl of `subset` so we avoid these annoyances on the user-side.

*Note that this is technically not prohibiting feature-parity with the existing Gibbs sampler, as we could implement this `subsumes` filtering in the Gibbs sampler itself before calling `subset`, but this PR just seems cleaner IMO.*