### PR TITLE
Improve error message for `initial_params`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.33.1"
+version = "0.33.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.33.0"
+version = "0.33.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -157,17 +157,21 @@ By default, it returns an instance of [`SampleFromPrior`](@ref).
 initialsampler(spl::Sampler) = SampleFromPrior()
 
 function set_values!!(
-    varinfo::AbstractVarInfo, initial_params::AbstractVector{T}, spl::AbstractSampler
-) where {T}
-    if T === Any
-        throw(
-            ArgumentError(
-                "`initial_params` must be a vector of type `Union{Real,Missing}`. " *
-                "If `initial_params` is a vector of vectors, please flatten it first using `vcat`.",
-            ),
-        )
-    end
+    varinfo::AbstractVarInfo, initial_params::AbstractVector, spl::AbstractSampler
+)
+    throw(
+        ArgumentError(
+            "`initial_params` must be a vector of type `Union{Real,Missing}`. " *
+            "If `initial_params` is a vector of vectors, please flatten it (e.g. using `vcat`) first.",
+        ),
+    )
+end
 
+function set_values!!(
+    varinfo::AbstractVarInfo,
+    initial_params::AbstractVector{<:Union{Real,Missing}},
+    spl::AbstractSampler,
+)
     flattened_param_vals = varinfo[spl]
     length(flattened_param_vals) == length(initial_params) || throw(
         DimensionMismatch(
@@ -199,7 +203,8 @@ function set_values!!(
                 if subsumes(vn, vv)
                     throw(
                         ArgumentError(
-                            "Variable $v not found in model, but it subsumes a variable ($vv) in the model. " *
+                            "The current model does not contain variable $v, but there's ($vv) in the model. " *
+                            "Using NamedTuple for initial_params is not supported for this model. " *
                             "Please use AbstractVector for initial_params instead of NamedTuple.",
                         ),
                     )

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -204,7 +204,6 @@ function set_values!!(
                     )
                 end
             end
-            
             throw(ArgumentError("Variable $v not found in the model."))
         end
     end

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -203,8 +203,8 @@ function set_values!!(
                 if subsumes(vn, vv)
                     throw(
                         ArgumentError(
-                            "The current model does not contain variable $v, but there's ($vv) in the model. " *
-                            "Using NamedTuple for initial_params is not supported for this model. " *
+                            "The current model contains sub-variables of $v, such as ($vv). " *
+                            "Using NamedTuple for initial_params is not supported in such a case. " *
                             "Please use AbstractVector for initial_params instead of NamedTuple.",
                         ),
                     )

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -193,9 +193,10 @@ function set_values!!(
 )
     vars_in_varinfo = keys(varinfo)
     for v in keys(initial_params)
-        if !(v in vars_in_varinfo)
+        vn = VarName{v}()
+        if !(vn in vars_in_varinfo)
             for vv in vars_in_varinfo
-                if subsumes(VarName{v}(), vv)
+                if subsumes(vn, vv)
                     throw(
                         ArgumentError(
                             "Variable $v not found in model, but it subsumes a variable ($vv) in the model. " *


### PR DESCRIPTION
Address https://github.com/TuringLang/DynamicPPL.jl/issues/774 partially.

This only improve the error message, and does not add support for using `OrderedDIct` for initializing.
 
The error messages are:

* for `Vector{Any}`
```
ArgumentError: `initial_params` must be a vector of type `Union{Real,Missing}`. If `initial_params` is a vector of vectors, please flatten it first using `vcat`.
```

* for `NamedTuple` (keys of `NamedTuple` subsumes some variables in the model, but itself not in the model)
```
ArgumentError: Variable X not found in model, but it subsumes a variable (X[1]) in the model. Please use AbstractVector for initial_params instead of NamedTuple.
```