### PR TITLE
Fix `condition` and `fix` in submodels

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,9 +14,8 @@ See https://github.com/TuringLang/DynamicPPL.jl/issues/857 for a full illustrati
     x ~ Normal()
     return y ~ Normal()
 end
-inner_conditioned = inner() | (x=1.0,)
 @model function outer()
-    return a ~ to_submodel(inner_conditioned)
+    return a ~ to_submodel(inner() | (x=1.0,))
 end
 ```
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,25 @@
 
 **Breaking changes**
 
+### Submodels
+
+Variables in a submodel can now be conditioned and fixed in a correct way.
+See https://github.com/TuringLang/DynamicPPL.jl/issues/857 for a full illustration, but essentially it means you can now do this:
+
+```julia
+@model function inner()
+    x ~ Normal()
+    return y ~ Normal()
+end
+inner_conditioned = inner() | (x=1.0,)
+@model function outer()
+    return a ~ to_submodel(inner_conditioned)
+end
+```
+
+and the `inner.x` variable will be correctly conditioned.
+(Previously, you would have to condition `inner()` with the variable `a.x`, meaning that you would need to know what prefix to use before you had actually prefixed it.)
+
 ### AD testing utilities
 
 `DynamicPPL.TestUtils.AD.run_ad` now links the VarInfo by default.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 
 **Breaking changes**
 
-### Submodels
+### Submodels: conditioning
 
 Variables in a submodel can now be conditioned and fixed in a correct way.
 See https://github.com/TuringLang/DynamicPPL.jl/issues/857 for a full illustration, but essentially it means you can now do this:
@@ -22,38 +22,7 @@ end
 and the `a.x` variable will be correctly conditioned.
 (Previously, you would have to condition `inner()` with the variable `a.x`, meaning that you would need to know what prefix to use before you had actually prefixed it.)
 
-### AD testing utilities
-
-`DynamicPPL.TestUtils.AD.run_ad` now links the VarInfo by default.
-To disable this, pass the `linked=false` keyword argument.
-If the calculated value or gradient is incorrect, it also throws a `DynamicPPL.TestUtils.AD.ADIncorrectException` rather than a test failure.
-This exception contains the actual and expected gradient so you can inspect it if needed; see the documentation for more information.
-From a practical perspective, this means that if you need to add this to a test suite, you need to use `@test run_ad(...) isa Any` rather than just `run_ad(...)`.
-
-### SimpleVarInfo linking / invlinking
-
-Linking a linked SimpleVarInfo, or invlinking an unlinked SimpleVarInfo, now displays a warning instead of an error.
-
-### VarInfo constructors
-
-`VarInfo(vi::VarInfo, values)` has been removed. You can replace this directly with `unflatten(vi, values)` instead.
-
-The `metadata` argument to `VarInfo([rng, ]model[, sampler, context, metadata])` has been removed.
-If you were not using this argument (most likely), then there is no change needed.
-If you were using the `metadata` argument to specify a blank `VarNamedVector`, then you should replace calls to `VarInfo` with `DynamicPPL.typed_vector_varinfo` instead (see 'Other changes' below).
-
-The `UntypedVarInfo` constructor and type is no longer exported.
-If you needed to construct one, you should now use `DynamicPPL.untyped_varinfo` instead.
-
-The `TypedVarInfo` constructor and type is no longer exported.
-The _type_ has been replaced with `DynamicPPL.NTVarInfo`.
-The _constructor_ has been replaced with `DynamicPPL.typed_varinfo`.
-
-Note that the exact kind of VarInfo returned by `VarInfo(rng, model, ...)` is an implementation detail.
-Previously, it was guaranteed that this would always be a VarInfo whose metadata was a `NamedTuple` containing `Metadata` structs.
-Going forward, this is no longer the case, and you should only assume that the returned object obeys the `AbstractVarInfo` interface.
-
-### VarName prefixing behaviour
+### Submodel prefixing
 
 The way in which VarNames in submodels are prefixed has been changed.
 This is best explained through an example.
@@ -95,8 +64,61 @@ outer() | (@varname(var"a.x") => 1.0,)
 outer() | (a.x=1.0,)
 ```
 
-If you are sampling from a model with submodels, this doesn't affect the way you interact with the `MCMCChains.Chains` object, because VarNames are converted into Symbols when stored in the chain.
+In a similar way, if the variable on the left-hand side of your tilde statement is not just a single identifier, any fields or indices it accesses are now properly respected.
+Consider the following setup:
+
+```julia
+using DynamicPPL, Distributions
+@model inner() = x ~ Normal()
+@model function outer()
+    a = Vector{Float64}(undef, 1)
+    a[1] ~ to_submodel(inner())
+    return a
+end
+```
+
+In this case, the variable sampled is actually the `x` field of the first element of `a`:
+
+```julia
+julia> only(keys(VarInfo(outer()))) == @varname(a[1].x)
+true
+```
+
+Before this version, it used to be a single variable called `var"a[1].x"`.
+
+Note that if you are sampling from a model with submodels, this doesn't affect the way you interact with the `MCMCChains.Chains` object, because VarNames are converted into Symbols when stored in the chain.
 (This behaviour will likely be changed in the future, in that Chains should be indexable by VarNames and not just Symbols, but that has not been implemented yet.)
