### PR TITLE
Adds `@returned_quantities` macro

### DIFF
--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -125,6 +125,7 @@ export AbstractVarInfo,
     # Convenience macros
     @addlogprob!,
     @submodel,
+    @returned_quantities,
     value_iterator_from_chain,
     check_model,
     check_model_and_trace,


### PR DESCRIPTION
This adds the `@returned_quantities` macro as discussed @yebai @mhauru 

This is meant to be a replacement for `@submodel` macro, but without the ability to do automatic prefixing. It ends up looking like 
```julia
julia> @model function demo1(x)
           x ~ Normal()
           return 1 + abs(x)
       end;

julia> @model function demo2(x, y, z)
            a = @returned_quantities prefix="sub1" demo1(x)
            b = @returned_quantities prefix="sub2" demo1(y)
            return z ~ Uniform(-a, b)
       end;

julia> rand(demo2(missing, missing, 0.4))
(var"sub1.x" = 0.5865756059371534, var"sub2.x" = -0.25563799658500047)
```