### PR TITLE
Fix for `check_model` on arrays with `undef`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.27.0"
+version = "0.27.1"
 
 
 [deps]

--- a/src/debug_utils.jl
+++ b/src/debug_utils.jl
@@ -287,7 +287,15 @@ end
 
 # tilde
 _has_missings(x) = ismissing(x)
-_has_missings(x::AbstractArray) = any(ismissing, x)
+function _has_missings(x::AbstractArray)
+    # Can't just use `any` because `x` might contain `undef`.
+    for i in eachindex(x)
+        if isassigned(x, i) && _has_missings(x[i])
+            return true
+        end
+    end
+    return false
+end
 
 # assume
 function record_pre_tilde_assume!(context::DebugContext, vn, dist, varinfo)

--- a/test/debug_utils.jl
+++ b/test/debug_utils.jl
@@ -174,4 +174,16 @@
 
         @test !DynamicPPL.has_static_constraints(model)
     end
+
+    @testset "vector with `undef`" begin
+        # Source: https://github.com/TuringLang/Turing.jl/pull/2218
+        @model function demo_undef(ns...)
+            x = Array{Real}(undef, ns...)
+            @. x ~ Normal(0, 2)
+        end
+        for ns in [(2,), (2, 2), (2, 2, 2)]
+            model = demo_undef(ns...)
+            @test check_model(model; error_on_failure=true)
+        end
+    end
 end


### PR DESCRIPTION
Supersedes #607.