### PR TITLE
Revert to using `setval_and_resample!` in `generated_quantities`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.30.2"
+version = "0.30.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/DynamicPPLMCMCChainsExt.jl
+++ b/ext/DynamicPPLMCMCChainsExt.jl
@@ -108,6 +108,7 @@ function DynamicPPL.generated_quantities(
     varinfo = DynamicPPL.VarInfo(model)
     iters = Iterators.product(1:size(chain, 1), 1:size(chain, 3))
     return map(iters) do (sample_idx, chain_idx)
+        # TODO: Use `fix` once we've addressed https://github.com/TuringLang/DynamicPPL.jl/issues/702.
         # Update the varinfo with the current sample and make variables not present in `chain`
         # to be sampled.
         DynamicPPL.setval_and_resample!(varinfo, chain, sample_idx, chain_idx)


### PR DESCRIPTION
As seen in #702 , `generated_quantities` currently does not work as intented for models with dot-tilde in it. This is due to changes made in #555 to `generated_quantities`, where we started using `fix` instead of `setval_and_resample!`.

Ideally, we should be using `fix` for this, so the changes introduces in #555 were completely reasonable. However, `fix` is still somewhat lacking in support; specifically, it lacks support for `.~`, as outlined in #702. This PR reverts these changes as a hotfix for the resulting bugs.

@mhauru 