### PR TITLE
Special-case ReshapeTransform for singleton inputs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.30.1"
+version = "0.30.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -286,8 +286,15 @@ function (f::ReshapeTransform)(x)
     if size(x) != f.input_size
         throw(DimensionMismatch("Expected input of size $(f.input_size), got $(size(x))"))
     end
-    # The call to `tovec` is only needed in case `x` is a scalar.
-    return reshape(tovec(x), f.output_size)
+    if f.output_size == ()
+        # Specially handle the case where x is a singleton array, see
+        # https://github.com/JuliaDiff/ReverseDiff.jl/issues/265 and
+        # https://github.com/TuringLang/DynamicPPL.jl/issues/698
+        return x[]
+    else
+        # The call to `tovec` is only needed in case `x` is a scalar.
+        return reshape(tovec(x), f.output_size)
+    end
 end
 
 function (inv_f::Bijectors.Inverse{<:ReshapeTransform})(x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -290,7 +290,7 @@ function (f::ReshapeTransform)(x)
         # Specially handle the case where x is a singleton array, see
         # https://github.com/JuliaDiff/ReverseDiff.jl/issues/265 and
         # https://github.com/TuringLang/DynamicPPL.jl/issues/698
-        return x[]
+        return fill(x[], ())
     else
         # The call to `tovec` is only needed in case `x` is a scalar.
         return reshape(tovec(x), f.output_size)


### PR DESCRIPTION
Closes #698.

I can confirm that this change fixes the two Turing tests that I listed here https://github.com/TuringLang/Turing.jl/pull/2376#issuecomment-2435695970. It might well fix all the other tests too, since they are giving the same error message.

```julia
using Turing
import ReverseDiff

alg = HMC(0.01, 5; adtype=AutoReverseDiff())

@model function vdemo6()
    x = Vector{Real}(undef, 10)
    @. x ~ InverseGamma(2, 3)
end
sample(vdemo6(), alg, 10)

@model function vdemo7()
    x = Array{Real}(undef, N, N)
    @. x ~ [InverseGamma(2, 3) for i in 1:N]
end
sample(vdemo7(), alg, 1000)
```