### PR TITLE
`missing` kwarg not handled correctly

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -67,11 +67,16 @@ model with different arguments.
 @generated function Model(
     f::F,
     args::NamedTuple{argnames,Targs},
-    defaults::NamedTuple,
+    defaults::NamedTuple{kwargnames,Tkwargs},
     context::AbstractContext=DefaultContext(),
-) where {F,argnames,Targs}
-    missings = Tuple(name for (name, typ) in zip(argnames, Targs.types) if typ <: Missing)
-    return :(Model{$missings}(f, args, defaults, context))
+) where {F,argnames,Targs,kwargnames,Tkwargs}
+    missing_args = Tuple(
+        name for (name, typ) in zip(argnames, Targs.types) if typ <: Missing
+    )
+    missing_kwargs = Tuple(
+        name for (name, typ) in zip(kwargnames, Tkwargs.types) if typ <: Missing
+    )
+    return :(Model{$(missing_args..., missing_kwargs...)}(f, args, defaults, context))
 end
 
 function Model(f, args::NamedTuple, context::AbstractContext=DefaultContext(); kwargs...)

--- a/test/model.jl
+++ b/test/model.jl
@@ -243,6 +243,11 @@ is_typed_varinfo(varinfo::DynamicPPL.SimpleVarInfo{<:NamedTuple}) = true
         @test length(test_defaults(missing, 2)()) == 2
     end
 
+    @testset "missing kwarg" begin
+        @model test_missing_kwarg(; x=missing) = x ~ Normal(0, 1)
+        @test :x in keys(rand(test_missing_kwarg()))
+    end
+
     @testset "extract priors" begin
         @testset "$(model.f)" for model in DynamicPPL.TestUtils.DEMO_MODELS
             priors = extract_priors(model)


### PR DESCRIPTION
https://github.com/TuringLang/Turing.jl/issues/2259

We perform the `inargnames` check for both args and kwargs, and so then we should also perform the `ismissing` check for both args and kwargs (only do it for args atm).