+
+### AD testing utilities
+
+`DynamicPPL.TestUtils.AD.run_ad` now links the VarInfo by default.
+To disable this, pass the `linked=false` keyword argument.
+If the calculated value or gradient is incorrect, it also throws a `DynamicPPL.TestUtils.AD.ADIncorrectException` rather than a test failure.
+This exception contains the actual and expected gradient so you can inspect it if needed; see the documentation for more information.
+From a practical perspective, this means that if you need to add this to a test suite, you need to use `@test run_ad(...) isa Any` rather than just `run_ad(...)`.
+
+### SimpleVarInfo linking / invlinking
+
+Linking a linked SimpleVarInfo, or invlinking an unlinked SimpleVarInfo, now displays a warning instead of an error.
+
+### VarInfo constructors
+
+`VarInfo(vi::VarInfo, values)` has been removed. You can replace this directly with `unflatten(vi, values)` instead.
+
+The `metadata` argument to `VarInfo([rng, ]model[, sampler, context, metadata])` has been removed.
+If you were not using this argument (most likely), then there is no change needed.
+If you were using the `metadata` argument to specify a blank `VarNamedVector`, then you should replace calls to `VarInfo` with `DynamicPPL.typed_vector_varinfo` instead (see 'Other changes' below).
+
+The `UntypedVarInfo` constructor and type is no longer exported.
+If you needed to construct one, you should now use `DynamicPPL.untyped_varinfo` instead.
+
+The `TypedVarInfo` constructor and type is no longer exported.
+The _type_ has been replaced with `DynamicPPL.NTVarInfo`.
+The _constructor_ has been replaced with `DynamicPPL.typed_varinfo`.
+
+Note that the exact kind of VarInfo returned by `VarInfo(rng, model, ...)` is an implementation detail.
+Previously, it was guaranteed that this would always be a VarInfo whose metadata was a `NamedTuple` containing `Metadata` structs.
+Going forward, this is no longer the case, and you should only assume that the returned object obeys the `AbstractVarInfo` interface.
 
 **Other changes**
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,7 +19,7 @@ end
 end
 ```
 
-and the `inner.x` variable will be correctly conditioned.
+and the `a.x` variable will be correctly conditioned.
 (Previously, you would have to condition `inner()` with the variable `a.x`, meaning that you would need to know what prefix to use before you had actually prefixed it.)
 
 ### AD testing utilities

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+AbstractPPL = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,7 +24,9 @@ makedocs(;
     format=Documenter.HTML(; size_threshold=2^10 * 400),
     modules=[DynamicPPL, Base.get_extension(DynamicPPL, :DynamicPPLMCMCChainsExt)],
     pages=[
-        "Home" => "index.md", "API" => "api.md", "Internals" => ["internals/varinfo.md"]
+        "Home" => "index.md",
+        "API" => "api.md",
+        "Internals" => ["internals/varinfo.md", "internals/submodel_condition.md"],
     ],
     checkdocs=:exports,
     doctest=false,

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -78,9 +78,9 @@ decondition
 
 ## Fixing and unfixing
 
-We can also _fix_ a collection of variables in a [`Model`](@ref) to certain using [`DynamicPPL.fix`](@ref).
+We can also _fix_ a collection of variables in a [`Model`](@ref) to certain values using [`DynamicPPL.fix`](@ref).
 
-This might seem quite similar to the aforementioned [`condition`](@ref) and its siblings,
+This is quite similar to the aforementioned [`condition`](@ref) and its siblings,
 but they are indeed different operations:
 
   - `condition`ed variables are considered to be _observations_, and are thus

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -78,7 +78,7 @@ decondition
 
 ## Fixing and unfixing
 
-We can also _fix_ a collection of variables in a [`Model`](@ref) to certain using [`fix`](@ref).
+We can also _fix_ a collection of variables in a [`Model`](@ref) to certain using [`DynamicPPL.fix`](@ref).
 
 This might seem quite similar to the aforementioned [`condition`](@ref) and its siblings,
 but they are indeed different operations:
@@ -89,19 +89,19 @@ but they are indeed different operations:
   - `fix`ed variables are considered to be _constant_, and are thus not included
     in any log-probability computations.
 
-The differences are more clearly spelled out in the docstring of [`fix`](@ref) below.
+The differences are more clearly spelled out in the docstring of [`DynamicPPL.fix`](@ref) below.
 
 ```@docs
-fix
+DynamicPPL.fix
 DynamicPPL.fixed
 ```
 
-The difference between [`fix`](@ref) and [`condition`](@ref) is described in the docstring of [`fix`](@ref) above.
+The difference between [`DynamicPPL.fix`](@ref) and [`DynamicPPL.condition`](@ref) is described in the docstring of [`DynamicPPL.fix`](@ref) above.
 
-Similarly, we can [`unfix`](@ref) variables, i.e. return them to their original meaning:
+Similarly, we can revert this with [`DynamicPPL.unfix`](@ref), i.e. return the variables to their original meaning:
 
 ```@docs
