### PR TITLE
Make subset preserve varname ordering in varinfo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.35.0"
+version = "0.35.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/abstract_varinfo.jl
+++ b/src/abstract_varinfo.jl
@@ -331,12 +331,7 @@ has_varnamedvector(vi::AbstractVarInfo) = false
 
 Subset a `varinfo` to only contain the variables `vns`.
 
-!!! warning
-    The ordering of the variables in the resulting `varinfo` is _not_
-    guaranteed to follow the ordering of the variables in `varinfo`.
-    Hence care must be taken, in particular when used in conjunction with
-    other methods which uses the vector-representation of the `varinfo`,
-    e.g. `getindex(varinfo, sampler)`.
+The ordering of variables in the return value will be the same as in `varinfo`.
 
 # Examples
 ```jldoctest varinfo-subset; setup = :(using Distributions, DynamicPPL)

--- a/src/simple_varinfo.jl
+++ b/src/simple_varinfo.jl
@@ -416,9 +416,9 @@ end
 
 function _subset(x::AbstractDict, vns::AbstractVector{VN}) where {VN<:VarName}
     vns_present = collect(keys(x))
-    vns_found = mapreduce(vcat, vns; init=VN[]) do vn
-        return filter(Base.Fix1(subsumes, vn), vns_present)
-    end
+    vns_found = filter(
+        vn_present -> any(subsumes(vn, vn_present) for vn in vns), vns_present
+    )
     C = ConstructionBase.constructorof(typeof(x))
     if isempty(vns_found)
         return C()
@@ -439,7 +439,8 @@ function _subset(x::NamedTuple, vns)
     end
 
     syms = map(getsym, vns)
-    return NamedTuple{Tuple(syms)}(Tuple(map(Base.Fix1(getindex, x), syms)))
+    x_syms = filter(Base.Fix2(in, syms), keys(x))
+    return NamedTuple{Tuple(x_syms)}(Tuple(map(Base.Fix1(getindex, x), x_syms)))
 end
 
 _subset(x::VarNamedVector, vns) = subset(x, vns)

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -351,7 +351,7 @@ end
         # TODO(mhauru) Note that this could still generate an empty metadata object if none
         # of the lenses in `vns` are in `metadata`. Not sure if that's okay. Checking for
         # emptiness would make this type unstable again.
-        :(NamedTuple{($sym,)}(tuple(subset(metadata.$sym, vns))))
+        :((; $sym=subset(metadata.$sym, vns)))
     else
         :(NamedTuple{}())
     end

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -736,6 +736,8 @@ end
                 vns_subset_reversed = reverse(vns_subset)
                 varinfo_subset_reversed = subset(varinfo, vns_subset_reversed)
                 @test varinfo_subset[:] == varinfo_subset_reversed[:]
+                ground_truth = [varinfo[vn] for vn in vns_subset]
+                @test varinfo_subset[:] == ground_truth
             end
         end
 

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -729,6 +729,14 @@ end
                 # Values should be the same.
                 @test [varinfo_merged[vn] for vn in vns] == [varinfo[vn] for vn in vns]
             end
+
+            @testset "$(convert(Vector{VarName}, vns_subset)) order" for vns_subset in
+                                                                         vns_supported
+                varinfo_subset = subset(varinfo, vns_subset)
+                vns_subset_reversed = reverse(vns_subset)
+                varinfo_subset_reversed = subset(varinfo, vns_subset_reversed)
+                @test varinfo_subset[:] == varinfo_subset_reversed[:]
+            end
         end
 
         # For certain varinfos we should have errors.


### PR DESCRIPTION
Previously, `subset(vi, vns)` had the variables in the return value ordered according to `vns` and not according to their order in `vi`. This PR makes the order be the same as that in `vi`.

This fixes the issue in https://github.com/TuringLang/Turing.jl/issues/2300#issuecomment-2692445692.

Since the docstring of `subset` previously said that the order was not guaranteed to be the same as `vi`, without saying what the order _would_ be, I've marked this as a patch rather than a breaking release. I think this is debatable, so feel free to debate it.

@torfjelde, was there a particular reason to not do this before, other than no one bothering to implement it?