### PR TITLE
DocsGHA: Grant write permission to pull-requests event

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -17,7 +17,7 @@ concurrency:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   docs:


### PR DESCRIPTION
To enable the Documenter.jl preview comment URL in PRs, write permissions are required for the `pull_request` event in GHA. This change grants the necessary permissions. See related PR for the comment feature: https://github.com/TuringLang/actions/pull/19.