-unfix
+DynamicPPL.unfix
 ```
 
 ## Predicting

--- a/docs/src/internals/submodel_condition.md
+++ b/docs/src/internals/submodel_condition.md
@@ -1,0 +1,233 @@
+# How `PrefixContext` and `ConditionContext` interact
+
+```@meta
+ShareDefaultModule = true
+```
+
+## PrefixContext
+
+`PrefixContext` is a context that, as the name suggests, prefixes all variables inside a model with a given symbol.
+Thus, for example:
+
+```@example
+using DynamicPPL, Distributions
+
+@model function f()
+    x ~ Normal()
+    return y ~ Normal()
+end
+
+@model function g()
+    return a ~ to_submodel(f())
+end
+```
+
+inside the submodel `f`, the variables `x` and `y` become `a.x` and `a.y` respectively.
+This is easiest to observe by running the model:
+
+```@example
+vi = VarInfo(g())
+keys(vi)
+```
+
+!!! note
+    
+    In this case, where `to_submodel` is called without any other arguments, the prefix to be used is automatically inferred from the name of the variable on the left-hand side of the tilde.
+    We will return to the 'manual prefixing' case later.
+
+What does it really mean to 'become' a different variable?
+We can see this from [the definition of `tilde_assume`, for example](https://github.com/TuringLang/DynamicPPL.jl/blob/60ee68e2ce28a15c6062c243019e6208d16802a5/src/context_implementations.jl#L87-L89):
+
+```
+function tilde_assume(context::PrefixContext, right, vn, vi)
+    return tilde_assume(context.context, right, prefix(context, vn), vi)
+end
+```
+
+Functionally, this means that even though the _initial_ entry to the tilde-pipeline has `vn` as `x` and `y`, once the `PrefixContext` has been applied, the later functions will see `a.x` and `a.y` instead.
+
+## ConditionContext
+
+`ConditionContext` is a context which stores values of variables that are to be conditioned on.
+These values may be stored as a `Dict` which maps `VarName`s to values, or alternatively as a `NamedTuple`.
+The latter only works correctly if all `VarName`s are 'basic', in that they have an identity optic (i.e., something like `a.x` or `a[1]` is forbidden).
+Because of this limitation, we will only use `Dict` in this example.
+
+!!! note
+    
+    If a `ConditionContext` with a `NamedTuple` encounters anything to do with a prefix, its internal `NamedTuple` is converted to a `Dict` anyway, so it is quite reasonable to ignore the `NamedTuple` case in this exposition.
+
+One can inspect the conditioning values with, for example:
+
+```@example
+@model function d()
+    x ~ Normal()
+    return y ~ Normal()
+end
+
+cond_model = d() | (@varname(x) => 1.0)
+cond_ctx = cond_model.context
+```
+
+There are several internal functions that are used to determine whether a variable is conditioned, and if so, what its value is.
+
+```@example
+DynamicPPL.hasconditioned_nested(cond_ctx, @varname(x))
+```
+
+```@example
+DynamicPPL.getconditioned_nested(cond_ctx, @varname(x))
+```
+
+These functions are in turn used by the function `DynamicPPL.contextual_isassumption`, which is largely the same as `hasconditioned_nested`, but also checks whether the value is `missing` (in which case it isn't really conditioned).
+
+```@example
+DynamicPPL.contextual_isassumption(cond_ctx, @varname(x))
+```
+
+!!! note
+    
+    Notice that (neglecting `missing` values) the return value of `contextual_isassumption` is the _opposite_ of `hasconditioned_nested`, i.e. for a variable that _is_ conditioned on, `contextual_isassumption` returns `false`.
+
+If a variable `x` is conditioned on, then the effect of this is to set the value of `x` to the given value (while still including its contribution to the log probability density).
+Since `x` is no longer a random variable, if we were to evaluate the model, we would find only one key in the `VarInfo`:
+
+```@example
+keys(VarInfo(cond_model))
+```
+
+## Joint behaviour: desiderata at the model level
+
+When paired together, these two contexts have the potential to cause substantial confusion: `PrefixContext` modifies the variable names that are seen, which may cause them to be out of sync with the values contained inside the `ConditionContext`.
+
+We begin by mentioning some high-level desiderata for their joint behaviour.
+Take these models, for example:
+
+```@example
+# We define a helper function to unwrap a layer of SamplingContext, to
+# avoid cluttering the print statements.
+unwrap_sampling_context(ctx::DynamicPPL.SamplingContext) = ctx.context
+unwrap_sampling_context(ctx::DynamicPPL.AbstractContext) = ctx
+@model function inner()
+    println("inner context: $(unwrap_sampling_context(__context__))")
+    x ~ Normal()
+    return y ~ Normal()
+end
+
+@model function outer()
+    println("outer context: $(unwrap_sampling_context(__context__))")
+    return a ~ to_submodel(inner())
+end
+
+# 'Outer conditioning'
+with_outer_cond = outer() | (@varname(a.x) => 1.0)
+
+# 'Inner conditioning'
+inner_cond = inner() | (@varname(x) => 1.0)
+@model function outer2()
+    println("outer context: $(unwrap_sampling_context(__context__))")
+    return a ~ to_submodel(inner_cond)
+end
+with_inner_cond = outer2()
+```
+
+We want that:
+
+ 1. `keys(VarInfo(outer()))` should return `[a.x, a.y]`;
+ 2. `keys(VarInfo(with_outer_cond))` should return `[a.y]`;
+ 3. `keys(VarInfo(with_inner_cond))` should return `[a.y]`,
+
+**In other words, we can condition submodels either from the outside (point (2)) or from the inside (point (3)), and the variable name we use to specify the conditioning should match the level at which we perform the conditioning.**
+
+This is an incredibly salient point because it means that submodels can be treated as individual, opaque objects, and we can condition them without needing to know what it will be prefixed with, or the context in which that submodel is being used.
+For example, this means we can reuse `inner_cond` in another model with a different prefix, and it will _still_ have its inner `x` value be conditioned, despite the prefix differing.
+
+!!! info
+    
+    In the current version of DynamicPPL, these criteria are all fulfilled. However, this was not the case in the past: in particular, point (3) was not fulfilled, and users had to condition the internal submodel with the prefixes that were used outside. (See [this GitHub issue](https://github.com/TuringLang/DynamicPPL.jl/issues/857) for more information; this issue was the direct motivation for this documentation page.)
+
+## Desiderata at the context level
+
+The above section describes how we expect conditioning and prefixing to behave from a user's perpective.
+We now turn to the question of how we implement this in terms of DynamicPPL contexts.
+We do not specify the implementation details here, but we will sketch out something resembling an API that will allow us to achieve the target behaviour.
+
+**Point (1)** does not involve any conditioning, only prefixing; it is therefore already satisfied by virtue of the `tilde_assume` method shown above.
+
+**Points (2) and (3)** are more tricky.
+As the reader may surmise, the difference between them is the order in which the contexts are stacked.
+
+For the _outer_ conditioning case (point (2)), the `ConditionContext` will contain a `VarName` that is already prefixed.
+When we enter the inner submodel, this `ConditionContext` has to be passed down and somehow combined with the `PrefixContext` that is created when we enter the submodel.
+We make the claim here that the best way to do this is to nest the `PrefixContext` _inside_ the `ConditionContext`.
+This is indeed what happens, as can be demonstrated by running the model.
+
+```@example
+with_outer_cond();
+nothing;
+```
+
+!!! info
+    
+    The `; nothing` at the end is purely to circumvent a Documenter.jl quirk where stdout is only shown if the return value of the final statement is `nothing`.
+    If these documentation pages are moved to Quarto, it will be possible to remove this.
+
+For the _inner_ conditioning case (point (3)), the outer model is not run with any special context.
+The inner model will itself contain a `ConditionContext` will contain a `VarName` that is not prefixed.
+When we run the model, this `ConditionContext` should be then nested _inside_ a `PrefixContext` to form the final evaluation context.
+Again, we can run the model to see this in action:
+
+```@example
+with_inner_cond();
+nothing;
+```
+
+Putting all of the information so far together, what it means is that if we have these two inner contexts (taken from above):
+
+```@example
+using DynamicPPL: PrefixContext, ConditionContext, DefaultContext
+
+inner_ctx_with_outer_cond = ConditionContext(
+    Dict(@varname(a.x) => 1.0), PrefixContext{:a}(DefaultContext())
+)
+inner_ctx_with_inner_cond = PrefixContext{:a}(
+    ConditionContext(Dict(@varname(x) => 1.0), DefaultContext())
+)
+```
+
+then we want both of these to be `true` (and thankfully, they are!):
+
+```@example
+DynamicPPL.hasconditioned_nested(inner_ctx_with_outer_cond, @varname(a.x))
+```
+
+```@example
+DynamicPPL.hasconditioned_nested(inner_ctx_with_inner_cond, @varname(a.x))
+```
+
+Essentially, our job is threefold:
+
+  - Firstly, given the correct arguments, we need to make sure that `hasconditioned_nested` and `getconditioned_nested` behave correctly.
+
+  - Secondly, we need to make sure that both the correct arguments are supplied. In order to do so:
+    
+      + We need to make sure that when evaluating a submodel, the context stack is arranged such that prefixes are applied _inside_ the parent model's context, but _outside_ the submodel's own context.
+      + We also need to make sure that the `VarName` passed to it is prefixed correctly. This is, in fact, _not_ handled by `tilde_assume`, because `contextual_isassumption` is much higher in the call stack than `tilde_assume` is. So, we need to explicitly prefix it.
+
+## How do we do it?
+
+`hasconditioned_nested` accomplishes this by doing the following:
+
+  - If the outermost layer is a `ConditionContext`, it checks whether the variable is contained in its values.
+  - If the outermost layer is a `PrefixContext`, it goes through the `PrefixContext`'s child context and prefixes any inner conditioned variables, before checking whether the variable is contained.
+
+We ensure that the context stack is correctly arranged by relying on the behaviour of `make_evaluate_args_and_kwargs`.
+This function is called whenever a model (which itself contains a context) is evaluated with a separate ('outer') context, and makes sure to arrange it such that the model's context is nested inside the outer context.
+Thus, as long as prefixing is implemented by applying a `PrefixContext` on the outermost layer of the _inner_ model context, this will be correctly combined with an outer context to give the behaviour seen above.
+
+And finally, we ensure that the `VarName` is correctly prefixed by modifying the `@model` macro (or, technically, its subsidiary `isassumption`) to explicitly prefix the variable before passing it to `contextual_isassumption`.
+
+## FixedContext
+
+Finally, note that all of the above also applies to the interaction between `PrefixContext` and `FixedContext`, except that the functions have different names.
+(`FixedContext` behaves the same way as `ConditionContext`, except that unlike conditioned variables, fixed variables do not contribute to the log probability density.)

--- a/docs/src/internals/submodel_condition.md
+++ b/docs/src/internals/submodel_condition.md
@@ -306,7 +306,7 @@ myprefix(big_ctx, @varname(x))
 ```
 
 This is a much better result!
