### PR TITLE
Use `subsume` when checking for repeated varnames

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.26.0"
+version = "0.26.1"
 
 
 [deps]

--- a/test/debug_utils.jl
+++ b/test/debug_utils.jl
@@ -93,6 +93,23 @@
             @test !issuccess
             @test_throws ErrorException check_model(buggy_model; error_on_failure=true)
         end
+
+        @testset "subsumes (x.a then x)" begin
+            @model function buggy_subsumes_demo_model()
+                x = (a=nothing,)
+                x.a ~ Normal()
+                x ~ Normal()
+                return nothing
+            end
+            buggy_model = buggy_subsumes_demo_model()
+
+            @test_logs (:warn,) (:warn,) check_model(buggy_model)
+            issuccess = check_model(
+                buggy_model; context=SamplingContext(), record_varinfo=false
+            )
+            @test !issuccess
+            @test_throws ErrorException check_model(buggy_model; error_on_failure=true)
+        end
     end
 
     @testset "incorrect use of condition" begin

--- a/test/debug_utils.jl
+++ b/test/debug_utils.jl
@@ -59,6 +59,40 @@
             model = ModelOuterWorking()
             @test check_model(model; error_on_failure=true)
         end
+
+        @testset "subsumes (x then x[1])" begin
+            @model function buggy_subsumes_demo_model()
+                x = Vector{Float64}(undef, 2)
+                x ~ MvNormal(zeros(2), I)
+                x[1] ~ Normal()
+                return nothing
+            end
+            buggy_model = buggy_subsumes_demo_model()
+
+            @test_logs (:warn,) (:warn,) check_model(buggy_model)
+            issuccess = check_model(
+                buggy_model; context=SamplingContext(), record_varinfo=false
+            )
+            @test !issuccess
+            @test_throws ErrorException check_model(buggy_model; error_on_failure=true)
+        end
+
+        @testset "subsumes (x[1] then x)" begin
+            @model function buggy_subsumes_demo_model()
+                x = Vector{Float64}(undef, 2)
+                x[1] ~ Normal()
+                x ~ MvNormal(zeros(2), I)
+                return nothing
+            end
+            buggy_model = buggy_subsumes_demo_model()
+
+            @test_logs (:warn,) (:warn,) check_model(buggy_model)
+            issuccess = check_model(
+                buggy_model; context=SamplingContext(), record_varinfo=false
+            )
+            @test !issuccess
+            @test_throws ErrorException check_model(buggy_model; error_on_failure=true)
+        end
     end
 
     @testset "incorrect use of condition" begin


### PR DESCRIPTION
@sunxd3 pointed out that we should be using `subsume` rather than equality when checking whether a varname has been seen in the model already (https://github.com/TuringLang/Turing.jl/pull/2218#issuecomment-2100722690).

This PR does exactly that.