### PR TITLE
Adds `@is_post_processing` macro

### DIFF
--- a/ext/DynamicPPLMCMCChainsExt.jl
+++ b/ext/DynamicPPLMCMCChainsExt.jl
@@ -54,7 +54,7 @@ function DynamicPPL.generated_quantities(
 
         # TODO: Some of the variables can be a view into the `varinfo`, so we need to
         # `deepcopy` the `varinfo` before passing it to `model`.
-        model(deepcopy(varinfo))
+        model(deepcopy(varinfo), DynamicPPL.PostProcessingContext())
     end
 end
 

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -129,6 +129,7 @@ export AbstractVarInfo,
     unfix,
     # Convenience macros
     @addlogprob!,
+    @is_post_processing,
     @submodel,
     value_iterator_from_chain
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1,6 +1,28 @@
 const INTERNALNAMES = (:__model__, :__context__, :__varinfo__)
 
 """
+    check_if_in_model_block_expr(name)
+
+Return an expression that can be evaluated to check if we're inside a model block.
+
+# Arguments
+- `name`: The name of the variable or method that can only be used inside a model block.
+    Error message will include this name.
+"""
+function check_if_in_model_block_expr(name)
+    return Expr(
+        :||,
+        Expr(
+            :&&,
+            Expr(:isdefined, esc(:__model__)),
+            Expr(:call, :isa, esc(:__model__), Model),
+        ),
+        # Otherwise, throw error.
+        :(error($(string(name)) * " can only be used inside a model block")),
+    )
+end
+
+"""
     need_concretize(expr)
 
 Return `true` if `expr` needs to be concretized, i.e., if it contains a colon `:` or 

--- a/src/model.jl
+++ b/src/model.jl
@@ -1253,7 +1253,7 @@ function generated_quantities(model::Model, chain::AbstractChains)
     iters = Iterators.product(1:size(chain, 1), 1:size(chain, 3))
     return map(iters) do (sample_idx, chain_idx)
         setval_and_resample!(varinfo, chain, sample_idx, chain_idx)
-        model(varinfo)
+        model(varinfo, PostProcessingContext())
     end
 end
 
@@ -1295,11 +1295,11 @@ julia> generated_quantities(model, values(parameters), keys(parameters))
 function generated_quantities(model::Model, parameters::NamedTuple)
     varinfo = VarInfo(model)
     setval_and_resample!(varinfo, values(parameters), keys(parameters))
-    return model(varinfo)
+    return model(varinfo, PostProcessingContext())
 end
 
 function generated_quantities(model::Model, values, keys)
     varinfo = VarInfo(model)
     setval_and_resample!(varinfo, values, keys)
-    return model(varinfo)
+    return model(varinfo, PostProcessingContext())
 end

--- a/src/submodel_macro.jl
+++ b/src/submodel_macro.jl
@@ -241,6 +241,7 @@ function submodel(prefix_expr, expr, ctx=esc(:__context__))
             )
         end
         quote
+            $(check_if_in_model_block_expr("@submodel"))
             $retval, $(esc(:__varinfo__)) = $(_evaluate!!)(
                 $(esc(R)), $(esc(:__varinfo__)), $(ctx)
             )

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -70,6 +70,7 @@ true
 """
 macro addlogprob!(ex)
     return quote
+        $(check_if_in_model_block_expr("@addlogprob!"))
         $(esc(:(__varinfo__))) = acclogp!!(
             $(esc(:(__context__))), $(esc(:(__varinfo__))), $(esc(ex))
         )


### PR DESCRIPTION
We're seeing more and more users making use of `generated_quantities` and the like, which means there are more and more use-cases where the user wants to exclude certain computations from the model during inference but include these during "post-processing"-steps (can we find a better name?).

This PR adds a macro `@is_post_processing` (again, better name please <3) which can be used to conditionally perform computation when not doing inference.

E.g.

``` julia
julia> @model function demo()
           x ~ Normal(0, 1)
           if @is_post_processing
               return x
           else
               return nothing
           end
       end
demo (generic function with 2 methods)

julia> model = demo();

julia> model()

julia> generated_quantities(model, (x = 1,))
1.0
```

This topic has come up on multiple occasions: https://github.com/TuringLang/DynamicPPL.jl/issues/510, https://github.com/TuringLang/DynamicPPL.jl/issues/94#issuecomment-683272598, and definitively other places too. I know there's generally a reluctance to rely on additional macros for these purposes but AFAIK there's no better solution, so at some point, e.g. now, I think we gotta bite the bullet and get something done.

And I don't think making the user add specific arguments to the model indicating whether they're in "post-processing"-mode or inference-mode is a good way to go for the following reasons:
1. The users needs to do this. As we have more users who are not familiar with Julia, this is not immediately obvious.
2. Doing "correctly", i.e. in a way that the check actually compiles away is non-trivial for basic users.
3. Only a context-based approach works well with nested models, i.e. usage of `@submodel`, since otherwise this "are we inference-ing"-argument needs to be passed down aaaall the models, which is annoying. Doing it with contexts, as we do in this PR, nesting of models, etc. _just works_.