### PR TITLE
Possible Improvements to `FixedContext`

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -235,6 +235,17 @@ function unwrap_right_left_vns(
     left::AbstractArray,
     vn::VarName,
 )
+    # Need to check that we don't end up double-counting log-probabilities.
+    combined_axes = Broadcast.combine_axes(left, right)
+    if prod(length, combined_axes) > length(left)
+        throw(
+            ArgumentError(
+                "a `.~` statement cannot result in a broadcasted expression with more elements than the left-hand side",
+            ),
+        )
+    end
+
+    # Extract the sub-varnames.
     vns = map(CartesianIndices(left)) do i
         return Accessors.IndexLens(Tuple(i)) ∘ vn
     end

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -402,12 +402,12 @@ end
 
 # `PrefixContext`
 function dot_tilde_assume(context::PrefixContext, right, left, vn, vi)
-    return dot_tilde_assume(context.context, right, prefix.(Ref(context), vn), vi)
+    return dot_tilde_assume(context.context, right, left, prefix.(Ref(context), vn), vi)
 end
 
 function dot_tilde_assume(rng, context::PrefixContext, sampler, right, left, vn, vi)
     return dot_tilde_assume(
-        rng, context.context, sampler, right, prefix.(Ref(context), vn), vi
+        rng, context.context, sampler, right, left, prefix.(Ref(context), vn), vi
     )
 end
 

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -77,44 +77,6 @@ function tilde_assume(
     return tilde_assume(rng, childcontext(context), args...)
 end
 
-function tilde_assume(context::PriorContext{<:NamedTuple}, right, vn, vi)
-    if haskey(context.vars, getsym(vn))
-        vi = setindex!!(vi, tovec(get(context.vars, vn)), vn)
-        settrans!!(vi, false, vn)
-    end
-    return tilde_assume(PriorContext(), right, vn, vi)
-end
-function tilde_assume(
-    rng::Random.AbstractRNG, context::PriorContext{<:NamedTuple}, sampler, right, vn, vi
-)
-    if haskey(context.vars, getsym(vn))
-        vi = setindex!!(vi, tovec(get(context.vars, vn)), vn)
-        settrans!!(vi, false, vn)
-    end
-    return tilde_assume(rng, PriorContext(), sampler, right, vn, vi)
-end
-
-function tilde_assume(context::LikelihoodContext{<:NamedTuple}, right, vn, vi)
-    if haskey(context.vars, getsym(vn))
-        vi = setindex!!(vi, tovec(get(context.vars, vn)), vn)
-        settrans!!(vi, false, vn)
-    end
-    return tilde_assume(LikelihoodContext(), right, vn, vi)
-end
-function tilde_assume(
-    rng::Random.AbstractRNG,
-    context::LikelihoodContext{<:NamedTuple},
-    sampler,
-    right,
-    vn,
-    vi,
-)
-    if haskey(context.vars, getsym(vn))
-        vi = setindex!!(vi, tovec(get(context.vars, vn)), vn)
-        settrans!!(vi, false, vn)
-    end
-    return tilde_assume(rng, LikelihoodContext(), sampler, right, vn, vi)
-end
 function tilde_assume(::LikelihoodContext, right, vn, vi)
     return assume(NoDist(right), vn, vi)
 end
@@ -328,37 +290,6 @@ function dot_tilde_assume(
 end
 
 # `LikelihoodContext`
-function dot_tilde_assume(context::LikelihoodContext{<:NamedTuple}, right, left, vn, vi)
-    return if haskey(context.vars, getsym(vn))
-        var = get(context.vars, vn)
-        _right, _left, _vns = unwrap_right_left_vns(right, var, vn)
-        set_val!(vi, _vns, _right, _left)
-        settrans!!.((vi,), false, _vns)
-        dot_tilde_assume(LikelihoodContext(), _right, _left, _vns, vi)
-    else
-        dot_tilde_assume(LikelihoodContext(), right, left, vn, vi)
-    end
-end
-function dot_tilde_assume(
-    rng::Random.AbstractRNG,
-    context::LikelihoodContext{<:NamedTuple},
-    sampler,
-    right,
-    left,
-    vn,
-    vi,
-)
-    return if haskey(context.vars, getsym(vn))
-        var = get(context.vars, vn)
-        _right, _left, _vns = unwrap_right_left_vns(right, var, vn)
-        set_val!(vi, _vns, _right, _left)
-        settrans!!.((vi,), false, _vns)
-        dot_tilde_assume(rng, LikelihoodContext(), sampler, _right, _left, _vns, vi)
-    else
-        dot_tilde_assume(rng, LikelihoodContext(), sampler, right, left, vn, vi)
-    end
-end
-
 function dot_tilde_assume(context::LikelihoodContext, right, left, vn, vi)
     return dot_assume(nodist(right), left, vn, vi)
 end
@@ -366,38 +297,6 @@ function dot_tilde_assume(
     rng::Random.AbstractRNG, context::LikelihoodContext, sampler, right, left, vn, vi
 )
     return dot_assume(rng, sampler, nodist(right), vn, left, vi)
-end
-
-# `PriorContext`
-function dot_tilde_assume(context::PriorContext{<:NamedTuple}, right, left, vn, vi)
-    return if haskey(context.vars, getsym(vn))
-        var = get(context.vars, vn)
-        _right, _left, _vns = unwrap_right_left_vns(right, var, vn)
-        set_val!(vi, _vns, _right, _left)
-        settrans!!.((vi,), false, _vns)
-        dot_tilde_assume(PriorContext(), _right, _left, _vns, vi)
-    else
-        dot_tilde_assume(PriorContext(), right, left, vn, vi)
-    end
-end
-function dot_tilde_assume(
-    rng::Random.AbstractRNG,
-    context::PriorContext{<:NamedTuple},
-    sampler,
-    right,
-    left,
-    vn,
-    vi,
-)
-    return if haskey(context.vars, getsym(vn))
-        var = get(context.vars, vn)
-        _right, _left, _vns = unwrap_right_left_vns(right, var, vn)
-        set_val!(vi, _vns, _right, _left)
-        settrans!!.((vi,), false, _vns)
-        dot_tilde_assume(rng, PriorContext(), sampler, _right, _left, _vns, vi)
-    else
-        dot_tilde_assume(rng, PriorContext(), sampler, right, left, vn, vi)
-    end
 end
 
 # `PrefixContext`

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -53,7 +53,7 @@ DefaultContext()
 julia> ctx_prior = DynamicPPL.setchildcontext(ctx, PriorContext()); # only compute the logprior
 
 julia> DynamicPPL.childcontext(ctx_prior)
-PriorContext{Nothing}(nothing)
+PriorContext()
 ```
 """
 setchildcontext
@@ -97,7 +97,7 @@ ParentContext(ParentContext(DefaultContext()))
 
 julia> # Replace the leaf context with another leaf.
        leafcontext(setleafcontext(ctx, PriorContext()))
-PriorContext{Nothing}(nothing)
+PriorContext()
 
 julia> # Append another parent context.
        setleafcontext(ctx, ParentContext(DefaultContext()))
@@ -195,32 +195,19 @@ struct DefaultContext <: AbstractContext end
 NodeTrait(context::DefaultContext) = IsLeaf()
 
 """
-    struct PriorContext{Tvars} <: AbstractContext
-        vars::Tvars
-    end
+    PriorContext <: AbstractContext
 
-The `PriorContext` enables the computation of the log prior of the parameters `vars` when
-running the model.
+A leaf context resulting in the exclusion of likelihood terms when running the model.
 """
-struct PriorContext{Tvars} <: AbstractContext
-    vars::Tvars
-end
-PriorContext() = PriorContext(nothing)
+struct PriorContext <: AbstractContext end
 NodeTrait(context::PriorContext) = IsLeaf()
 
 """
-    struct LikelihoodContext{Tvars} <: AbstractContext
-        vars::Tvars
-    end
+    LikelihoodContext <: AbstractContext
 
-The `LikelihoodContext` enables the computation of the log likelihood of the parameters when
-running the model. `vars` can be used to evaluate the log likelihood for specific values
-of the model's parameters. If `vars` is `nothing`, the parameter values inside the `VarInfo` will be used by default.
+A leaf context resulting in the exclusion of prior terms when running the model.
 """
-struct LikelihoodContext{Tvars} <: AbstractContext
-    vars::Tvars
-end
-LikelihoodContext() = LikelihoodContext(nothing)
+struct LikelihoodContext <: AbstractContext end
 NodeTrait(context::LikelihoodContext) = IsLeaf()
 
 """

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -501,6 +501,13 @@ NodeTrait(::FixedContext) = IsParent()
 childcontext(context::FixedContext) = context.context
 setchildcontext(parent::FixedContext, child) = FixedContext(parent.values, child)
 
+has_fixed_symbol(context::FixedContext, vn::VarName) = has_symbol(context.values, vn)
+
+has_symbol(d::AbstractDict, vn::VarName) = haskey(d, vn)
+@generated function has_symbol(::NamedTuple{names}, ::VarName{sym}) where {names, sym}
+    return sym in names
+end
+
 """
     hasfixed(context::AbstractContext, vn::VarName)
 

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -729,4 +729,13 @@ module Issue537 end
         res = model()
         @test res == (a=1, b=1, c=2, d=2, t=DynamicPPL.TypeWrap{Int}())
     end
+
+    @testset "invalid .~ expressions" begin
+        @model function demo_with_invalid_dot_tilde()
+            m = Matrix{Float64}(undef, 1, 2)
+            m .~ [Normal(); Normal()]
+        end
+
+        @test_throws ArgumentError demo_with_invalid_dot_tilde()()
+    end
 end


### PR DESCRIPTION
As pointed out by @penelopeysm and @mhauru in #702 , `FixedContext` and `ConditionContext` doesn't quite do what we want for `.~` statements. One of the reasons we first introduced `fix` was to avoid hitting the `tilde_*_assume` pipeline to improve performance.

This PR implements a possible way of fixing #702 which involves overloading the `tilde_dot_assume` for `FixedContext` to handle cases where only parts of the LHS is `fixed`.

With this branch we can do stuff like fixing only a subset of a `.~` statement:
```julia
julia> @model function demo(n)
           m = Vector{Float64}(undef, n)
           m .~ Normal()
           s ~ Normal()

           return (; m)
       end
demo (generic function with 2 methods)

julia> model = fix(demo(2), @varname(m[1]) => 0.0);

julia> model()
(m = [0.0, -0.019050747797961672],)

julia> rand(model)
(var"m[2]" = 0.41118414073410653, s = -0.2798438193201507)
```

However, it requires overloading `tilde_dot_assume` for `FixedContext`, which does go slightly against what `tilde_*_assume` is meant to do (it's meant to be used for random variables, but clearly fixed variables are not random).

# Performance implications

IMO the interesting "case" is when we use `fix(::Model, ::NamedTuple)` since this is consistently what we consider as the "fast mode" in Turing.jl / DynamicPPL.jl, and we can always ask the user to provide the values as a `NamedTuple` if they really want performance.

There are a few different "approaches" we can take with `fixed` (and equally `condition`):
1. Use current approach. This calls `conditional_isfixed` + `getfixed_nested(__context__, vn)` in the main-body of a `@model`. _When it works_, this is very performant, as it's just compile-time generated check of `sym in names` for `VarName{sym}` and `NamedTuple{names}`.
2. Remove current approach in favour of overloading `tilde_*_assume` pipeline to extract the fixed values.
3. A "hybrid" approach. Use (1) whenever possible, _but_ if we hit the `tilde_*_assume`, we _also_ check there for `tilde_dot_assume` (so that we cover the cases listed in #702) by iterating over all the variables and defering to `tilde_assume` (i.e. without the `dot`).

I ran the following snippet on this branch and `#master`:

```julia
using Revise, DynamicPPL, Distributions, BenchmarkTools

@model function demo(n)
    m = Vector{Float64}(undef, n)
    m .~ Normal()
    s ~ Normal()
end

iter = 1:14
suite = BenchmarkGroup()
for nlog2 in iter
    n = 2^nlog2
    model = fix(demo(n), m=zeros(n))
    vi = VarInfo(model)
    suite[n] = @benchmarkable $model($vi)
end
results = run(suite, seconds=60)
OrderedDict(2^nlog2 => results[2^nlog2] for nlog2 in iter)
```

## On `#master` (Approach 1)
```julia
julia> OrderedDict(2^nlog2 => results[2^nlog2] for nlog2 in iter)
OrderedDict{Int64, BenchmarkTools.Trial} with 14 entries:
  2     => 125.000 ns
  4     => 125.000 ns
  8     => 125.000 ns
  16    => 125.000 ns
  32    => 84.000 ns
  64    => 125.000 ns
  128   => 83.000 ns
  256   => 166.000 ns
  512   => 208.000 ns
  1024  => 291.000 ns
  2048  => 333.000 ns
  4096  => 500.000 ns
  8192  => 1.000 μs
  16384 => 2.083 μs
```

## On this branch (Approach 3)
```julia
julia> OrderedDict(2^nlog2 => results[2^nlog2] for nlog2 in iter)
OrderedDict{Int64, BenchmarkTools.Trial} with 14 entries:
  2     => 166.000 ns
  4     => 166.000 ns
  8     => 208.000 ns
  16    => 208.000 ns
  32    => 208.000 ns
  64    => 166.000 ns
  128   => 125.000 ns
  256   => 250.000 ns
  512   => 291.000 ns
  1024  => 375.000 ns
  2048  => 375.000 ns
  4096  => 583.000 ns
  8192  => 1.000 μs
  16384 => 2.125 μs
```
As we can see, the performance difference is very, very minor. **However**, note that this PR still includes the `contetxual_isfixed` checki n the main body of the model.

## Replace current approach fully be overloading tilde

**If we remove this, i.e. only rely on overloading tilde-pipeline**, we get the following result:

```julia
julia> OrderedDict(2^nlog2 => results[2^nlog2] for nlog2 in iter)
OrderedDict{Int64, BenchmarkTools.Trial} with 14 entries:
  2     => 167.000 ns
  4     => 166.000 ns
  8     => 208.000 ns
  16    => 250.000 ns
  32    => 208.000 ns
  64    => 209.000 ns
  128   => 291.000 ns
  256   => 416.000 ns
  512   => 583.000 ns
  1024  => 875.000 ns
  2048  => 1.500 μs
  4096  => 2.416 μs
  8192  => 4.875 μs
  16384 => 9.125 μs
```

As we see here, once we have to rely on a for-loop over the variables to check, we do incur a "signfiicant" runtime overhead.

## Conclusion

Performing the check in `dot_tilde_assume` _only when explicitly needed_ doesn't really hurt performance much for `fix(::Model, ::NamedTuple)` (i.e. Approach 2 vs. Approach 1).

_However_, purely relying on Approach 3 (i.e. replacing current approach completely with overloading tilde assume) _does_ have quite a significant overhead for just evaluation (assuming this will be even worse when computing gradients).

Soooo I'm leaning towards Approach 2 (as is implemented in this branch), even though it does make things a bit uglier.