### PR TITLE
Fix for `check_model` on Julia <1.9

### DIFF
--- a/src/debug_utils.jl
+++ b/src/debug_utils.jl
@@ -289,7 +289,7 @@ end
 _isassigned(x::AbstractArray, i) = isassigned(x, i)
 # HACK(torfjelde): Julia v1.7 only supports `isassigned(::AbstractArray, ::Int...)`.
 # TODO(torfjelde): Determine exactly in which version this change was introduced.
-if VERSION < v"1.8"
+if VERSION < v"v1.9.0-alpha1"
     _isassigned(x::AbstractArray, inds::Tuple) = isassigned(x, inds...)
     _isassigned(x::AbstractArray, idx::CartesianIndex) = _isassigned(x, Tuple(idx))
 end

--- a/src/debug_utils.jl
+++ b/src/debug_utils.jl
@@ -286,11 +286,19 @@ function record_varname!(context::DebugContext, varname::VarName, dist)
 end
 
 # tilde
+_isassigned(x::AbstractArray, i) = isassigned(x, i)
+# HACK(torfjelde): Julia v1.7 only supports `isassigned(::AbstractArray, ::Int...)`.
+# TODO(torfjelde): Determine exactly in which version this change was introduced.
+if VERSION < v"1.8"
+    _isassigned(x::AbstractArray, inds::Tuple) = isassigned(x, inds...)
+    _isassigned(x::AbstractArray, idx::CartesianIndex) = _isassigned(x, Tuple(idx))
+end
+
 _has_missings(x) = ismissing(x)
 function _has_missings(x::AbstractArray)
     # Can't just use `any` because `x` might contain `undef`.
     for i in eachindex(x)
-        if isassigned(x, i) && _has_missings(x[i])
+        if _isassigned(x, i) && _has_missings(x[i])
             return true
         end
     end


### PR DESCRIPTION
`isassigned(::AbstractArray, ::CartesianIndex)` is not supported on Julia <1.9, even though it can be returned by `eachindex`.

Ref: https://github.com/TuringLang/Turing.jl/pull/2231 whose CI is currently failiing because of this (https://github.com/TuringLang/Turing.jl/actions/runs/9879092184/job/27284539618?pr=2231)