### PR TITLE
Add fields to docstring for AD test utils

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.36.1"
+version = "0.36.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/test_utils/ad.jl
+++ b/src/test_utils/ad.jl
@@ -26,6 +26,9 @@ const REFERENCE_ADTYPE = AutoForwardDiff()
 Exception thrown when an AD backend returns an incorrect value or gradient.
 
 The type parameter `T` is the numeric type of the value and gradient.
+
+# Fields
+$(TYPEDFIELDS)
 """
 struct ADIncorrectException{T<:AbstractFloat} <: Exception
     value_expected::T
@@ -41,6 +44,9 @@ Data structure to store the results of the AD correctness test.
 
 The type parameter `Tparams` is the numeric type of the parameters passed in;
 `Tresult` is the type of the value and the gradient.
+
+# Fields
+$(TYPEDFIELDS)
 """
 struct ADResult{Tparams<:AbstractFloat,Tresult<:AbstractFloat}
     "The DynamicPPL model that was tested"


### PR DESCRIPTION
The docstrings don't list the fields of the return types. This fixes it.

Needs a patch bump so that the 'stable' version of the docs has this info.