-The implementation of related functions such as `hasconditioned_nested` and `getconditioned_nested`, under the hood, use a similar recursion scheme, so you will find that this is a common pattern when reading the source code of various prefixing-related functions, you will find that this is a common pattern
+The implementation of related functions such as `hasconditioned_nested` and `getconditioned_nested`, under the hood, use a similar recursion scheme, so you will find that this is a common pattern when reading the source code of various prefixing-related functions.
 When editing this code, it is worth being mindful of this as a potential source of incorrectness.
 
 !!! info

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -105,7 +105,11 @@ function contextual_isassumption(context::AbstractContext, vn)
 end
 
 isfixed(expr, vn) = false
-isfixed(::Union{Symbol,Expr}, vn) = :($(DynamicPPL.contextual_isfixed)(__context__, $vn))
+function isfixed(::Union{Symbol,Expr}, vn)
+    return :($(DynamicPPL.contextual_isfixed)(
+        __context__, $(DynamicPPL.prefix)(__context__, $vn)
+    ))
+end
 
 """
     contextual_isfixed(context, vn)
@@ -443,7 +447,9 @@ function generate_tilde(left, right)
         )
         $isassumption = $(DynamicPPL.isassumption(left, vn))
         if $(DynamicPPL.isfixed(left, vn))
-            $left = $(DynamicPPL.getfixed_nested)(__context__, $vn)
+            $left = $(DynamicPPL.getfixed_nested)(
+                __context__, $(DynamicPPL.prefix)(__context__, $vn)
+            )
         elseif $isassumption
             $(generate_tilde_assume(left, dist, vn))
         else

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -131,7 +131,7 @@ function tilde_assume!!(context, right, vn, vi)
         # change in the future.
         if should_auto_prefix(right)
             dppl_model = right.model.model # This isa DynamicPPL.Model
-            prefixed_submodel_context = PrefixContext{getsym(vn)}(dppl_model.context)
+            prefixed_submodel_context = PrefixContext{Symbol(vn)}(dppl_model.context)
             new_dppl_model = contextualize(dppl_model, prefixed_submodel_context)
             right = to_submodel(new_dppl_model, true)
         end

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -57,7 +57,6 @@ function tilde_assume(context::AbstractContext, args...)
     return tilde_assume(NodeTrait(tilde_assume, context), context, args...)
 end
 function tilde_assume(::IsLeaf, context::AbstractContext, right, vn, vi)
-    @show "isleaf", vn
     return assume(right, vn, vi)
 end
 function tilde_assume(::IsParent, context::AbstractContext, args...)

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -131,7 +131,7 @@ function tilde_assume!!(context, right, vn, vi)
         # change in the future.
         if should_auto_prefix(right)
             dppl_model = right.model.model # This isa DynamicPPL.Model
-            prefixed_submodel_context = PrefixContext{Symbol(vn)}(dppl_model.context)
+            prefixed_submodel_context = PrefixContext(vn, dppl_model.context)
             new_dppl_model = contextualize(dppl_model, prefixed_submodel_context)
             right = to_submodel(new_dppl_model, true)
         end

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -426,7 +426,7 @@ hasconditioned_nested(::IsLeaf, context, vn) = hasconditioned(context, vn)
 function hasconditioned_nested(::IsParent, context, vn)
     return hasconditioned(context, vn) || hasconditioned_nested(childcontext(context), vn)
 end
-function hasconditioned_nested(context::PrefixContext{Prefix}, vn) where {Prefix}
+function hasconditioned_nested(context::PrefixContext, vn)
     return hasconditioned_nested(collapse_prefix_stack(context), vn)
 end
 
@@ -444,7 +444,7 @@ end
 function getconditioned_nested(::IsLeaf, context, vn)
     return error("context $(context) does not contain value for $vn")
 end
-function getconditioned_nested(context::PrefixContext{Prefix}, vn) where {Prefix}
+function getconditioned_nested(context::PrefixContext, vn)
     return getconditioned_nested(collapse_prefix_stack(context), vn)
 end
 function getconditioned_nested(::IsParent, context, vn)

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -691,6 +691,14 @@ end
 Apply `PrefixContext`s to any conditioned or fixed values inside them, and remove
 the `PrefixContext`s from the context stack.
 
+!!! note
+    If you are reading this docstring, you might probably be interested in a more
+thorough explanation of how PrefixContext and ConditionContext / FixedContext
+interact with one another, especially in the context of submodels.
+    The DynamicPPL documentation contains [a separate page on this
+topic](https://turinglang.org/DynamicPPL.jl/previews/PR892/internals/submodel_condition/)
+which explains this in much more detail.
+
 ```jldoctest
 julia> using DynamicPPL: collapse_prefix_stack
 

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -281,6 +281,19 @@ end
 
 Same as `prefix`, but additionally returns a new context stack that has all the
 PrefixContexts removed.
+
+NOTE: This does _not_ modify any variables in any `ConditionContext` and
+`FixedContext` that may be present in the context stack. This is because this
+function is only used in `tilde_assume`, which is lower in the tilde-pipeline
+than `contextual_isassumption` and `contextual_isfixed` (the functions which
+actually use the `ConditionContext` and `FixedContext` values). Thus, by this
+time, any `ConditionContext`s and `FixedContext`s present have already served
+their purpose.
+
+If you call this function, you must therefore be careful to ensure that you _do
+not_ need to modify any inner `ConditionContext`s and `FixedContext`s. If you
+_do_ need to modify them, then you may need to use
+`prefix_cond_and_fixed_variables` instead.
 """
 function prefix_and_strip_contexts(ctx::PrefixContext{Prefix}, vn::VarName) where {Prefix}
     child_context = childcontext(ctx)

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -519,6 +519,11 @@ function conditioned(context::ConditionContext)
     # precedence over decendants of `context`.
     return _merge(context.values, conditioned(childcontext(context)))
 end
