### PR TITLE
Fix Zygote pullback depwarning

### DIFF
--- a/ext/DynamicPPLZygoteRulesExt.jl
+++ b/ext/DynamicPPLZygoteRulesExt.jl
@@ -19,7 +19,7 @@ ZygoteRules.@adjoint function DynamicPPL.dot_observe(
         DynamicPPL.increment_num_produce!(vi)
         return sum(map(Distributions.loglikelihood, dists, value)), vi
     end
-    return ZygoteRules.pullback(__context__, dot_observe_fallback, spl, dists, value, vi)
+    return ZygoteRules.pullback(dot_observe_fallback, __context__, spl, dists, value, vi)
 end
 
 end # module


### PR DESCRIPTION
Zygote kept saying this:
```
┌ Warning: Incorrect argument order for pullback, please use:
│ 
│   pullback(f, __context__::Context, args)
│ 
│ instead of:
│ 
│   pullback(__context__::Context, f, args)
│ 
│ This is usually caused by a call to pullback in a higher-order @adjoint.
│ The above warning will become an error in Zygote 0.7.
└ @ Zygote ~/.julia/packages/Zygote/nsBv0/src/compiler/interface.jl:95
```