### PR TITLE
Implement custom `getindex` for UntypedVarInfo

### DIFF
--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -1694,7 +1694,8 @@ Return the current value(s) of the random variables sampled by `spl` in `vi`.
 
 The value(s) may or may not be transformed to Euclidean space.
 """
-getindex(vi::UntypedVarInfo, spl::Sampler) = copy(getindex(vi.metadata.vals, _getranges(vi, spl)))
+getindex(vi::UntypedVarInfo, spl::Sampler) =
+    copy(getindex(vi.metadata.vals, _getranges(vi, spl)))
 getindex(vi::VarInfo, spl::Sampler) = copy(getindex_internal(vi, _getranges(vi, spl)))
 function getindex(vi::TypedVarInfo, spl::Sampler)
     # Gets the ranges as a NamedTuple

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -1694,6 +1694,7 @@ Return the current value(s) of the random variables sampled by `spl` in `vi`.
 
 The value(s) may or may not be transformed to Euclidean space.
 """
+getindex(vi::UntypedVarInfo, spl::Sampler) = copy(getindex(vi.metadata.vals, _getranges(vi, spl)))
 getindex(vi::VarInfo, spl::Sampler) = copy(getindex_internal(vi, _getranges(vi, spl)))
 function getindex(vi::TypedVarInfo, spl::Sampler)
     # Gets the ranges as a NamedTuple


### PR DESCRIPTION
Closes #705.

Note that CI on 1.11 will still fail because of #702. However, the `test/turing/varinfo.jl` tests pass now. Specifically, this test:

https://github.com/TuringLang/DynamicPPL.jl/blob/18af48aee1e6cdac33ebb02166ecdf9fca694c8a/test/turing/varinfo.jl#L264-L265