+function conditioned(context::PrefixContext{Prefix}) where {Prefix}
+    return conditioned(
+        prefix_conditioned_variables(childcontext(context), VarName{Prefix}())
+    )
+end
 
 struct FixedContext{Values,Ctx<:AbstractContext} <: AbstractContext
     values::Values

--- a/src/model.jl
+++ b/src/model.jl
@@ -429,7 +429,7 @@ julia> # Nested ones also work.
        # (Note that `PrefixContext` also prefixes the variables of any
        # ConditionContext that is _inside_ it; because of this, the type of the
        # container has to be broadened to a `Dict`.)
-       cm = condition(contextualize(m, PrefixContext{:a}(ConditionContext((m=1.0,)))), x=100.0);
+       cm = condition(contextualize(m, PrefixContext(@varname(a), ConditionContext((m=1.0,)))), x=100.0);
 
 julia> Set(keys(conditioned(cm))) == Set([@varname(a.m), @varname(x)])
 true
@@ -441,7 +441,7 @@ julia> # Since we conditioned on `a.m`, it is not treated as a random variable.
  a.x
 
 julia> # We can also condition on `a.m` _outside_ of the PrefixContext:
-       cm = condition(contextualize(m, PrefixContext{:a}(DefaultContext())), (@varname(a.m) => 1.0));
+       cm = condition(contextualize(m, PrefixContext(@varname(a))), (@varname(a.m) => 1.0));
 
 julia> conditioned(cm)
 Dict{VarName{:a, Accessors.PropertyLens{:m}}, Float64} with 1 entry:
@@ -769,7 +769,7 @@ julia> # Returns all the variables we have fixed on + their values.
 (x = 100.0, m = 1.0)
 
 julia> # The rest of this is the same as the `condition` example above.
-       cm = fix(contextualize(m, PrefixContext{:a}(fix(m=1.0))), x=100.0);
+       cm = fix(contextualize(m, PrefixContext(@varname(a), fix(m=1.0))), x=100.0);
 
 julia> Set(keys(fixed(cm))) == Set([@varname(a.m), @varname(x)])
 true
@@ -779,7 +779,7 @@ julia> keys(VarInfo(cm))
  a.x
 
 julia> # We can also condition on `a.m` _outside_ of the PrefixContext:
-       cm = fix(contextualize(m, PrefixContext{:a}(DefaultContext())), (@varname(a.m) => 1.0));
+       cm = fix(contextualize(m, PrefixContext(@varname(a))), (@varname(a.m) => 1.0));
 
 julia> fixed(cm)
 Dict{VarName{:a, Accessors.PropertyLens{:m}}, Float64} with 1 entry:

--- a/src/model.jl
+++ b/src/model.jl
@@ -431,10 +431,8 @@ julia> # Nested ones also work.
        # container has to be broadened to a `Dict`.)
        cm = condition(contextualize(m, PrefixContext{:a}(ConditionContext((m=1.0,)))), x=100.0);
 
-julia> conditioned(cm)
-Dict{VarName, Any} with 2 entries:
-  a.m => 1.0
-  x   => 100.0
+julia> Set(keys(conditioned(cm))) == Set([@varname(a.m), @varname(x)])
+true
 
 julia> # Since we conditioned on `a.m`, it is not treated as a random variable.
        # However, `a.x` will still be a random variable.
@@ -770,29 +768,27 @@ julia> # Returns all the variables we have fixed on + their values.
        fixed(fix(m, x=100.0, m=1.0))
 (x = 100.0, m = 1.0)
 
-julia> # Nested ones also work (note that `PrefixContext` does nothing to the result).
+julia> # The rest of this is the same as the `condition` example above.
        cm = fix(contextualize(m, PrefixContext{:a}(fix(m=1.0))), x=100.0);
 
+julia> Set(keys(fixed(cm))) == Set([@varname(a.m), @varname(x)])
+true
+
+julia> keys(VarInfo(cm))
+1-element Vector{VarName{:a, Accessors.PropertyLens{:x}}}:
+ a.x
+
+julia> # We can also condition on `a.m` _outside_ of the PrefixContext:
+       cm = fix(contextualize(m, PrefixContext{:a}(DefaultContext())), (@varname(a.m) => 1.0));
+
 julia> fixed(cm)
-(x = 100.0, m = 1.0)
+Dict{VarName{:a, Accessors.PropertyLens{:m}}, Float64} with 1 entry:
+  a.m => 1.0
 
-julia> # Since we fixed on `m`, not `a.m` as it will appear after prefixed,
-       # `a.m` is treated as a random variable.
+julia> # Now `a.x` will be sampled.
        keys(VarInfo(cm))
