### PR TITLE
Streamline internal de/conditioning interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.33.0"
+version = "0.33.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -65,7 +65,7 @@ DynamicPPL.LogDensityFunction
 A [`Model`](@ref) can be conditioned on a set of observations with [`AbstractPPL.condition`](@ref) or its alias [`|`](@ref).
 
 ```@docs
-|(::Model, ::Any)
+|(::Model, ::Union{Tuple,NamedTuple,AbstractDict{<:VarName}})
 condition
 DynamicPPL.conditioned
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -403,6 +403,7 @@ LikelihoodContext
 PriorContext
 MiniBatchContext
 PrefixContext
+ConditionContext
 ```
 
 ### Samplers

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -447,8 +447,16 @@ function decondition_context(context::ConditionContext, sym, syms...)
         # No more values left, can unwrap
         decondition_context(childcontext(context), syms...)
     else
-        ConditionContext(new_values, decondition_context(childcontext(context), syms...))
+        ConditionContext(
+            new_values, decondition_context(childcontext(context), sym, syms...)
+        )
     end
+end
+function decondition_context(context::NamedConditionContext, vn::VarName{sym}) where {sym}
+    return ConditionContext(
+        BangBang.delete!!(context.values, sym),
+        decondition_context(childcontext(context), vn),
+    )
 end
 
 """

--- a/test/contexts.jl
+++ b/test/contexts.jl
@@ -243,7 +243,9 @@ end
             end
 
             @testset "Dict" begin
-                ctx = ConditionContext(Dict(@varname(x) => 1, @varname(y) => 2, @varname(z) => 3))
+                ctx = ConditionContext(
+                    Dict(@varname(x) => 1, @varname(y) => 2, @varname(z) => 3)
+                )
                 # Decondition all variables
                 @test decondition_context(ctx) isa DefaultContext
                 # Decondition only some variables
@@ -254,7 +256,8 @@ end
                 @test dctx isa ConditionContext
                 @test dctx.values == Dict(@varname(x) => 1)
                 # Decondition all variables manually
-                @test decondition_context(ctx, @varname(x), @varname(y), @varname(z)) isa DefaultContext
+                @test decondition_context(ctx, @varname(x), @varname(y), @varname(z)) isa
+                    DefaultContext
             end
         end
     end

--- a/test/contexts.jl
+++ b/test/contexts.jl
@@ -11,6 +11,7 @@ using DynamicPPL:
     PointwiseLogdensityContext,
     contextual_isassumption,
     ConditionContext,
+    decondition_context,
     hasconditioned,
     getconditioned,
     hasconditioned_nested,
@@ -194,6 +195,68 @@ end
         @test SamplingContext(SampleFromPrior(), DefaultContext()) == context
         @test SamplingContext(SampleFromPrior(), DefaultContext()) == context
         @test EnzymeCore.EnzymeRules.inactive_type(typeof(context))
+    end
+
+    @testset "ConditionContext" begin
+        @testset "Nesting" begin
+            @testset "NamedTuple" begin
+                n1 = (x=1, y=2)
+                n2 = (x=3,)
+                # Values from outer context should override inner one
+                ctx1 = ConditionContext(n1, ConditionContext(n2))
+                @test ctx1.values == (x=1, y=2)
+                # Check that the two ConditionContexts are collapsed 
+                @test childcontext(ctx1) isa DefaultContext
+                # Then test the nesting the other way round
+                ctx2 = ConditionContext(n2, ConditionContext(n1))
+                @test ctx2.values == (x=3, y=2)
+                @test childcontext(ctx2) isa DefaultContext
+            end
+
+            @testset "Dict" begin
+                # Same tests as NamedTuple above
+                d1 = Dict(@varname(x) => 1, @varname(y) => 2)
+                d2 = Dict(@varname(x) => 3)
+                ctx1 = ConditionContext(d1, ConditionContext(d2))
+                @test ctx1.values == Dict(@varname(x) => 1, @varname(y) => 2)
+                @test childcontext(ctx1) isa DefaultContext
+                ctx2 = ConditionContext(d2, ConditionContext(d1))
+                @test ctx2.values == Dict(@varname(x) => 3, @varname(y) => 2)
+                @test childcontext(ctx2) isa DefaultContext
+            end
+        end
+
+        @testset "decondition_context" begin
+            @testset "NamedTuple" begin
+                ctx = ConditionContext((x=1, y=2, z=3))
+                # Decondition all variables
+                @test decondition_context(ctx) isa DefaultContext
+                # Decondition only some variables
+                dctx = decondition_context(ctx, :x)
+                @test dctx isa ConditionContext
+                @test dctx.values == (y=2, z=3)
+                dctx = decondition_context(ctx, :y, :z)
+                @test dctx isa ConditionContext
+                @test dctx.values == (x=1,)
+                # Decondition all variables manually
+                @test decondition_context(ctx, :x, :y, :z) isa DefaultContext
+            end
+
+            @testset "Dict" begin
+                ctx = ConditionContext(Dict(@varname(x) => 1, @varname(y) => 2, @varname(z) => 3))
+                # Decondition all variables
+                @test decondition_context(ctx) isa DefaultContext
+                # Decondition only some variables
+                dctx = decondition_context(ctx, @varname(x))
+                @test dctx isa ConditionContext
+                @test dctx.values == Dict(@varname(y) => 2, @varname(z) => 3)
+                dctx = decondition_context(ctx, @varname(y), @varname(z))
+                @test dctx isa ConditionContext
+                @test dctx.values == Dict(@varname(x) => 1)
+                # Decondition all variables manually
+                @test decondition_context(ctx, @varname(x), @varname(y), @varname(z)) isa DefaultContext
+            end
+        end
     end
 
     @testset "FixedContext" begin

--- a/test/contexts.jl
+++ b/test/contexts.jl
@@ -259,6 +259,23 @@ end
                 @test decondition_context(ctx, @varname(x), @varname(y), @varname(z)) isa
                     DefaultContext
             end
+
+            @testset "Nesting" begin
+                ctx = ConditionContext(
+                    (x=1, y=2), ConditionContext(Dict(@varname(a) => 3, @varname(b) => 4))
+                )
+                # Decondition an outer variable
+                dctx = decondition_context(ctx, :x)
+                @test dctx.values == (y=2,)
+                @test childcontext(dctx).values == Dict(@varname(a) => 3, @varname(b) => 4)
+                # Decondition an inner variable
+                dctx = decondition_context(ctx, @varname(a))
+                @test dctx.values == (x=1, y=2)
+                @test childcontext(dctx).values == Dict(@varname(b) => 4)
+                # Try deconditioning everything
+                dctx = decondition_context(ctx)
+                @test dctx isa DefaultContext
+            end
         end
     end
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -103,22 +103,22 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
     @testset "model conditioning with various arguments" begin
         @model function demo_condition()
             x ~ Normal()
-            y ~ Normal(x)
+            return y ~ Normal(x)
         end
         model = demo_condition()
         # Test that different syntaxes work and give the same underlying ConditionContext
         @testset "NamedTuple ConditionContext" begin
-            expected_values = (y = 2,)
+            expected_values = (y=2,)
             @test condition(model, (y=2,)).context.values == expected_values
-            @test condition(model, y=2).context.values == expected_values
             @test condition(model; y=2).context.values == expected_values
-            @test (model | (y = 2, )).context.values == expected_values
+            @test condition(model; y=2).context.values == expected_values
+            @test (model | (y=2,)).context.values == expected_values
         end
         @testset "AbstractDict ConditionContext" begin
             expected_values = Dict(@varname(y) => 2)
             @test condition(model, Dict(@varname(y) => 2)).context.values == expected_values
             @test condition(model, @varname(y) => 2).context.values == expected_values
-            @test (model | (@varname(y) => 2, )).context.values == expected_values
+            @test (model | (@varname(y) => 2,)).context.values == expected_values
         end
     end
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -100,6 +100,28 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
         end
     end
 
+    @testset "model conditioning with various arguments" begin
+        @model function demo_condition()
+            x ~ Normal()
+            y ~ Normal(x)
+        end
+        model = demo_condition()
+        # Test that different syntaxes work and give the same underlying ConditionContext
+        @testset "NamedTuple ConditionContext" begin
+            expected_values = (y = 2,)
+            @test condition(model, (y=2,)).context.values == expected_values
+            @test condition(model, y=2).context.values == expected_values
+            @test condition(model; y=2).context.values == expected_values
+            @test (model | (y = 2, )).context.values == expected_values
+        end
+        @testset "AbstractDict ConditionContext" begin
+            expected_values = Dict(@varname(y) => 2)
+            @test condition(model, Dict(@varname(y) => 2)).context.values == expected_values
+            @test condition(model, @varname(y) => 2).context.values == expected_values
+            @test (model | (@varname(y) => 2, )).context.values == expected_values
+        end
+    end
+
     @testset "DynamicPPL#684: threadsafe evaluation with multiple types" begin
         @model function multiple_types(x)
             ns ~ filldist(Normal(0, 2.0), 3)


### PR DESCRIPTION
This PR:

- in `src/contexts.jl`, removes the methods `AbstractPPL.condition(values, ...)` in favour of directly using the `ConditionContext()` constructor.

  This is mainly inspired by Aqua's complaints about how we are pirating `AbstractPPL.{de,}condition` (see #775). I've tested locally and this PR would fix all of the `condition`-related type piracies. But also semantically, I think that `condition` is something you do to a model, not a context (and AbstractPPL's API sort of specifies that too). Since contexts are DynamicPPL-internal, I think it makes sense that we use an different, internal, function to manipulate that.

- likewise, renames `AbstractPPL.decondition(context, ...)` to `decondition_context(context, ...)`. Suggestions for other names welcome!

- shifts the bulk of the 'figuring-out-arguments-and-coercing-to-the-right-format' stuff into a helper function, called `_make_conditioning_values`. This allows us to have a much more specific type for the `ConditionContext` struct itself, while retaining the current flexibility of the model conditioning syntax.

- adds tests for all of the above

-----------

Going beyond the name changes, there are two changes to functionality, which are both in the new `decondition_context`:

 - `decondition_context` now checks if there are no more conditioned values left, and if so, unwraps the layer of `ConditionContext`. This shouldn't really affect anything, it just makes for cleaner context trees. For example:

    ```julia
    julia> ctx = ConditionContext(Dict(@varname(x) => 1, @varname(y) => 2))
    ConditionContext(Dict{VarName{sym, typeof(identity)} where sym, Int64}(x => 1, y => 2), DefaultContext())

    julia> # On current master
           decondition(ctx, @varname(x), @varname(y)) # On current master
    ConditionContext(Dict{VarName{sym, typeof(identity)} where sym, Int64}(), DefaultContext())

    julia> # With this PR
           decondition_context(ctx, @varname(x), @varname(y))
    DefaultContext()
    ```

 - `decondition_context` also makes sure to deepcopy the previous conditioned values, to avoid surprises due to mutation in `BangBang.delete!!`:

    ```julia
    julia> ctx = ConditionContext(Dict(@varname(x) => 1, @varname(y) => 2))
    ConditionContext(Dict{VarName{sym, typeof(identity)} where sym, Int64}(x => 1, y => 2), DefaultContext())

    julia> # On current master
           decondition(ctx, @varname(x)); decondition(ctx, @varname(y))
    ConditionContext(Dict{VarName{sym, typeof(identity)} where sym, Int64}(), DefaultContext())

    julia> # With this PR
           decondition_context(ctx, @varname(x)); decondition_context(ctx, @varname(y))
    ConditionContext(Dict{VarName{sym, typeof(identity)} where sym, Int64}(x => 1), DefaultContext())
    ```