### PR TITLE
Stricter types for evaluate!! methods

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -909,13 +909,18 @@ function AbstractPPL.evaluate!!(model::Model, context::AbstractContext)
     return evaluate!!(model, VarInfo(), context)
 end
 
-function AbstractPPL.evaluate!!(model::Model, args...)
+function AbstractPPL.evaluate!!(
+    model::Model, args::Union{AbstractVarInfo,AbstractSampler,AbstractContext}...
+)
     return evaluate!!(model, Random.default_rng(), args...)
 end
 
 # without VarInfo
 function AbstractPPL.evaluate!!(
-    model::Model, rng::Random.AbstractRNG, sampler::AbstractSampler, args...
+    model::Model,
+    rng::Random.AbstractRNG,
+    sampler::AbstractSampler,
+    args::AbstractContext...,
 )
     return evaluate!!(model, rng, VarInfo(), sampler, args...)
 end

--- a/test/model.jl
+++ b/test/model.jl
@@ -396,4 +396,18 @@ is_typed_varinfo(varinfo::DynamicPPL.SimpleVarInfo{<:NamedTuple}) = true
             end
         end
     end
+
+    @testset "Erroneous model call" begin
+        # Calling a model with the wrong arguments used to lead to infinite recursion, see
+        # https://github.com/TuringLang/Turing.jl/issues/2182. This guards against it.
+        @model function a_model(x)
+            m ~ Normal(0, 1)
+            x ~ Normal(m, 1)
+            return nothing
+        end
+        instance = a_model(1.0)
+        # `instance` should be called with rng, context, etc., but one may easily get
+        # confused and call it the way you are meant to call `a_model`.
+        @test_throws MethodError instance(1.0)
+    end
 end


### PR DESCRIPTION
Addresses https://github.com/TuringLang/Turing.jl/issues/2182

The earlier
```
function AbstractPPL.evaluate!!(model::Model, args...)
    return evaluate!!(model, Random.default_rng(), args...)
end
```
could lead to infinite recursion. Restricting the types of the varargs solves that.

I would have wanted to rework the method definitions of `evaluate!!` more generally because I find it hard to understand what all the valid ways of calling it are. I thought about it for a bit and couldn't come up with a good solution though, so maybe later.