### PR TITLE
Implement missing tilde_assume method

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # DynamicPPL Changelog
 
+## 0.36.1
+
+Fixed a missing method for `tilde_assume`.
+
 ## 0.36.0
 
 **Breaking changes**

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.36.0"
+version = "0.36.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/context_implementations.jl
+++ b/src/context_implementations.jl
@@ -57,6 +57,7 @@ function tilde_assume(context::AbstractContext, args...)
     return tilde_assume(NodeTrait(tilde_assume, context), context, args...)
 end
 function tilde_assume(::IsLeaf, context::AbstractContext, right, vn, vi)
+    # no rng nor sampler
     return assume(right, vn, vi)
 end
 function tilde_assume(::IsParent, context::AbstractContext, args...)
@@ -69,11 +70,17 @@ end
 function tilde_assume(
     ::IsLeaf, rng::Random.AbstractRNG, context::AbstractContext, sampler, right, vn, vi
 )
+    # rng and sampler
     return assume(rng, sampler, right, vn, vi)
+end
+function tilde_assume(::IsLeaf, context::AbstractContext, sampler, right, vn, vi)
+    # sampler but no rng
+    return assume(Random.default_rng(), sampler, right, vn, vi)
 end
 function tilde_assume(
     ::IsParent, rng::Random.AbstractRNG, context::AbstractContext, args...
 )
+    # rng but no sampler
     return tilde_assume(rng, childcontext(context), args...)
 end
 


### PR DESCRIPTION
In Turing.jl v0.37, when a Gibbs sampler is used without specifying component samplers for all variables, the variables without samplers are sampled once at the beginning and don't ever move from there. See https://github.com/TuringLang/Turing.jl/issues/2536.

This patch is required to preserve that behaviour - without this patch it will throw a MethodError as it was trying to look for the newly added method. Specifically it was this line in Turing.jl that was calling the missing method https://github.com/TuringLang/Turing.jl/blob/fc32e10bc17ae3fda4d7e825b6fde45dc7bdb179/src/mcmc/gibbs.jl#L162-L168

Should hopefully be simple enough to approve -- though I'm very much not a fan of how the N optional arguments force us to define 2^N methods, and it may be worth thinking about how to deal with this in a better way long-term. See also #720.