### PR TITLE
[Proof of concept] Handling latent parameters

### DIFF
--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -181,6 +181,7 @@ include("logdensityfunction.jl")
 include("model_utils.jl")
 include("extract_priors.jl")
 include("values_as_in_model.jl")
+include("latent_handling.jl")
 
 include("debug_utils.jl")
 using .DebugUtils

--- a/src/latent_handling.jl
+++ b/src/latent_handling.jl
@@ -1,0 +1,108 @@
+struct LatentHandlingContext{Ctx<:AbstractContext} <: AbstractContext
+    context::Ctx
+end
+
+LatentHandlingContext() = LatentHandlingContext(DefaultContext())
+
+NodeTrait(context::LatentHandlingContext) = IsParent()
+childcontext(context::LatentHandlingContext) = context.context
+function setchildcontext(context::LatentHandlingContext, child::AbstractContext)
+    return LatentHandlingContext(child)
+end
+
+"""
+    latent(dist)
+
+Return a distribution for the latent parameters of `dist`.
+"""
+function latent end
+
+"""
+    conditional(dist, latents)
+
+Return the distribution of emissions with the latent parameters of `dist` set to `latents`.
+"""
+function conditional end
+
+"""
+    marginalize(dist)
+
+Return the `dist` with the latent parameters marginalized out.
+"""
+function marginalize end
+
+"""
+    has_latents(dist)
+
+Return `true` if the distribution `dist` has latent parameters, otherwise `false`.
+
+Note that if `has_latents(dist) = true`, then `dist` is assumed to implement the following methods:
+1. `latent(dist)`: Return the latent parameters of the distribution.
+2. `conditional(dist, latents)`: Return a new distribution with the latent parameters set to `latents`.
+3. `marginalize(dist)`: Return a new distribution with the latent parameters marginalized out.
+"""
+has_latents(dist) = false
+
+# Overload the tilde-statements to handle latent parameters.
+function suffix_varname(vn::VarName{sym}, ::Val{suffix}) where {sym,suffix}
+    return VarName{Symbol(sym, ".", suffix)}(vn.optic)
+end
+
+# Cand dispatch on `dist` to choose different suffixes for latent variables.
+suffix_latent_varname(dist, vn) = suffix_varname(vn, Val{:latent}())
+
+# `tilde_assume`
+function tilde_assume(context::LatentHandlingContext, right, vn, vi)
+    has_latents(right) || return tilde_assume(childcontext(context), right, vn, vi)
+    # Execute `tilde_assume` for the latent variables first.
+    right_latent = latent(right)
+    value_latent, logp_marginal, vi = tilde_assume(
+        childcontext(context), right_latent, suffix_latent_varname(right, vn), vi
+    )
+    # Now execute the conditional on the latent variables.
+    right_conditional = conditional(right, value_latent)
+    value_conditional, logp_conditional, vi = tilde_assume(
+        childcontext(context), right_conditional, vn, vi
+    )
+    # Return as usual.
+    return value_conditional, logp_marginal + logp_conditional, vi
+end
+function tilde_assume(
+    rng::Random.AbstractRNG, context::LatentHandlingContext, sampler, right, vn, vi
+)
+    if !has_latents(right)
+        return tilde_assume(rng, childcontext(context), sampler, right, vn, vi)
+    end
+    # Execute `tilde_assume` for the latent variables first.
+    right_latent = latent(right)
+    value_latent, logp_marginal, vi = tilde_assume(
+        rng,
+        childcontext(context),
+        sampler,
+        right_latent,
+        suffix_latent_varname(right, vn),
+        vi,
+    )
+    # Now execute the conditional on the latent variables.
+    right_conditional = conditional(right, value_latent)
+    value_conditional, logp_conditional, vi = tilde_assume(
+        rng, childcontext(context), sampler, right_conditional, vn, vi
+    )
+    # Return as usual.
+    return value_conditional, logp_marginal + logp_conditional, vi
+end
+# `tilde_observe`
+function tilde_observe(context::LatentHandlingContext, right, left, vi)
+    has_latents(right) || return tilde_observe(childcontext(context), right, left, vi)
+    # When used as `observe`, we want to use the marginalized version.
+    right_marginal = marginalize(right)
+    return tilde_observe(childcontext(context), right_marginal, left, vi)
+end
+function tilde_observe(context::LatentHandlingContext, sampler, right, left, vi)
+    if !has_latents(right)
+        return tilde_observe(childcontext(context), sampler, right, left, vi)
+    end
+    # When used as `observe`, we want to use the marginalized version.
+    right_marginal = marginalize(right)
+    return tilde_observe(childcontext(context), sampler, right_marginal, left, vi)
+end


### PR DESCRIPTION
Okay, so this all started from this gist https://gist.github.com/JasonPekos/82be830e4bf390fd1cc2886a7518aede by @JasonPekos using Turing.jl combined with @gdalle's HiddenMarkovModels.jl.


This PR demonstrates how we could support such latent parameter models on the RHS of `~` without any / minimal intervention of the user, aaannd it's fairly easy to handle. 

We could also do the same to replace `@submodel`, though there it's a bit non-trivial because there are two "types" of realizations: the random variables involved in `~` and those `return`ed, so let's leave that for now.

But with this PR, one needs to implement a few methods:
- `latent(dist)`: returns a `Distribution` for the latent parameters.
- `conditional(dist, latents)`: returns a `Distribution` for the conditional distribution of the data given the latent parameters.
- `marginalize(dist)`: returns a `Distribution` for the marginal distribution of the data.

And that's it!

For example, to allow straight-forward usage of HiddenMarkovModels.jl with Turing.jl, the following "just works":

