### PR TITLE
Refer to `logprior` in `logjoint`'s doc

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -1053,7 +1053,7 @@ Base.rand(model::Model) = rand(Random.default_rng(), NamedTuple, model)
 
 Return the log joint probability of variables `varinfo` for the probabilistic `model`.
 
-See [`logjoint`](@ref) and [`loglikelihood`](@ref).
+See [`logprior`](@ref) and [`loglikelihood`](@ref).
 """
 function logjoint(model::Model, varinfo::AbstractVarInfo)
     return getlogp(last(evaluate!!(model, varinfo, DefaultContext())))

--- a/src/simple_varinfo.jl
+++ b/src/simple_varinfo.jl
@@ -575,7 +575,7 @@ end
 
 Return the log joint probability of variables `θ` for the probabilistic `model`.
 
-See [`logjoint`](@ref) and [`loglikelihood`](@ref).
+See [`logprior`](@ref) and [`loglikelihood`](@ref).
 
 # Examples
 ```jldoctest; setup=:(using Distributions)


### PR DESCRIPTION
Feels like a typo,  c.f. `logprior` and `loglikelihood`'s docs.