### PR TITLE
Fix `varinfo[:]` for empty varinfo

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 
 `varinfo[:]` now returns an empty vector if `varinfo::DynamicPPL.NTVarInfo` is empty, rather than erroring.
 
+In its place, `check_model` now issues a warning if the model is empty.
+
 ## 0.36.4
 
 Added compatibility with DifferentiationInterface.jl 0.7, and also with JET.jl 0.10.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # DynamicPPL Changelog
 
+## 0.36.5
+
+`varinfo[:]` now returns an empty vector if `varinfo::DynamicPPL.NTVarInfo` is empty, rather than erroring.
+
 ## 0.36.4
 
 Added compatibility with DifferentiationInterface.jl 0.7, and also with JET.jl 0.10.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.36.4"
+version = "0.36.5"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/debug_utils.jl
+++ b/src/debug_utils.jl
@@ -338,6 +338,11 @@ function conditioned_varnames(context)
 end
 
 function check_varnames_seen(varnames_seen::AbstractDict{VarName,Int})
+    if isempty(varnames_seen)
+        @warn "The model does not contain any parameters."
+        return true
+    end
+
     issuccess = true
     for (varname, count) in varnames_seen
         if count == 0

--- a/src/debug_utils.jl
+++ b/src/debug_utils.jl
@@ -421,6 +421,8 @@ julia> print(trace)
  assume: x ~ Normal{Float64}(μ=0.0, σ=1.0) ⟼ -0.670252 (logprob = -1.14356)
 
 julia> issuccess, trace = check_model_and_trace(rng, demo_correct() | (x = 1.0,));
+┌ Warning: The model does not contain any parameters.
+└ @ DynamicPPL.DebugUtils DynamicPPL.jl/src/debug_utils.jl:342
 
 julia> issuccess
 true

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -854,6 +854,9 @@ getindex_internal(vi::VarInfo, ::Colon) = getindex_internal(vi.metadata, Colon()
 function getindex_internal(vi::NTVarInfo, ::Colon)
     return reduce(vcat, map(Base.Fix2(getindex_internal, Colon()), vi.metadata))
 end
+function getindex_internal(vi::VarInfo{NamedTuple{(),Tuple{}}}, ::Colon)
+    return float(Real)[]
+end
 function getindex_internal(md::Metadata, ::Colon)
     return mapreduce(
         Base.Fix1(getindex_internal, md), vcat, md.vns; init=similar(md.vals, 0)

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -115,9 +115,8 @@ end
             @test ~isempty(vi)
         end
 
-        vi = VarInfo()
-        test_base(vi)
-        test_base(DynamicPPL.typed_varinfo(vi))
+        test_base(VarInfo())
+        test_base(DynamicPPL.typed_varinfo(VarInfo()))
         test_base(SimpleVarInfo())
         test_base(SimpleVarInfo(Dict()))
         test_base(SimpleVarInfo(DynamicPPL.VarNamedVector()))

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -79,7 +79,7 @@ end
         @test hash(vn2) == hash(vn1)
 
         function test_base(vi_original)
-            vi = empty!!(deepcopy(vi_original))
+            vi = deepcopy(vi_original)
             @test getlogp(vi) == 0
             @test isempty(vi[:])
 

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -79,7 +79,7 @@ end
         @test hash(vn2) == hash(vn1)
 
         function test_base!!(vi_original)
-            vi = empty!!(vi_original)
+            vi = empty!!(deepcopy(vi_original))
             @test getlogp(vi) == 0
             @test isempty(vi[:])
 
@@ -97,8 +97,10 @@ end
 
             @test length(vi[vn]) == 1
             @test vi[vn] == r
+            @test vi[:] == [r]
             vi = DynamicPPL.setindex!!(vi, 2 * r, vn)
             @test vi[vn] == 2 * r
+            @test vi[:] == [2 * r]
 
             # TODO(mhauru) Implement these functions for other VarInfo types too.
             if vi isa DynamicPPL.UntypedVectorVarInfo

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -78,7 +78,7 @@ end
         @test vn2 == vn1
         @test hash(vn2) == hash(vn1)
 
-        function test_base!!(vi_original)
+        function test_base(vi_original)
             vi = empty!!(deepcopy(vi_original))
             @test getlogp(vi) == 0
             @test isempty(vi[:])
@@ -116,11 +116,11 @@ end
         end
 
         vi = VarInfo()
-        test_base!!(vi)
-        test_base!!(DynamicPPL.typed_varinfo(vi))
-        test_base!!(SimpleVarInfo())
-        test_base!!(SimpleVarInfo(Dict()))
-        test_base!!(SimpleVarInfo(DynamicPPL.VarNamedVector()))
+        test_base(vi)
+        test_base(DynamicPPL.typed_varinfo(vi))
+        test_base(SimpleVarInfo())
+        test_base(SimpleVarInfo(Dict()))
+        test_base(SimpleVarInfo(DynamicPPL.VarNamedVector()))
     end
 
     @testset "get/set/acc/resetlogp" begin


### PR DESCRIPTION
Closes #918 (at least on the DPPL side; there are more things to fix on the Turing side).

```julia
using DynamicPPL, Distributions

@model e(x) = x ~ Normal()

vi = VarInfo(e(1.0))
vi[:]
```

Before this PR, this would error. After this PR, it returns an empty vector.

Interestingly, I think the tests were meant have caught this, but they didn't because varinfos were being mutated (see comment below).