### PR TITLE
Replace usage of `typeof` (inferred) by `Core.Typeof` (runtime)

### DIFF
--- a/src/abstract_varinfo.jl
+++ b/src/abstract_varinfo.jl
@@ -363,6 +363,8 @@ Determine the default `eltype` of the values returned by `vi[spl]`.
     This method is considered legacy, and is likely to be deprecated in the future.
 """
 function Base.eltype(vi::AbstractVarInfo, spl::Union{AbstractSampler,SampleFromPrior})
+    # TODO(torfjelde): Does this cause issues with Enzyme.jl?
+    # TODO(torfjelde): Is there _any_ scenario where this isn't just `typeof(getlogp(vi))`?
     T = Base.promote_op(getindex, typeof(vi), typeof(spl))
     if T === Union{}
         # In this case `getindex(vi, spl)` errors

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -737,7 +737,7 @@ For a `context` that is _not_ a `SamplingContext`, we fall back to
 `matchingvalue(SampleFromPrior(), vi, value)`.
 """
 function matchingvalue(sampler, vi, value)
-    T = typeof(value)
+    T = Core.Typeof(value)
     if hasmissing(T)
         _value = convert(get_matching_type(sampler, vi, T), value)
         if _value === value

--- a/src/simple_varinfo.jl
+++ b/src/simple_varinfo.jl
@@ -217,7 +217,7 @@ function SimpleVarInfo(θ::Union{<:NamedTuple,<:AbstractDict})
         SimpleVarInfo{SIMPLEVARINFO_DEFAULT_ELTYPE}(θ)
     else
         # Infer from `values`.
-        SimpleVarInfo{float_type_with_fallback(infer_nested_eltype(typeof(θ)))}(θ)
+        SimpleVarInfo{float_type_with_fallback(infer_nested_eltype(Core.Typeof(θ)))}(θ)
     end
 end
 


### PR DESCRIPTION
This is per @wsmoses suggestion after a chat we (and @mhauru ) had earlier today.

It's an attempt to fix some issues we've had with Enzyme.jl-integration; in particular, https://github.com/TuringLang/Turing.jl/issues/2240