-1-element Vector{VarName{:a, Accessors.PropertyLens{:m}}}:
- a.m
-
-julia> # If we instead fix on `a.m`, `m` in the model will be considered an observation.
-       cm = fix(contextualize(m, PrefixContext{:a}(fix(@varname(a.m) => 1.0,))), x=100.0);
-
-julia> fixed(cm)[@varname(x)]
-100.0
-
-julia> fixed(cm)[@varname(a.m)]
-1.0
-
-julia> keys(VarInfo(cm)) # <= no variables are sampled
-VarName[]
+1-element Vector{VarName{:a, Accessors.PropertyLens{:x}}}:
+ a.x
 ```
 """
 fixed(model::Model) = fixed(model.context)

--- a/src/submodel_macro.jl
+++ b/src/submodel_macro.jl
@@ -223,12 +223,12 @@ end
 prefix_submodel_context(prefix, left, ctx) = prefix_submodel_context(prefix, ctx)
 function prefix_submodel_context(prefix, ctx)
     # E.g. `prefix="asd[$i]"` or `prefix=asd` with `asd` to be evaluated.
-    return :($(PrefixContext){$(Symbol)($(esc(prefix)))}($ctx))
+    return :($(PrefixContext)($(Val)($(Symbol)($(esc(prefix)))), $ctx))
 end
 
 function prefix_submodel_context(prefix::Union{AbstractString,Symbol}, ctx)
     # E.g. `prefix="asd"`.
-    return :($(PrefixContext){$(esc(Meta.quot(Symbol(prefix))))}($ctx))
+    return :($(PrefixContext)($(esc(Meta.quot(Val(Symbol(prefix))))), $ctx))
 end
 
 function prefix_submodel_context(prefix::Bool, ctx)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1286,7 +1286,10 @@ broadcast_safe(x::Distribution) = (x,)
 broadcast_safe(x::AbstractContext) = (x,)
 
 # Convert (x=1,) to Dict(@varname(x) => 1)
-_nt_to_varname_dict(nt) = Dict(VarName{k}() => v for (k, v) in pairs(nt))
+function to_varname_dict(nt::NamedTuple)
+    return Dict{VarName,Any}(VarName{k}() => v for (k, v) in pairs(nt))
+end
+to_varname_dict(d::AbstractDict) = d
 # Version of `merge` used by `conditioned` and `fixed` to handle
 # the scenario where we might try to merge a dict with an empty
 # tuple.
@@ -1294,9 +1297,9 @@ _nt_to_varname_dict(nt) = Dict(VarName{k}() => v for (k, v) in pairs(nt))
 _merge(left::NamedTuple, right::NamedTuple) = merge(left, right)
 _merge(left::AbstractDict, right::AbstractDict) = merge(left, right)
 _merge(left::AbstractDict, ::NamedTuple{()}) = left
-_merge(left::AbstractDict, right::NamedTuple) = merge(left, _nt_to_varname_dict(right))
+_merge(left::AbstractDict, right::NamedTuple) = merge(left, to_varname_dict(right))
 _merge(::NamedTuple{()}, right::AbstractDict) = right
-_merge(left::NamedTuple, right::AbstractDict) = merge(_nt_to_varname_dict(left), right)
+_merge(left::NamedTuple, right::AbstractDict) = merge(to_varname_dict(left), right)
 
 """
     unique_syms(vns::T) where {T<:NTuple{N,VarName}}

--- a/test/contexts.jl
+++ b/test/contexts.jl
@@ -11,12 +11,18 @@ using DynamicPPL:
     IsParent,
     PointwiseLogdensityContext,
     contextual_isassumption,
+    FixedContext,
     ConditionContext,
     decondition_context,
     hasconditioned,
     getconditioned,
+    conditioned,
+    fixed,
     hasconditioned_nested,
-    getconditioned_nested
+    getconditioned_nested,
+    collapse_prefix_stack,
+    prefix_cond_and_fixed_variables,
+    getvalue
 
 using EnzymeCore
 
@@ -154,6 +160,29 @@ Base.IteratorEltype(::Type{<:AbstractContext}) = Base.EltypeUnknown()
             @test DynamicPPL.prefix(ctx3, vn) == @varname(b.a.x[1])
             ctx4 = DynamicPPL.ValuesAsInModelContext(OrderedDict(), false, ctx3)
             @test DynamicPPL.prefix(ctx4, vn) == @varname(b.a.x[1])
+        end
+
+        @testset "prefix_and_strip_contexts" begin
+            vn = @varname(x[1])
+            ctx1 = PrefixContext{:a}(DefaultContext())
+            new_vn, new_ctx = DynamicPPL.prefix_and_strip_contexts(ctx1, vn)
+            @test new_vn == @varname(a.x[1])
+            @test new_ctx == DefaultContext()
+
+            ctx2 = SamplingContext(PrefixContext{:a}(DefaultContext()))
+            new_vn, new_ctx = DynamicPPL.prefix_and_strip_contexts(ctx2, vn)
+            @test new_vn == @varname(a.x[1])
+            @test new_ctx == SamplingContext()
+
+            ctx3 = PrefixContext{:a}(ConditionContext((a=1,)))
+            new_vn, new_ctx = DynamicPPL.prefix_and_strip_contexts(ctx3, vn)
+            @test new_vn == @varname(a.x[1])
+            @test new_ctx == ConditionContext((a=1,))
+
+            ctx4 = SamplingContext(PrefixContext{:a}(ConditionContext((a=1,))))
+            new_vn, new_ctx = DynamicPPL.prefix_and_strip_contexts(ctx4, vn)
+            @test new_vn == @varname(a.x[1])
+            @test new_ctx == SamplingContext(ConditionContext((a=1,)))
         end
 
         @testset "evaluation: $(model.f)" for model in DynamicPPL.TestUtils.DEMO_MODELS
@@ -304,6 +333,101 @@ Base.IteratorEltype(::Type{<:AbstractContext}) = Base.EltypeUnknown()
             @test model_fixed().s == s
             @test model_fixed().m != m
             @test logprior(model_fixed, (; m)) == logprior(condition(model; s=s), (; m))
+        end
+    end
+
+    @testset "PrefixContext + Condition/FixedContext interactions" begin
+        @testset "prefix_cond_and_fixed_variables" begin
+            c1 = ConditionContext((c=1, d=2))
+            c1_prefixed = prefix_cond_and_fixed_variables(c1, @varname(a))
+            @test c1_prefixed isa ConditionContext
+            @test childcontext(c1_prefixed) isa DefaultContext
+            @test c1_prefixed.values[@varname(a.c)] == 1
+            @test c1_prefixed.values[@varname(a.d)] == 2
+
+            c2 = FixedContext((f=1, g=2))
+            c2_prefixed = prefix_cond_and_fixed_variables(c2, @varname(a))
+            @test c2_prefixed isa FixedContext
+            @test childcontext(c2_prefixed) isa DefaultContext
+            @test c2_prefixed.values[@varname(a.f)] == 1
+            @test c2_prefixed.values[@varname(a.g)] == 2
+
+            c3 = ConditionContext((c=1, d=2), FixedContext((f=1, g=2)))
+            c3_prefixed = prefix_cond_and_fixed_variables(c3, @varname(a))
+            c3_prefixed_child = childcontext(c3_prefixed)
+            @test c3_prefixed isa ConditionContext
+            @test c3_prefixed.values[@varname(a.c)] == 1
+            @test c3_prefixed.values[@varname(a.d)] == 2
+            @test c3_prefixed_child isa FixedContext
+            @test c3_prefixed_child.values[@varname(a.f)] == 1
+            @test c3_prefixed_child.values[@varname(a.g)] == 2
+            @test childcontext(c3_prefixed_child) isa DefaultContext
+        end
+
+        @testset "collapse_prefix_stack" begin
+            # Utility function to make sure that there are no PrefixContexts in
+            # the context stack.
+            function has_no_prefixcontexts(ctx::AbstractContext)
+                return !(ctx isa PrefixContext) && (
+                    NodeTrait(ctx) isa IsLeaf || has_no_prefixcontexts(childcontext(ctx))
+                )
+            end
+
+            # Prefix -> Condition
+            c1 = PrefixContext{:a}(ConditionContext((c=1, d=2)))
+            c1 = collapse_prefix_stack(c1)
+            @test has_no_prefixcontexts(c1)
+            c1_vals = conditioned(c1)
+            @test length(c1_vals) == 2
+            @test getvalue(c1_vals, @varname(a.c)) == 1
+            @test getvalue(c1_vals, @varname(a.d)) == 2
+
+            # Condition -> Prefix
+            c2 = (ConditionContext((c=1, d=2), PrefixContext{:a}(DefaultContext())))
+            c2 = collapse_prefix_stack(c2)
+            @test has_no_prefixcontexts(c2)
+            c2_vals = conditioned(c2)
+            @test length(c2_vals) == 2
+            @test getvalue(c2_vals, @varname(c)) == 1
+            @test getvalue(c2_vals, @varname(d)) == 2
+
+            # Prefix -> Fixed
+            c3 = PrefixContext{:a}(FixedContext((f=1, g=2)))
+            c3 = collapse_prefix_stack(c3)
+            c3_vals = fixed(c3)
+            @test length(c3_vals) == 2
+            @test length(c3_vals) == 2
+            @test getvalue(c3_vals, @varname(a.f)) == 1
+            @test getvalue(c3_vals, @varname(a.g)) == 2
+
+            # Fixed -> Prefix
+            c4 = (FixedContext((f=1, g=2), PrefixContext{:a}(DefaultContext())))
+            c4 = collapse_prefix_stack(c4)
+            @test has_no_prefixcontexts(c4)
+            c4_vals = fixed(c4)
+            @test length(c4_vals) == 2
+            @test getvalue(c4_vals, @varname(f)) == 1
+            @test getvalue(c4_vals, @varname(g)) == 2
+
+            # Prefix -> Condition -> Prefix -> Condition
+            c5 = PrefixContext{:a}(
+                ConditionContext((c=1,), PrefixContext{:b}(ConditionContext((d=2,))))
+            )
+            c5 = collapse_prefix_stack(c5)
+            @test has_no_prefixcontexts(c5)
+            c5_vals = conditioned(c5)
+            @test length(c5_vals) == 2
+            @test getvalue(c5_vals, @varname(a.c)) == 1
+            @test getvalue(c5_vals, @varname(a.b.d)) == 2
+
+            # Prefix -> Condition -> Prefix -> Fixed
+            c6 = PrefixContext{:a}(
+                ConditionContext((c=1,), PrefixContext{:b}(FixedContext((d=2,))))
+            )
+            c6 = collapse_prefix_stack(c6)
+            @test has_no_prefixcontexts(c6)
+            @test conditioned(c6) == Dict(@varname(a.c) => 1)
+            @test fixed(c6) == Dict(@varname(a.b.d) => 2)
         end
     end
 end

--- a/test/contexts.jl
+++ b/test/contexts.jl
@@ -105,7 +105,6 @@ Base.IteratorEltype(::Type{<:AbstractContext}) = Base.EltypeUnknown()
                     vcat,
                     pairs(conditioned_values),
                 )
-                @show conditioned_vns
 
                 # We can now loop over them to check which ones are missing. We use
                 # `getvalue` to handle the awkward case where sometimes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,7 @@ include("test_util.jl")
         include("threadsafe.jl")
         include("debug_utils.jl")
         include("deprecated.jl")
+        include("submodels.jl")
     end
 
     if GROUP == "All" || GROUP == "Group2"

--- a/test/submodels.jl
+++ b/test/submodels.jl
@@ -122,9 +122,7 @@ using Test
                 p.b ~ Normal()
                 return (p.a, p.b)
             end
-            expected_vns = Set([
-                @varname(var"p.a".x[1]), @varname(var"p.a".y), @varname(p.b)
-            ])
+            expected_vns = Set([@varname(p.a.x[1]), @varname(p.a.y), @varname(p.b)])
             @test Set(keys(VarInfo(g()))) == expected_vns
 
             # Check that we can condition/fix on any of them from the outside

--- a/test/submodels.jl
+++ b/test/submodels.jl
@@ -1,0 +1,117 @@
+module DPPLSubmodelTests
+
+using DynamicPPL
+using Distributions
+using Test
+
+@testset "submodels.jl" begin
+    @testset "Conditioning variables" begin
+        @testset "Auto prefix" begin
+            @model function inner()
+                x ~ Normal()
+                return y ~ Normal()
+            end
+            @model function outer()
+                return a ~ to_submodel(inner())
+            end
+            inner_cond = inner() | (@varname(x) => 1.0)
+            with_outer_cond = outer() | (@varname(a.x) => 1.0)
+
+            # No conditioning
+            @test Set(keys(VarInfo(outer()))) == Set([@varname(a.x), @varname(a.y)])
+            # Conditioning from the outside
+            @test Set(keys(VarInfo(with_outer_cond))) == Set([@varname(a.y)])
+            # Conditioning from the inside
+            @model function outer2()
+                return a ~ to_submodel(inner_cond)
+            end
+            with_inner_cond = outer2()
+            @test Set(keys(VarInfo(with_inner_cond))) == Set([@varname(a.y)])
+        end
+
+        @testset "No prefix" begin
+            @model function inner()
+                x ~ Normal()
+                return y ~ Normal()
+            end
+            @model function outer()
+                return a ~ to_submodel(inner(), false)
+            end
+            inner_cond = inner() | (@varname(x) => 1.0)
+            with_outer_cond = outer() | (@varname(x) => 1.0)
+
+            # No conditioning
+            @test Set(keys(VarInfo(outer()))) == Set([@varname(x), @varname(y)])
+            # Conditioning from the outside
+            @test Set(keys(VarInfo(with_outer_cond))) == Set([@varname(y)])
+            # Conditioning from the inside
+            @model function outer2()
+                return a ~ to_submodel(inner_cond, false)
+            end
+            with_inner_cond = outer2()
+            @test Set(keys(VarInfo(with_inner_cond))) == Set([@varname(y)])
+        end
+
+        @testset "Manual prefix" begin
+            @model function inner()
+                x ~ Normal()
+                return y ~ Normal()
+            end
+            @model function outer()
+                return a ~ to_submodel(prefix(inner(), :b), false)
+            end
+            inner_cond = inner() | (@varname(x) => 1.0)
+            with_outer_cond = outer() | (@varname(b.x) => 1.0)
+
+            # No conditioning
+            @test Set(keys(VarInfo(outer()))) == Set([@varname(b.x), @varname(b.y)])
+            # Conditioning from the outside
+            @test Set(keys(VarInfo(with_outer_cond))) == Set([@varname(b.y)])
+            # Conditioning from the inside
+            @model function outer2()
+                return a ~ to_submodel(prefix(inner_cond, :b), false)
+            end
+            with_inner_cond = outer2()
+            @test Set(keys(VarInfo(with_inner_cond))) == Set([@varname(b.y)])
+        end
+
+        @testset "Nested submodels" begin
+            @model function f()
+                x ~ Normal()
+                return y ~ Normal()
+            end
+            @model function g()
+                return _unused ~ to_submodel(prefix(f(), :b), false)
+            end
+            @model function h()
+                return a ~ to_submodel(g())
+            end
+
+            # No conditioning
+            @test Set(keys(VarInfo(h()))) == Set([@varname(a.b.x), @varname(a.b.y)])
+
+            # Conditioning at the top level
+            condition_h = h() | (@varname(a.b.x) => 1.0)
+            @test Set(keys(VarInfo(condition_h))) == Set([@varname(a.b.y)])
+
+            # Conditioning at the second level
+            condition_g = g() | (@varname(b.x) => 1.0)
+            @model function h2()
+                return a ~ to_submodel(condition_g)
+            end
+            @test Set(keys(VarInfo(h2()))) == Set([@varname(a.b.y)])
+
+            # Conditioning at the very bottom
+            condition_f = f() | (@varname(x) => 1.0)
+            @model function g2()
+                return _unused ~ to_submodel(prefix(condition_f, :b), false)
+            end
+            @model function h3()
+                return a ~ to_submodel(g2())
+            end
+            @test Set(keys(VarInfo(h3()))) == Set([@varname(a.b.y)])
+        end
+    end
+end
+
+end


### PR DESCRIPTION
## Summary

This PR closes #857, i.e., gives users sensible ways of conditioning and fixing variables in submodels. To aid in understanding this, it also adds a long piece of documentation ([**PREVIEW HERE**](https://turinglang.org/DynamicPPL.jl/previews/PR892/internals/submodel_condition/)) explaining the design.

## Performance

In the table below I compare the time taken for `_evaluate!!(model, ...)` on `breaking` (the base branch) and `py/submodel-cond` (HEAD of this PR). For good measure, the followup PR #896 is also benchmarked.

The model tested comprises `m` submodels, all of which contain `n` assumed variables. All times are in µs.

<details>
<summary>Profiling code (click to expand)</summary>

```julia
using DynamicPPL, Distributions, Chairmarks
using Plots

