### PR TITLE
Added back `prob` and `logprob` macros

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.27.0"
+version = "0.27.1"
 
 
 [deps]

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -135,6 +135,19 @@ export AbstractVarInfo,
 using Distributions: loglikelihood
 export loglikelihood
 
+# TODO: Remove once we've updated tutorials, etc.
+macro logprob_str(str)
+    return error(
+        "The `@logprob_str` macro is no longer supported. See https://turinglang.org/dev/docs/using-turing/guide/#querying-probabilities-from-model-or-chain for information on how to query probabilities.",
+    )
+end
+
+macro prob_str(str)
+    return error(
+        "The `@prob_str` macro is no longer supported. See https://turinglang.org/dev/docs/using-turing/guide/#querying-probabilities-from-model-or-chain for information on how to query probabilities.",
+    )
+end
+
 # Used here and overloaded in Turing
 function getspace end
 

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -129,7 +129,10 @@ export AbstractVarInfo,
     @submodel,
     value_iterator_from_chain,
     check_model,
-    check_model_and_trace
+    check_model_and_trace,
+    # Deprecated.
+    @logprob_str,
+    @prob_str
 
 # Reexport
 using Distributions: loglikelihood
@@ -137,15 +140,15 @@ export loglikelihood
 
 # TODO: Remove once we've updated tutorials, etc.
 macro logprob_str(str)
-    return error(
+    return :(error(
         "The `@logprob_str` macro is no longer supported. See https://turinglang.org/dev/docs/using-turing/guide/#querying-probabilities-from-model-or-chain for information on how to query probabilities, and https://github.com/TuringLang/DynamicPPL.jl/issues/356 for information regarding its removal.",
-    )
+    ))
 end
 
 macro prob_str(str)
-    return error(
+    return :(error(
         "The `@prob_str` macro is no longer supported. See https://turinglang.org/dev/docs/using-turing/guide/#querying-probabilities-from-model-or-chain for information on how to query probabilities, and https://github.com/TuringLang/DynamicPPL.jl/issues/356 for information regarding its removal.",
-    )
+    ))
 end
 
 # Used here and overloaded in Turing

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -138,7 +138,7 @@ export AbstractVarInfo,
 using Distributions: loglikelihood
 export loglikelihood
 
-# TODO: Remove once we've updated tutorials, etc.
+# TODO: Remove once we feel comfortable people aren't using it anymore.
 macro logprob_str(str)
     return :(error(
         "The `@logprob_str` macro is no longer supported. See https://turinglang.org/dev/docs/using-turing/guide/#querying-probabilities-from-model-or-chain for information on how to query probabilities, and https://github.com/TuringLang/DynamicPPL.jl/issues/356 for information regarding its removal.",

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -138,13 +138,13 @@ export loglikelihood
 # TODO: Remove once we've updated tutorials, etc.
 macro logprob_str(str)
     return error(
-        "The `@logprob_str` macro is no longer supported. See https://turinglang.org/dev/docs/using-turing/guide/#querying-probabilities-from-model-or-chain for information on how to query probabilities.",
+        "The `@logprob_str` macro is no longer supported. See https://turinglang.org/dev/docs/using-turing/guide/#querying-probabilities-from-model-or-chain for information on how to query probabilities, and https://github.com/TuringLang/DynamicPPL.jl/issues/356 for information regarding its removal.",
     )
 end
 
 macro prob_str(str)
     return error(
-        "The `@prob_str` macro is no longer supported. See https://turinglang.org/dev/docs/using-turing/guide/#querying-probabilities-from-model-or-chain for information on how to query probabilities.",
+        "The `@prob_str` macro is no longer supported. See https://turinglang.org/dev/docs/using-turing/guide/#querying-probabilities-from-model-or-chain for information on how to query probabilities, and https://github.com/TuringLang/DynamicPPL.jl/issues/356 for information regarding its removal.",
     )
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,11 @@ include("test_util.jl")
             include("ad.jl")
         end
 
+        @testset "prob and logprob macro" begin
+            @test_throws ErrorException prob"..."
+            @test_throws ErrorException logprob"..."
+        end
+
         @testset "doctests" begin
             DocMeta.setdocmeta!(
                 DynamicPPL,


### PR DESCRIPTION
#604 removed these two macros, but this will just result in ambiguous errors for lots of users (this feature has been displayed in the Turing.jl docs and we know there are people using it) without telling them anything about why the changes was made.

This PR makes them instead error, providing some information on where to find discussion + how to "replace" some of its functionality.