### PR TITLE
Add AbstractRNG types to fix method ambiguities in Turing

### DIFF
--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -66,10 +66,14 @@ end
 function tilde_assume(rng::Random.AbstractRNG, context::AbstractContext, args...)
     return tilde_assume(NodeTrait(tilde_assume, context), rng, context, args...)
 end
-function tilde_assume(::IsLeaf, rng::Random.AbstractRNG, context::AbstractContext, sampler, right, vn, vi)
+function tilde_assume(
+    ::IsLeaf, rng::Random.AbstractRNG, context::AbstractContext, sampler, right, vn, vi
+)
     return assume(rng, sampler, right, vn, vi)
 end
-function tilde_assume(::IsParent, rng::Random.AbstractRNG, context::AbstractContext, args...)
+function tilde_assume(
+    ::IsParent, rng::Random.AbstractRNG, context::AbstractContext, args...
+)
     return tilde_assume(rng, childcontext(context), args...)
 end
 
@@ -121,7 +125,9 @@ end
 function tilde_assume(context::PrefixContext, right, vn, vi)
     return tilde_assume(context.context, right, prefix(context, vn), vi)
 end
-function tilde_assume(rng::Random.AbstractRNG, context::PrefixContext, sampler, right, vn, vi)
+function tilde_assume(
+    rng::Random.AbstractRNG, context::PrefixContext, sampler, right, vn, vi
+)
     return tilde_assume(rng, context.context, sampler, right, prefix(context, vn), vi)
 end
 

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -315,7 +315,9 @@ function dot_tilde_assume(::IsParent, rng, context::AbstractContext, args...)
     return dot_tilde_assume(rng, childcontext(context), args...)
 end
 
-function dot_tilde_assume(rng, ::DefaultContext, sampler, right, left, vns, vi)
+function dot_tilde_assume(
+    rng::Random.AbstractRNG, ::DefaultContext, sampler, right, left, vns, vi
+)
     return dot_assume(rng, sampler, right, vns, left, vi)
 end
 

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -63,13 +63,13 @@ function tilde_assume(::IsParent, context::AbstractContext, args...)
     return tilde_assume(childcontext(context), args...)
 end
 
-function tilde_assume(rng, context::AbstractContext, args...)
+function tilde_assume(rng::Random.AbstractRNG, context::AbstractContext, args...)
     return tilde_assume(NodeTrait(tilde_assume, context), rng, context, args...)
 end
-function tilde_assume(::IsLeaf, rng, context::AbstractContext, sampler, right, vn, vi)
+function tilde_assume(::IsLeaf, rng::Random.AbstractRNG, context::AbstractContext, sampler, right, vn, vi)
     return assume(rng, sampler, right, vn, vi)
 end
-function tilde_assume(::IsParent, rng, context::AbstractContext, args...)
+function tilde_assume(::IsParent, rng::Random.AbstractRNG, context::AbstractContext, args...)
     return tilde_assume(rng, childcontext(context), args...)
 end
 
@@ -121,7 +121,7 @@ end
 function tilde_assume(context::PrefixContext, right, vn, vi)
     return tilde_assume(context.context, right, prefix(context, vn), vi)
 end
-function tilde_assume(rng, context::PrefixContext, sampler, right, vn, vi)
+function tilde_assume(rng::Random.AbstractRNG, context::PrefixContext, sampler, right, vn, vi)
     return tilde_assume(rng, context.context, sampler, right, prefix(context, vn), vi)
 end
 
@@ -291,7 +291,7 @@ end
 function dot_tilde_assume(context::AbstractContext, args...)
     return dot_tilde_assume(NodeTrait(dot_tilde_assume, context), context, args...)
 end
-function dot_tilde_assume(rng, context::AbstractContext, args...)
+function dot_tilde_assume(rng::Random.AbstractRNG, context::AbstractContext, args...)
     return dot_tilde_assume(NodeTrait(dot_tilde_assume, context), rng, context, args...)
 end
 


### PR DESCRIPTION
Related to https://github.com/TuringLang/Turing.jl/pull/2290

This PR fixes 4 of the following method ambiguities (which arise when testing Turing, but are probably better resolved here):

```
Ambiguity #1
dot_tilde_assume(rng, context::AbstractPPL.AbstractContext, args...) @ DynamicPPL ~/ppl/dppl/src/context_implementations.jl:294
dot_tilde_assume(context::Turing.Experimental.GibbsContext, right, left, vns, vi) @ Turing.Experimental ~/ppl/lib/src/experimental/gibbs.jl:77

Possible fix, define
  dot_tilde_assume(::Turing.Experimental.GibbsContext, ::AbstractPPL.AbstractContext, ::Any, ::Any, ::Any)

Ambiguity #2
dot_tilde_assume(rng, context::AbstractPPL.AbstractContext, args...) @ DynamicPPL ~/ppl/dppl/src/context_implementations.jl:294
dot_tilde_assume(ctx::Turing.Optimisation.OptimizationContext, right, left, vns, vi) @ Turing.Optimisation ~/ppl/lib/src/optimisation/Optimisation.jl:85

Possible fix, define
  dot_tilde_assume(::Turing.Optimisation.OptimizationContext, ::AbstractPPL.AbstractContext, ::Any, ::Any, ::Any)

Ambiguity #3
tilde_assume(rng, context::AbstractPPL.AbstractContext, args...) @ DynamicPPL ~/ppl/dppl/src/context_implementations.jl:66
tilde_assume(context::Turing.Experimental.GibbsContext, right, vn, vi) @ Turing.Experimental ~/ppl/lib/src/experimental/gibbs.jl:36

Possible fix, define
  tilde_assume(::Turing.Experimental.GibbsContext, ::AbstractPPL.AbstractContext, ::Any, ::Any)

Ambiguity #4
tilde_assume(rng, context::AbstractPPL.AbstractContext, args...) @ DynamicPPL ~/ppl/dppl/src/context_implementations.jl:66
tilde_assume(ctx::Turing.Optimisation.OptimizationContext, dist, vn, vi) @ Turing.Optimisation ~/ppl/lib/src/optimisation/Optimisation.jl:67

Possible fix, define
  tilde_assume(::Turing.Optimisation.OptimizationContext, ::AbstractPPL.AbstractContext, ::Any, ::Any)
```