@model function inner(n)
    xs = Vector{Float64}(undef, n)
    for i in eachindex(xs)
        xs[i] ~ Normal(0, 1)
    end
end
@model function outer1(n)
    a ~ to_submodel(inner(n))
end
@model function outer10(n)
    a1 ~ to_submodel(inner(n))
    a2 ~ to_submodel(inner(n))
    a3 ~ to_submodel(inner(n))
    a4 ~ to_submodel(inner(n))
    a5 ~ to_submodel(inner(n))
    a6 ~ to_submodel(inner(n))
    a7 ~ to_submodel(inner(n))
    a8 ~ to_submodel(inner(n))
    a9 ~ to_submodel(inner(n))
    a10 ~ to_submodel(inner(n))
end
@model function outer20(n)
    a1 ~ to_submodel(inner(n))
    a2 ~ to_submodel(inner(n))
    a3 ~ to_submodel(inner(n))
    a4 ~ to_submodel(inner(n))
    a5 ~ to_submodel(inner(n))
    a6 ~ to_submodel(inner(n))
    a7 ~ to_submodel(inner(n))
    a8 ~ to_submodel(inner(n))
    a9 ~ to_submodel(inner(n))
    a10 ~ to_submodel(inner(n))
    a11 ~ to_submodel(inner(n))
    a12 ~ to_submodel(inner(n))
    a13 ~ to_submodel(inner(n))
    a14 ~ to_submodel(inner(n))
    a15 ~ to_submodel(inner(n))
    a16 ~ to_submodel(inner(n))
    a17 ~ to_submodel(inner(n))
    a18 ~ to_submodel(inner(n))
    a19 ~ to_submodel(inner(n))
    a20 ~ to_submodel(inner(n))
