### PR TITLE
Interpolate `DynamicPPL.check_dot_tilde_rhs` into macro

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # DynamicPPL Changelog
 
+## 0.35.6
+
+Fixed the implementation of `.~`, such that running a model with it no longer requires DynamicPPL itself to be loaded.
+
 ## 0.35.5
 
 Several internal methods have been removed:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.35.5"
+version = "0.35.6"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -519,7 +519,7 @@ Generate the expression that replaces `left .~ right` in the model body.
 function generate_dot_tilde(left, right)
     @gensym dist left_axes idx
     return quote
-        $dist = DynamicPPL.check_dot_tilde_rhs($right)
+        $dist = $(DynamicPPL.check_dot_tilde_rhs)($right)
         $left_axes = axes($left)
         for $idx in Iterators.product($left_axes...)
             $left[$idx...] ~ $dist


### PR DESCRIPTION
Fixes https://github.com/TuringLang/DynamicPPL.jl/issues/868

The function itself needs to be interpolated, otherwise it will be left to the caller to resolve. This is OK if they have imported DynamicPPL (as used to be the case in Turing 0.36) but now since Turing no longer exports DynamicPPL, `check_dot_tilde_rhs` can no longer be accessed by the user.

I suppose this also guards against users redefining the function themselves 😄 