### PR TITLE
Clean up varinfo get/set functions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,16 @@
 # DynamicPPL Changelog
 
+## 0.35.5
+
+Several internal methods have been removed:
+
+  - `DynamicPPL.getall(vi::AbstractVarInfo)` has been removed. You can directly replace this with `getindex_internal(vi, Colon())`.
+  - `DynamicPPL.setall!(vi::AbstractVarInfo, values)` has been removed. Rewrite the calling function to not assume mutation and use `unflatten(vi, values)` instead.
+  - `DynamicPPL.replace_values(md::Metadata, values)` and `DynamicPPL.replace_values(nt::NamedTuple, values)` (where the `nt` is a NamedTuple of Metadatas) have been removed. Use `DynamicPPL.unflatten_metadata` as a direct replacement.
+  - `DynamicPPL.set_values!!(vi::AbstractVarInfo, values)` has been renamed to `DynamicPPL.set_initial_values(vi::AbstractVarInfo, values)`; it also no longer mutates the varinfo argument.
+
+The **exported** method `VarInfo(vi::VarInfo, values)` has been deprecated, and will be removed in the next minor version. You can replace this directly with `unflatten(vi, values)` instead.
+
 ## 0.35.4
 
 Fixed a type instability in an implementation of `with_logabsdet_jacobian`, which resulted in the log-jacobian returned being an Int in some cases and a Float in others.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.35.4"
+version = "0.35.5"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/abstract_varinfo.jl
+++ b/src/abstract_varinfo.jl
@@ -162,8 +162,16 @@ Base.getindex(vi::AbstractVarInfo, ::Colon) = values_as(vi, Vector)
 """
     getindex_internal(vi::AbstractVarInfo, vn::VarName)
     getindex_internal(vi::AbstractVarInfo, vns::Vector{<:VarName})
+    getindex_internal(vi::AbstractVarInfo, ::Colon)
 
-Return the current value(s) of `vn` (`vns`) in `vi` as represented internally in `vi`.
+Return the internal value of the varname `vn`, varnames `vns`, or all varnames
+in `vi` respectively. The internal value is the value of the variables that is
+stored in the varinfo object; this may be the actual realisation of the random
+variable (i.e. the value sampled from the distribution), or it may have been
+transformed to Euclidean space, depending on whether the varinfo was linked.
+
+See https://turinglang.org/docs/developers/transforms/dynamicppl/ for more
+information on how transformed variables are stored in DynamicPPL.
 
 See also: [`getindex(vi::AbstractVarInfo, vn::VarName, dist::Distribution)`](@ref)
 """

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -100,6 +100,8 @@ const TypedVarInfo = VarInfo{<:NamedTuple}
 const VarInfoOrThreadSafeVarInfo{Tmeta} = Union{
     VarInfo{Tmeta},ThreadSafeVarInfo{<:VarInfo{Tmeta}}
 }
+# TODO: Remove this
+@deprecate VarInfo(vi::VarInfo, x::AbstractVector) unflatten(vi, x)
 
 # NOTE: This is kind of weird, but it effectively preserves the "old"
 # behavior where we're allowed to call `link!` on the same `VarInfo`

--- a/test/model.jl
+++ b/test/model.jl
@@ -163,12 +163,12 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
                 Random.seed!(100 + i)
                 vi = VarInfo()
                 model(Random.default_rng(), vi, sampler)
-                vals = DynamicPPL.getall(vi)
+                vals = vi[:]
 
                 Random.seed!(100 + i)
                 vi = VarInfo()
                 model(Random.default_rng(), vi, sampler)
-                @test DynamicPPL.getall(vi) == vals
+                @test vi[:] == vals
             end
         end
     end
@@ -240,7 +240,7 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
         for i in 1:10
             # Sample with large variations.
             r_raw = randn(length(vi[:])) * 10
-            DynamicPPL.setall!(vi, r_raw)
+            vi = DynamicPPL.unflatten(vi, r_raw)
             @test vi[@varname(m)] == r_raw[1]
             @test vi[@varname(x)] != r_raw[2]
             model(vi)

--- a/test/simple_varinfo.jl
+++ b/test/simple_varinfo.jl
@@ -258,7 +258,7 @@
                 # `getlogp` should be equal to the logjoint with log-absdet-jac correction.
                 lp = getlogp(svi)
                 # needs higher atol because of https://github.com/TuringLang/Bijectors.jl/issues/375
-                @test lp ≈ lp_true atol=1.2e-5
+                @test lp ≈ lp_true atol = 1.2e-5
             end
         end
     end

--- a/test/simple_varinfo.jl
+++ b/test/simple_varinfo.jl
@@ -257,7 +257,8 @@
 
                 # `getlogp` should be equal to the logjoint with log-absdet-jac correction.
                 lp = getlogp(svi)
-                @test lp ≈ lp_true
+                # needs higher atol because of https://github.com/TuringLang/Bijectors.jl/issues/375
+                @test lp ≈ lp_true atol=1.2e-5
             end
         end
     end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -8,9 +8,10 @@
 end
 const gdemo_default = gdemo_d()
 
+# TODO(penelopeysm): Remove this (and also test/compat/ad.jl)
 function test_model_ad(model, logp_manual)
     vi = VarInfo(model)
-    x = DynamicPPL.getall(vi)
+    x = vi[:]
 
     # Log probabilities using the model.
     ℓ = DynamicPPL.LogDensityFunction(model, vi)


### PR DESCRIPTION
Closes #795 

As discussed in #795 and also https://github.com/TuringLang/DynamicPPL.jl/pull/793/files#r1936255984 there are many internal DPPL functions which more or less do the same thing. This PR cleans them up a bit.

More comments to be made on the diff.