### PR TITLE
Implementation of `varname_and_value_leaves` that can handle containers

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1029,6 +1029,46 @@ function varname_and_value_leaves(vn::VarName, x)
 end
 
 """
+    varname_and_value_leaves(container)
+
+Return an iterator over all varname-value pairs that are represented by `container`.
+
+This is the same as [`varname_and_value_leaves(vn::VarName, x)`](@ref) but over a container
+containing multiple varnames.
+
+See also: [`varname_and_value_leaves(vn::VarName, x)`](@ref).
+
+# Examples
+```jldoctest varname-and-value-leaves-container
+julia> using DynamicPPL: varname_and_value_leaves
+
+julia> # With an `OrderedDict`
+       dict = OrderedDict(@varname(y) => 1, @varname(z) => [[2.0], [3.0]]);
+
+julia> foreach(println, varname_and_value_leaves(dict))
+(y, 1)
+(z[1][1], 2.0)
+(z[2][1], 3.0)
+
+julia> # With a `NamedTuple`
+       nt = (y = 1, z = [[2.0], [3.0]]);
+
+julia> foreach(println, varname_and_value_leaves(nt))
+(y, 1)
+(z[1][1], 2.0)
+(z[2][1], 3.0)
+```
+"""
+function varname_and_value_leaves(container::OrderedDict)
+    return Iterators.flatten(varname_and_value_leaves(k, v) for (k, v) in container)
+end
+function varname_and_value_leaves(container::NamedTuple)
+    return Iterators.flatten(
+        varname_and_value_leaves(VarName{k}(), v) for (k, v) in pairs(container)
+    )
+end
+
+"""
     Leaf{T}
 
 A container that represents the leaf of a nested structure, implementing


### PR DESCRIPTION
We often find ourselves in situations where we need to flatten both varnames and values together to produce a "simple" map `varname => value` where `value isa Real` rather than a `Vector` or `NamedTuple`, e.g. in construction of `MCMCChains.Chains`.

For this we have the function `varname_and_value_leaves(vn, x)` which takes in a `VarName` and some value `x`, e.g. a `Vector`, and returns an iterator over pairs of `VarName` and `Real` as desired:

https://github.com/TuringLang/DynamicPPL.jl/blob/0e40bd00295a4f483148e59a24962a7f903abb17/src/utils.jl#L970-L985

But very often we actually want to do this for a container of multiple `VarName`s, e.g. `OrderedDict` or `NamedTuple`. Currently we just do this "by hand" every time we need this, but that seems unnecessary.

Sooo this PR just adds an implementation for `OrderedDict` and `NamedTuple` (which are the most common containers we work with, though the impl is very trivial) so we don't have to do this by hand everywhere.

Ref: #663 where we would benefit from this in the tests.