### PR TITLE
Add `show_context_stack(::AbstractContext)`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # DynamicPPL Changelog
 
+## 0.36.12
+
+Added an unexported method, `DynamicPPL.show_context_stack`, for minimalistic printing of context stacks (which is useful when debugging e.g. submodels).
+
 ## 0.36.11
 
 Make `ThreadSafeVarInfo` hold a total of `Threads.nthreads() * 2` logp values, instead of just `Threads.nthreads()`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.36.11"
+version = "0.36.12"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -817,3 +817,17 @@ function prefix_cond_and_fixed_variables(
         context, prefix_cond_and_fixed_variables(childcontext(context), prefix)
     )
 end
+
+_pretty(ctx::AbstractContext) = split(string(ctx), "Context")[1]
+"""
+    show_stack(ctx::AbstractContext)
+
+Return a minimalistic string representation of the context stack `ctx`. Useful
+for debugging complicated context problems, e.g. with submodels.
+
+For example, `SamplingContext(ConditionContext(..., DefaultContext())` will
+print as `Sampling->Condition->Default`.
+"""
+show_stack(ctx::AbstractContext) = show_stack(NodeTrait(ctx), ctx)
+show_stack(::IsLeaf, ctx) = _pretty(ctx)
+show_stack(::IsParent, ctx) = _pretty(ctx) * "->" * show_stack(childcontext(ctx))


### PR DESCRIPTION
The docstring says it all. Basically this is a method I've been wanting for ages and I finally decided to implement it after realising that `GibbsContext` contains a complete VarInfo inside it and it's impossible to parse the output of `@show context`. Obviously I could just run this myself every time I needed it, but I thought it might be useful enough to be added to DynamicPPL itself, hence the PR.

Not even sure if this warrants a patch bump + release, opinions are welcome.