``` julia
using DynamicPPL, Distributions, HiddenMarkovModels, Random, LinearAlgebra, Bijectors

struct FixedLengthHMM{M}
    hmm::M
    n::Int
end

struct MarginalizedHMM{M,V,F} <: Distribution{V,F}
    hmm::M
end

function MarginalizedHMM(hmm::FixedLengthHMM)
    # TODO: Determine variate form and type from `hmm`.
    return MarginalizedHMM{typeof(hmm),Multivariate,Continuous}(hmm)
end

UnivariateMarginalizedHMM = MarginalizedHMM{<:FixedLengthHMM,Univariate,Continuous}
MultivariateMarginalizedHMM = MarginalizedHMM{<:FixedLengthHMM,Multivariate,Continuous}

function Distributions.rand(rng::Random.AbstractRNG, dist::MarginalizedHMM)
    return last(rand(dist.hmm.hmm, dist.hmm.n))
end
function Distributions.logpdf(dist::MarginalizedHMM, x::AbstractVector{<:Real})
    return logdensityof(dist.hmm.hmm, x)
end
function Distributions.logpdf(dist::MarginalizedHMM, x::Real)
    return logdensityof(dist.hmm.hmm, x)
end

# Latent distribution.
struct LatentDistribution{M,V,F} <: Distribution{V,F}
    hmm::M
end

function LatentDistribution(hmm::FixedLengthHMM)
    return LatentDistribution{typeof(hmm),Multivariate,Discrete}(hmm)
end

function Distributions.rand(rng::Random.AbstractRNG, dist::LatentDistribution)
    return first(rand(dist.hmm.hmm, dist.hmm.n))
end

function Distributions.logpdf(dist::LatentDistribution, x::AbstractVector{<:Real})
    @assert length(x) == dist.hmm.n "Length of `x` must match number of latent states."
    hmm = dist.hmm.hmm
    lp = HiddenMarkovModels.log_initialization(hmm)[x[1]]
    logtrans = HiddenMarkovModels.log_transition_matrix(hmm)
    for t in 2:(dist.hmm.n)
        lp += logtrans[x[t - 1], x[t]]
    end
    return lp
end

# Conditional.
struct ConditionalHMM{M,A,V,F} <: Distribution{V,F}
    hmm::M
    latents::A
end

function ConditionalHMM(hmm::FixedLengthHMM, latents)
    # TODO: Determine variate form and type from `hmm`.
    return ConditionalHMM{typeof(hmm),typeof(latents),Multivariate,Continuous}(hmm, latents)
end

function Distributions.rand(rng::Random.AbstractRNG, dist::ConditionalHMM)
    # Sample from the emission distributions conditional on the latent states.
    hmm = dist.hmm.hmm
    conditionals = HiddenMarkovModels.obs_distributions(hmm)[dist.latents]
    return [rand(rng, c) for c in conditionals]
end

function Distributions.logpdf(dist::ConditionalHMM, y::AbstractVector{<:Real})
    hmm = dist.hmm.hmm
    conditionals = HiddenMarkovModels.obs_distributions(hmm)[dist.latents]
    return sum(logpdf(c, y[i]) for (i, c) in enumerate(conditionals))
end

# Make compatible with DPPL.
DynamicPPL.check_tilde_rhs(hmm::FixedLengthHMM) = hmm
DynamicPPL.has_latents(hmm::FixedLengthHMM) = true
# Dispatches for the different distributions.
DynamicPPL.latent(hmm::FixedLengthHMM) = LatentDistribution(hmm)
DynamicPPL.conditional(hmm::FixedLengthHMM, latents) = ConditionalHMM(hmm, latents)
DynamicPPL.marginalize(hmm::FixedLengthHMM) = MarginalizedHMM(hmm)
# Choose varname suffix.
function DynamicPPL.suffix_latent_varname(::FixedLengthHMM, vn)
    return DynamicPPL.suffix_varname(vn, Val{:z}())
end
```

With this, we have

``` julia
julia> """
           hmm(K, T)

       A Hidden Markov Model with `K` states and `T` observations with marginalized hidden states.
       """
       @model function hmm(K, T)
           # Transition matrix.
           π ~ product_distribution(fill(Dirichlet(fill(1 / K, K)), K))
           # Mean of emission distribution.
           μ ~ Bijectors.ordered(MvNormal(zeros(K), 10I))

           # HMM(init, trans, emissions).
           hmm = HMM(π[:, 1], permutedims(π), Normal.(μ, 1))
           y ~ FixedLengthHMM(hmm, T)

           return y
       end

hmm

julia> model = DynamicPPL.contextualize(hmm(K, T), DynamicPPL.LatentHandlingContext());
       # Captures the latent variables!

julia> rand(OrderedDict, model)

       # And we can condition.
OrderedDict{Any, Any} with 4 entries:
  π   => [0.88056 0.989755; 0.11944 0.010245]
  μ   => [-2.40058, 34.1099]
  y.z => [1, 1, 1, 2, 1, 1, 1, 1, 1, 2]
  y   => [-0.386338, -1.5516, -2.39555, 34.6776, -3.41318, -2.45152, -2.37044, -2.38218, -2.3104, 32.9849]

julia> y = model();

julia> model_conditioned = model | (y=y,);
       # And now the latent parameters are also gone!

julia> rand(OrderedDict, model_conditioned)
OrderedDict{Any, Any} with 2 entries:
  π => [0.755412 0.992134; 0.244588 0.00786611]
  μ => [-1.03905, -1.02069]
```

Some other people who have expressed interest in this: