### PR TITLE
Fix for `LogDensityFunction`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.27.2"
+version = "0.27.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
## Issue

When evaluating a `Model`, there are two "sources" of contexts provided: 1) explicitly passed to `evaluate!!` as an argument, and 2) through the context attached to the model itself in `model.context`.

The latter was introduced because in many scenarios it makes sense to "contextualize" a `Model`, e.g. attach a `ConditionContext` to a `Model` to specify which parameters are considered `conditioned`. The former is present because back in the day when the samplers were heavily tied to DynamicPPL and we passed a `sampler` argument in almost every place where we now pass `context`.

To "bridge" the two approaches, when we call `evaluate!!`, the process of "resolving" the context that eventually ends up as `__context__` in the model itself, occurs here:

https://github.com/TuringLang/DynamicPPL.jl/blob/d384da21e168ca089f16551231913700a4454efc/src/model.jl#L995-L997

In short, we do:
1. Replace the _leaf_ context of `model.context` with the leaf context provided by `context` argument.
2. Set the child context of `context` argument to the context resulting from (1).

This might be a bit strange, but the result is that `context` takes precedence over `model.context`, as it's considered to be "more important" due to the "user" explicitly passing it to `evaluate!!`.

We did this because some samplers were using contexts to specify certain behaviors that had to be respected, e.g. `context` could be a `PriorContext` to indicate that the prior should be evaluated while `model.context` could be a `DefaultContext`, in which case we wanted the result to be `PriorContext`.

This also means that `LogDensityFunction`, effectively a convenient wrapper around `evaluate!!`, also has _two_ sources of contexts: `f.model.context` and `f.context`. By default, i.e. if we call `LogDensityFunction(model)`, we specify these to be the _same_, i.e. `f.context === f.model.context`. This is clearly very redundant, since we're just specifiying the same context twice. Moreover, since, as seen above, we effectively concatenate `context` and `model.context`, this results in `LogDensityFunction` evaluating the model with the context "doubled". In most cases, this still results in the intended behavior, _but_ once you start changing certain fields of the `LogDensityFunction`, e.g. `LogDensityFunction(model_new, f.varinfo, f.context)`, interesting things can happen. For example, in https://github.com/TuringLang/Turing.jl/pull/2231, I ran into an issue where I'd get two `ConditionContext` conditioning the _same_ variable; one from `f.model.context` (what I intended) and one from `f.context` (what I did _not_ intend). 

## Solution

This PR addresses this issue for `LogDensityFunction` by simply allowing `nothing` in `f.context`, which is resolved to `leafcontext(model.context)` if not specified. This addresses the issues I've encountered above, but the _proper_ way of fixing this would, IMO, be to either:
1. Allow `nothing` to be passed in place of `context` "everywhere", i.e. we make them all `Optional{AbstractContext} = Union{Nothing,AbstractContext}` types, and resolve to `model.context` whenever it's `nothing`.
2. Drop the `context` argument from `evaluate!!` completely and instead always just "attach" the `context` to the `Model`. This seems "nicer" overall, _but_ will require quite a bit of work both here and on the Turing.jl side + it's not quite clear to me that this will indeed quite work (`context` is used many other places than just in `evaluate!!`, e.g. `unflatten`, to allow samplers in `SamplingContext` to change behaviors further).