end

function profile(m, n)
    @info "Profiling with $m submodel(s) and $n inner model size"
    if m == 1
        model = outer1(n)
    elseif m == 10
        model = outer10(n)
    elseif m == 20
        model = outer20(n)
    else
        error("Invalid value for m")
    end
    v = VarInfo(model); c = DefaultContext();
    b = @be DynamicPPL._evaluate!!(model, v, c)
    @info "... got $(median(b).time)"
    return median(b).time
end
ms = [1, 10, 20]
ns = [1, 10, 25, 50, 100, 200]

# call profile(m, n) for m in ms for n in ns
```
</details>

```
         PR base      #892 - THIS PR    #896
m   n    breaking     py/submodel-cond  py/submodel-prefix
1   1    0.665634146  0.77410526        0.403409091
1   10   1.45625      1.60305263        1.16836
1   25   2.9          3.0375            2.549272727
1   50   4.9834       5.0418            4.645833333
1   100  9.416666667  9.43066667        9.3125
1   200  18.125       18.042            17.709
10  1    44.333       49                39.5
10  10   61.7085      65.458            54.625
10  25   85.875       92.771            81.458
10  50   136.458      140.812           129.042
10  100  235.708      232.6875          225.125
10  200  411.875      403.125           399.291
20  1    594.708      605.167           579.9585
20  10   650.9995     671.271           627.7915
20  25   734.417      759.937           708.375
20  50   866.292      876.521           839.708
20  100  1135.1665    1143.646          1110.6875
20  200  1702.291     1701.792          1644.166
```

## TODO

- [x] Check performance
  - [x] Understand why performance is improved
- [x] Apply the same fixes for `fix`
- [x] Check whether the behaviour of `decondition` and `unfix` is still sensible (it should be, but you never know...)
- [x] Document the approach taken in managing stacks of PrefixContext and (ConditionContext | FixedContext)
  - [x] Correct the blurb about tilde_assume (it's no longer accurate after this PR)
  - [x] Add a section on getting nested submodels right (i.e. PrefixContexts of PrefixContexts)
- [x] Add changelog entry
- [x] Add high-level tests for behaviour at the model level
  - [x] paying special attention to nested submodels, because that's what broke #815;
  - [x] also make sure to check manual prefixing and no prefixing;
  - [x] also make sure to check the old-style conditioning via model arguments (the code I modified should _not_ affect this because it doesn't touch the `inargnames` checks, only the `contextual_isassumption` checks; but probably good to test anyway)
  - [x] also make sure to test with non-identity-lens varnames on LHS of submodel tilde
- [x] Add unit tests for new functions