### PR TITLE
Fixed incorrect calls to `to_linked_internal_transform`

### DIFF
--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -591,7 +591,7 @@ function get_and_set_val!(
             push!!.((vi,), vns, _link_broadcast_new.((vi,), vns, dists, r), dists, (spl,))
             # NOTE: Need to add the correction.
             # FIXME: This is not great.
-            acclogp_assume!!(vi, sum(logabsdetjac.(link_transform.(dists), r)))
+            acclogp!!(vi, sum(logabsdetjac.(link_transform.(dists), r)))
             # `push!!` sets the trans-flag to `false` by default.
             settrans!!.((vi,), true, vns)
         else

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -257,7 +257,7 @@ function assume(
     else
         r = init(rng, dist, sampler)
         if istrans(vi)
-            f = to_linked_internal_transform(vi, dist)
+            f = to_linked_internal_transform(vi, vn, dist)
             push!!(vi, vn, f(r), dist, sampler)
             # By default `push!!` sets the transformed flag to `false`.
             settrans!!(vi, true, vn)
@@ -500,7 +500,7 @@ end
 # HACK: These methods are only used in the `get_and_set_val!` methods below.
 # FIXME: Remove these.
 function _link_broadcast_new(vi, vn, dist, r)
-    b = to_linked_internal_transform(vi, dist)
+    b = to_linked_internal_transform(vi, vn, dist)
     return b(r)
 end
 

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -785,7 +785,9 @@ DynamicPPL.getspace(::DynamicPPL.Sampler{MySAlg}) = (:s,)
         # Sampling from `model2` should hit the `istrans(vi) == true` branches
         # because all the existing variables are linked.
         model2 = demo(2)
-        varinfo2 = last(DynamicPPL.evaluate!!(model2, deepcopy(varinfo1), SamplingContext()))
+        varinfo2 = last(
+            DynamicPPL.evaluate!!(model2, deepcopy(varinfo1), SamplingContext())
+        )
         for vn in [@varname(x[1]), @varname(x[2])]
             @test DynamicPPL.istrans(varinfo2, vn)
         end
@@ -804,7 +806,9 @@ DynamicPPL.getspace(::DynamicPPL.Sampler{MySAlg}) = (:s,)
         # Sampling from `model2` should hit the `istrans(vi) == true` branches
         # because all the existing variables are linked.
         model2 = demo_dot(2)
-        varinfo2 = last(DynamicPPL.evaluate!!(model2, deepcopy(varinfo1), SamplingContext()))
+        varinfo2 = last(
+            DynamicPPL.evaluate!!(model2, deepcopy(varinfo1), SamplingContext())
+        )
         for vn in [@varname(x), @varname(y[1])]
             @test DynamicPPL.istrans(varinfo2, vn)
         end


### PR DESCRIPTION
Came across these isuse when trying the following with JET.jl 👀 
```julia
julia> using DynamicPPL, Distributions, JET

julia> @model function demo()
           x = Vector{Float64}(undef, 2)
           x[1] ~ Normal()
           x[2] ~ Normal()
           return x
       end
demo (generic function with 4 methods)

julia> model = demo();

julia> vi = DynamicPPL.typed_varinfo(model);

julia> for vn in keys(vi)
           DynamicPPL.set_flag!(vi, vn, "del")
       end^C

julia> f, argtypes = DynamicPPL.DebugUtils.gen_evaluator_call_with_types(model, DynamicPPL.typed_varinfo(model), SamplingContext());

julia> report_call(f, argtypes)
═════ 1 possible error found ═════
┌ demo(__model__::Model{…}, __varinfo__::TypedVarInfo{…}, __context__::SamplingContext{…}) @ Main ./REPL[124]:4
│┌ tilde_assume!!(context::SamplingContext{…}, right::Normal{…}, vn::VarName{…}, vi::TypedVarInfo{…}) @ DynamicPPL /Users/tfjelde/.julia/packages/DynamicPPL/Awq82/src/context_implementations.jl:144
││┌ tilde_assume(context::SamplingContext{…}, right::Normal{…}, vn::VarName{…}, vi::TypedVarInfo{…}) @ DynamicPPL /Users/tfjelde/.julia/packages/DynamicPPL/Awq82/src/context_implementations.jl:52
│││┌ tilde_assume(::Random.TaskLocalRNG, ::DefaultContext, ::SampleFromPrior, ::Normal{…}, ::VarName{…}, ::TypedVarInfo{…}) @ DynamicPPL /Users/tfjelde/.julia/packages/DynamicPPL/Awq82/src/context_implementations.jl:67
││││┌ tilde_assume(::DynamicPPL.IsLeaf, rng::Random.TaskLocalRNG, context::DefaultContext, sampler::SampleFromPrior, right::Normal{…}, vn::VarName{…}, vi::TypedVarInfo{…}) @ DynamicPPL /Users/tfjelde/.julia/packages/DynamicPPL/Awq82/src/context_implementations.jl:72
│││││┌ assume(rng::Random.TaskLocalRNG, sampler::SampleFromPrior, dist::Normal{…}, vn::VarName{…}, vi::TypedVarInfo{…}) @ DynamicPPL /Users/tfjelde/.julia/packages/DynamicPPL/Awq82/src/context_implementations.jl:260
││││││ no matching method found `to_linked_internal_transform(::TypedVarInfo{@NamedTuple{x::DynamicPPL.Metadata{Dict{VarName{:x, Accessors.IndexLens{Tuple{Int64}}}, Int64}, Vector{Normal{Float64}}, Vector{VarName{:x, Accessors.IndexLens{Tuple{Int64}}}}, Vector{Float64}, Vector{Set{DynamicPPL.Selector}}}}, Float64}, ::Normal{Float64})`: f = DynamicPPL.to_linked_internal_transform(vi::TypedVarInfo{@NamedTuple{x::DynamicPPL.Metadata{Dict{…}, Vector{…}, Vector{…}, Vector{…}, Vector{…}}}, Float64}, dist::Normal{Float64})
│││││└────────────────────
```