### PR TITLE
Remove `context` from model evaluation (use `model.context` instead)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -35,8 +35,9 @@ To aid with this process, `contextualize` is now exported from DynamicPPL.
 
 The main situation where one _did_ want to specify an additional evaluation context was when that context was a `SamplingContext`.
 Doing this would allow you to run the model and sample fresh values, instead of just using the values that existed in the VarInfo object.
-Thus, this release also introduces the unexported function `sample!!`.
-Essentially, `sample!!(rng, model, varinfo, sampler)` is a drop-in replacement for `evaluate!!(model, varinfo, SamplingContext(rng, sampler))`.
+Thus, this release also introduces the **unexported** function `evaluate_and_sample!!`.
+Essentially, `evaluate_and_sample!!(rng, model, varinfo, sampler)` is a drop-in replacement for `evaluate!!(model, varinfo, SamplingContext(rng, sampler))`.
+**Do note that this is an internal method**, and its name or semantics are liable to change in the future without warning.
 
 There are many methods that no longer take a context argument, and listing them all would be too much.
 However, here are the more user-facing ones:
@@ -50,7 +51,7 @@ However, here are the more user-facing ones:
 And a couple of more internal changes:
 
   - `evaluate!!`, `evaluate_threadsafe!!`, and `evaluate_threadunsafe!!` no longer accept context arguments
-  - `evaluate!!` no longer takes rng and sampler (if you used this, you should use `sample!!` instead, or construct your own `SamplingContext`)
+  - `evaluate!!` no longer takes rng and sampler (if you used this, you should use `evaluate_and_sample!!` instead, or construct your own `SamplingContext`)
   - The model evaluation function, `model.f` for some `model::Model`, no longer takes a context as an argument
 
 ## 0.36.12

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,6 +18,41 @@ This release overhauls how VarInfo objects track variables such as the log joint
   - `getlogp` now returns a `NamedTuple` with keys `logprior` and `loglikelihood`. If you want the log joint probability, which is what `getlogp` used to return, use `getlogjoint`.
   - Correspondingly `setlogp!!` and `acclogp!!` should now be called with a `NamedTuple` with keys `logprior` and `loglikelihood`. The `acclogp!!` method with a single scalar value has been deprecated and falls back on `accloglikelihood!!`, and the single scalar version of `setlogp!!` has been removed. Corresponding setter/accumulator functions exist for the log prior as well.
 
+### Evaluation contexts
+
+Historically, evaluating a DynamicPPL model has required three arguments: a model, some kind of VarInfo, and a context.
+It's less known, though, that since DynamicPPL 0.14.0 the _model_ itself actually contains a context as well.
+This version therefore excises the context argument, and instead uses `model.context` as the evaluation context.
+
+The upshot of this is that many functions that previously took a context argument now no longer do.
+There were very few such functions where the context argument was actually used (most of them simply took `DefaultContext()` as the default value).
+
+`evaluate!!(model, varinfo, ext_context)` is deprecated, and broadly speaking you should replace calls to that with `new_model = contextualize(model, ext_context); evaluate!!(new_model, varinfo)`.
+If the 'external context' `ext_context` is a parent context, then you should wrap `model.context` appropriately to ensure that its information content is not lost.
+If, on the other hand, `ext_context` is a `DefaultContext`, then you can just drop the argument entirely.
+
+To aid with this process, `contextualize` is now exported from DynamicPPL.
+
+The main situation where one _did_ want to specify an additional evaluation context was when that context was a `SamplingContext`.
+Doing this would allow you to run the model and sample fresh values, instead of just using the values that existed in the VarInfo object.
+Thus, this release also introduces the unexported function `sample!!`.
+Essentially, `sample!!(rng, model, varinfo, sampler)` is a drop-in replacement for `evaluate!!(model, varinfo, SamplingContext(rng, sampler))`.
+
+There are many methods that no longer take a context argument, and listing them all would be too much.
+However, here are the more user-facing ones:
+
+  - `LogDensityFunction` no longer has a context field (or type parameter)
+  - `DynamicPPL.TestUtils.AD.run_ad` no longer uses a context (and the returned `ADResult` object no longer has a context field)
+  - `VarInfo(rng, model, sampler)` and other VarInfo constructors / functions that made VarInfos (e.g. `typed_varinfo`) from a model
+  - `(::Model)(args...)`: specifically, this now only takes `rng` and `varinfo` arguments (with both being optional)
+  - If you are using the `__context__` special variable inside a model, you will now have to use `__model__.context` instead
+
+And a couple of more internal changes:
+
+  - `evaluate!!`, `evaluate_threadsafe!!`, and `evaluate_threadunsafe!!` no longer accept context arguments
+  - `evaluate!!` no longer takes rng and sampler (if you used this, you should use `sample!!` instead, or construct your own `SamplingContext`)
+  - The model evaluation function, `model.f` for some `model::Model`, no longer takes a context as an argument
+
 ## 0.36.12
 
 Removed several unexported functions.

--- a/benchmarks/src/DynamicPPLBenchmarks.jl
+++ b/benchmarks/src/DynamicPPLBenchmarks.jl
@@ -81,13 +81,12 @@ function make_suite(model, varinfo_choice::Symbol, adbackend::Symbol, islinked::
     end
 
     adbackend = to_backend(adbackend)
-    context = DynamicPPL.DefaultContext()
 
     if islinked
         vi = DynamicPPL.link(vi, model)
     end
 
-    f = DynamicPPL.LogDensityFunction(model, vi, context; adtype=adbackend)
+    f = DynamicPPL.LogDensityFunction(model, vi; adtype=adbackend)
     # The parameters at which we evaluate f.
     θ = vi[:]
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -455,7 +455,7 @@ By default, it does not perform any actual sampling: it only evaluates the model
 To perform sampling, you can either wrap `model.context` in a `SamplingContext`, or use this convenience method:
 
 ```@docs
-DynamicPPL.sample!!
+DynamicPPL.evaluate_and_sample!!
 ```
 
 The behaviour of a model execution can be changed with evaluation contexts, which are a field of the model.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -36,6 +36,12 @@ getargnames
 getmissings
 ```
 
+The context of a model can be set using [`contextualize`](@ref):
+
+```@docs
+contextualize
+```
+
 ## Evaluation
 
 With [`rand`](@ref) one can draw samples from the prior distribution of a [`Model`](@ref).
@@ -438,13 +444,21 @@ DynamicPPL.varname_and_value_leaves
 
 ### Evaluation Contexts
 
-Internally, both sampling and evaluation of log densities are performed with [`AbstractPPL.evaluate!!`](@ref).
+Internally, model evaluation is performed with [`AbstractPPL.evaluate!!`](@ref).
 
 ```@docs
 AbstractPPL.evaluate!!
 ```
 
-The behaviour of a model execution can be changed with evaluation contexts that are passed as additional argument to the model function.
+This method mutates the `varinfo` used for execution.
+By default, it does not perform any actual sampling: it only evaluates the model using the values of the variables that are already in the `varinfo`.
+To perform sampling, you can either wrap `model.context` in a `SamplingContext`, or use this convenience method:
+
+```@docs
+DynamicPPL.sample!!
+```
+
+The behaviour of a model execution can be changed with evaluation contexts, which are a field of the model.
 Contexts are subtypes of `AbstractPPL.AbstractContext`.
 
 ```@docs

--- a/ext/DynamicPPLForwardDiffExt.jl
+++ b/ext/DynamicPPLForwardDiffExt.jl
@@ -11,7 +11,6 @@ function DynamicPPL.tweak_adtype(
     ad::ADTypes.AutoForwardDiff{chunk_size},
     ::DynamicPPL.Model,
     vi::DynamicPPL.AbstractVarInfo,
-    ::DynamicPPL.AbstractContext,
 ) where {chunk_size}
     params = vi[:]
 

--- a/ext/DynamicPPLJETExt.jl
+++ b/ext/DynamicPPLJETExt.jl
@@ -4,15 +4,10 @@ using DynamicPPL: DynamicPPL
 using JET: JET
 
 function DynamicPPL.Experimental.is_suitable_varinfo(
-    model::DynamicPPL.Model,
-    context::DynamicPPL.AbstractContext,
-    varinfo::DynamicPPL.AbstractVarInfo;
-    only_ddpl::Bool=true,
+    model::DynamicPPL.Model, varinfo::DynamicPPL.AbstractVarInfo; only_ddpl::Bool=true
 )
     # Let's make sure that both evaluation and sampling doesn't result in type errors.
-    f, argtypes = DynamicPPL.DebugUtils.gen_evaluator_call_with_types(
-        model, varinfo, context
-    )
+    f, argtypes = DynamicPPL.DebugUtils.gen_evaluator_call_with_types(model, varinfo)
     # If specified, we only check errors originating somewhere in the DynamicPPL.jl.
     # This way we don't just fall back to untyped if the user's code is the issue.
     result = if only_ddpl
@@ -24,14 +19,19 @@ function DynamicPPL.Experimental.is_suitable_varinfo(
 end
 
 function DynamicPPL.Experimental._determine_varinfo_jet(
-    model::DynamicPPL.Model, context::DynamicPPL.AbstractContext; only_ddpl::Bool=true
+    model::DynamicPPL.Model; only_ddpl::Bool=true
 )
+    # Use SamplingContext to test type stability.
+    sampling_model = DynamicPPL.contextualize(
+        model, DynamicPPL.SamplingContext(model.context)
+    )
+
     # First we try with the typed varinfo.
-    varinfo = DynamicPPL.typed_varinfo(model, context)
+    varinfo = DynamicPPL.typed_varinfo(sampling_model)
 
     # Let's make sure that both evaluation and sampling doesn't result in type errors.
     issuccess, result = DynamicPPL.Experimental.is_suitable_varinfo(
-        model, context, varinfo; only_ddpl
+        sampling_model, varinfo; only_ddpl
     )
 
     if !issuccess
@@ -46,7 +46,7 @@ function DynamicPPL.Experimental._determine_varinfo_jet(
     else
         # Warn the user that we can't use the type stable one.
         @warn "Model seems incompatible with typed varinfo. Falling back to untyped varinfo."
-        DynamicPPL.untyped_varinfo(model, context)
+        DynamicPPL.untyped_varinfo(sampling_model)
     end
 end
 

--- a/ext/DynamicPPLMCMCChainsExt.jl
+++ b/ext/DynamicPPLMCMCChainsExt.jl
@@ -115,7 +115,7 @@ function DynamicPPL.predict(
     iters = Iterators.product(1:size(chain, 1), 1:size(chain, 3))
     predictive_samples = map(iters) do (sample_idx, chain_idx)
         DynamicPPL.setval_and_resample!(varinfo, parameter_only_chain, sample_idx, chain_idx)
-        varinfo = last(DynamicPPL.sample!!(rng, model, varinfo))
+        varinfo = last(DynamicPPL.evaluate_and_sample!!(rng, model, varinfo))
 
         vals = DynamicPPL.values_as_in_model(model, false, varinfo)
         varname_vals = mapreduce(

--- a/ext/DynamicPPLMCMCChainsExt.jl
+++ b/ext/DynamicPPLMCMCChainsExt.jl
@@ -115,7 +115,7 @@ function DynamicPPL.predict(
     iters = Iterators.product(1:size(chain, 1), 1:size(chain, 3))
     predictive_samples = map(iters) do (sample_idx, chain_idx)
         DynamicPPL.setval_and_resample!(varinfo, parameter_only_chain, sample_idx, chain_idx)
-        model(rng, varinfo, DynamicPPL.SampleFromPrior())
+        varinfo = last(DynamicPPL.sample!!(rng, model, varinfo))
 
         vals = DynamicPPL.values_as_in_model(model, false, varinfo)
         varname_vals = mapreduce(

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -102,6 +102,7 @@ export AbstractVarInfo,
     # LogDensityFunction
     LogDensityFunction,
     # Contexts
+    contextualize,
     SamplingContext,
     DefaultContext,
     PrefixContext,

--- a/src/experimental.jl
+++ b/src/experimental.jl
@@ -4,16 +4,15 @@ using DynamicPPL: DynamicPPL
 
 # This file only defines the names of the functions, and their docstrings. The actual implementations are in `ext/DynamicPPLJETExt.jl`, since we don't want to depend on JET.jl other than as a weak dependency.
 """
-    is_suitable_varinfo(model::Model, context::AbstractContext, varinfo::AbstractVarInfo; kwargs...)
+    is_suitable_varinfo(model::Model, varinfo::AbstractVarInfo; kwargs...)
 
-Check if the `model` supports evaluation using the provided `context` and `varinfo`.
+Check if the `model` supports evaluation using the provided `varinfo`.
 
 !!! warning
     Loading JET.jl is required before calling this function.
 
 # Arguments
 - `model`: The model to verify the support for.
-- `context`: The context to use for the model evaluation.
 - `varinfo`: The varinfo to verify the support for.
 
 # Keyword Arguments
@@ -29,7 +28,7 @@ function is_suitable_varinfo end
 function _determine_varinfo_jet end
 
 """
-    determine_suitable_varinfo(model[, context]; only_ddpl::Bool=true)
+    determine_suitable_varinfo(model; only_ddpl::Bool=true)
 
 Return a suitable varinfo for the given `model`.
 
@@ -41,7 +40,6 @@ See also: [`DynamicPPL.Experimental.is_suitable_varinfo`](@ref).
 
 # Arguments
 - `model`: The model for which to determine the varinfo.
-- `context`: The context to use for the model evaluation. Default: `SamplingContext()`.
 
 # Keyword Arguments
 - `only_ddpl`: If `true`, only consider error reports within DynamicPPL.jl.
@@ -85,14 +83,10 @@ julia> vi isa typeof(DynamicPPL.typed_varinfo(model_with_static_support()))
 true
 ```
 """
-function determine_suitable_varinfo(
-    model::DynamicPPL.Model,
-    context::DynamicPPL.AbstractContext=DynamicPPL.SamplingContext();
-    only_ddpl::Bool=true,
-)
+function determine_suitable_varinfo(model::DynamicPPL.Model; only_ddpl::Bool=true)
     # If JET.jl has been loaded, and thus `determine_varinfo` has been defined, we use that.
     return if Base.get_extension(DynamicPPL, :DynamicPPLJETExt) !== nothing
-        _determine_varinfo_jet(model, context; only_ddpl)
+        _determine_varinfo_jet(model; only_ddpl)
     else
         # Warn the user.
         @warn "JET.jl is not loaded. Assumes the model is compatible with typed varinfo."

--- a/src/extract_priors.jl
+++ b/src/extract_priors.jl
@@ -116,7 +116,7 @@ function extract_priors(rng::Random.AbstractRNG, model::Model)
     # workaround for the fact that `order` is still hardcoded in VarInfo, and hence you
     # can't push new variables without knowing the num_produce. Remove this when possible.
     varinfo = setaccs!!(varinfo, (PriorDistributionAccumulator(), NumProduceAccumulator()))
-    varinfo = last(sample!!(rng, model, varinfo))
+    varinfo = last(evaluate_and_sample!!(rng, model, varinfo))
     return getacc(varinfo, Val(:PriorDistributionAccumulator)).priors
 end
 

--- a/src/extract_priors.jl
+++ b/src/extract_priors.jl
@@ -116,8 +116,7 @@ function extract_priors(rng::Random.AbstractRNG, model::Model)
     # workaround for the fact that `order` is still hardcoded in VarInfo, and hence you
     # can't push new variables without knowing the num_produce. Remove this when possible.
     varinfo = setaccs!!(varinfo, (PriorDistributionAccumulator(), NumProduceAccumulator()))
-    new_model = contextualize(model, SamplingContext(rng, model.context))
-    varinfo = last(evaluate!!(new_model, varinfo))
+    varinfo = last(sample!!(rng, model, varinfo))
     return getacc(varinfo, Val(:PriorDistributionAccumulator)).priors
 end
 

--- a/src/extract_priors.jl
+++ b/src/extract_priors.jl
@@ -116,7 +116,8 @@ function extract_priors(rng::Random.AbstractRNG, model::Model)
     # workaround for the fact that `order` is still hardcoded in VarInfo, and hence you
     # can't push new variables without knowing the num_produce. Remove this when possible.
     varinfo = setaccs!!(varinfo, (PriorDistributionAccumulator(), NumProduceAccumulator()))
-    varinfo = last(evaluate!!(model, varinfo, SamplingContext(rng)))
+    new_model = contextualize(model, SamplingContext(rng, model.context))
+    varinfo = last(evaluate!!(new_model, varinfo))
     return getacc(varinfo, Val(:PriorDistributionAccumulator)).priors
 end
 
@@ -135,6 +136,6 @@ function extract_priors(model::Model, varinfo::AbstractVarInfo)
     varinfo = setaccs!!(
         deepcopy(varinfo), (PriorDistributionAccumulator(), NumProduceAccumulator())
     )
-    varinfo = last(evaluate!!(model, varinfo, DefaultContext()))
+    varinfo = last(evaluate!!(model, varinfo))
     return getacc(varinfo, Val(:PriorDistributionAccumulator)).priors
 end

--- a/src/logdensityfunction.jl
+++ b/src/logdensityfunction.jl
@@ -28,9 +28,9 @@ A struct which contains a model, along with all the information necessary to:
  - and if `adtype` is provided, calculate the gradient of the log density at
  that point.
 
-At its most basic level, a LogDensityFunction wraps the model together with its
-the type of varinfo to be used. These must be known in order to calculate the
-log density (using [`DynamicPPL.evaluate!!`](@ref)).
+At its most basic level, a LogDensityFunction wraps the model together with the
+type of varinfo to be used. These must be known in order to calculate the log
+density (using [`DynamicPPL.evaluate!!`](@ref)).
 
 If the `adtype` keyword argument is provided, then this struct will also store
 the adtype along with other information for efficient calculation of the
@@ -139,7 +139,7 @@ end
         adtype::Union{Nothing,ADTypes.AbstractADType}
     )
 
-Create a new LogDensityFunction using the model, and varinfo from the given
+Create a new LogDensityFunction using the model and varinfo from the given
 `ldf` argument, but with the AD type set to `adtype`. To remove the AD type,
 pass `nothing` as the second argument.
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -856,17 +856,20 @@ end
 
 """
     evaluate!!(model::Model, varinfo)
-    evaluate!!(model::Model, varinfo, context)
 
-Evaluate the `model` with the given `varinfo`. If an extra context stack is
-provided, the model's context is inserted into that context stack. See
-`combine_model_and_external_contexts`.
+Evaluate the `model` with the given `varinfo`.
 
 If multiple threads are available, the varinfo provided will be wrapped in a
 `ThreadSafeVarInfo` before evaluation.
 
 Returns a tuple of the model's return value, plus the updated `varinfo`
 (unwrapped if necessary).
+
+    evaluate!!(model::Model, varinfo, context)
+
+When an extra context stack is provided, the model's context is inserted into
+that context stack. See `combine_model_and_external_contexts`. This method is
+deprecated.
 """
 function AbstractPPL.evaluate!!(model::Model, varinfo::AbstractVarInfo)
     return if use_threadsafe_eval(model.context, varinfo)
@@ -924,13 +927,16 @@ end
 
 """
     _evaluate!!(model::Model, varinfo)
-    _evaluate!!(model::Model, varinfo, context)
 
-Evaluate the `model` with the given `varinfo`. If an additional `context` is provided,
-the model's context is combined with that context.
+Evaluate the `model` with the given `varinfo`.
 
 This function does not wrap the varinfo in a `ThreadSafeVarInfo`. It also does not
 reset the log probability of the `varinfo` before running.
+
+    _evaluate!!(model::Model, varinfo, context)
+
+If an additional `context` is provided, the model's context is combined with
+that context before evaluation.
 """
 function _evaluate!!(model::Model, varinfo::AbstractVarInfo)
     args, kwargs = make_evaluate_args_and_kwargs(model, varinfo)
@@ -975,7 +981,7 @@ function combine_model_and_external_contexts(
 end
 
 """
-    make_evaluate_args_and_kwargs(model, varinfo, context)
+    make_evaluate_args_and_kwargs(model, varinfo)
 
 Return the arguments and keyword arguments to be passed to the evaluator of the model, i.e. `model.f`e.
 """

--- a/src/model.jl
+++ b/src/model.jl
@@ -815,7 +815,7 @@ end
 # ^ Weird Documenter.jl bug means that we have to write the two above separately
 # as it can only detect the `function`-less syntax.
 function (model::Model)(rng::Random.AbstractRNG, varinfo::AbstractVarInfo=VarInfo())
-    return first(sample!!(rng, model, varinfo))
+    return first(evaluate_and_sample!!(rng, model, varinfo))
 end
 
 """
@@ -829,7 +829,7 @@ function use_threadsafe_eval(context::AbstractContext, varinfo::AbstractVarInfo)
 end
 
 """
-    sample!!([rng::Random.AbstractRNG, ]model::Model, varinfo[, sampler])
+    evaluate_and_sample!!([rng::Random.AbstractRNG, ]model::Model, varinfo[, sampler])
 
 Evaluate the `model` with the given `varinfo`, but perform sampling during the
 evaluation using the given `sampler` by wrapping the model's context in a
@@ -839,7 +839,7 @@ If `sampler` is not provided, defaults to [`SampleFromPrior`](@ref).
 
 Returns a tuple of the model's return value, plus the updated `varinfo` object.
 """
-function sample!!(
+function evaluate_and_sample!!(
     rng::Random.AbstractRNG,
     model::Model,
     varinfo::AbstractVarInfo,
@@ -848,10 +848,10 @@ function sample!!(
     sampling_model = contextualize(model, SamplingContext(rng, sampler, model.context))
     return evaluate!!(sampling_model, varinfo)
 end
-function sample!!(
+function evaluate_and_sample!!(
     model::Model, varinfo::AbstractVarInfo, sampler::AbstractSampler=SampleFromPrior()
 )
-    return sample!!(Random.default_rng(), model, varinfo, sampler)
+    return evaluate_and_sample!!(Random.default_rng(), model, varinfo, sampler)
 end
 
 """
@@ -1038,7 +1038,7 @@ Base.nameof(model::Model{<:Function}) = nameof(model.f)
 Generate a sample of type `T` from the prior distribution of the `model`.
 """
 function Base.rand(rng::Random.AbstractRNG, ::Type{T}, model::Model) where {T}
-    x = last(sample!!(rng, model, SimpleVarInfo{Float64}(OrderedDict())))
+    x = last(evaluate_and_sample!!(rng, model, SimpleVarInfo{Float64}(OrderedDict())))
     return values_as(x, T)
 end
 

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -58,7 +58,7 @@ function AbstractMCMC.step(
     kwargs...,
 )
     vi = VarInfo()
-    DynamicPPL.sample!!(rng, model, vi, sampler)
+    DynamicPPL.evaluate_and_sample!!(rng, model, vi, sampler)
     return vi, nothing
 end
 

--- a/src/sampler.jl
+++ b/src/sampler.jl
@@ -58,12 +58,12 @@ function AbstractMCMC.step(
     kwargs...,
 )
     vi = VarInfo()
-    model(rng, vi, sampler)
+    DynamicPPL.sample!!(rng, model, vi, sampler)
     return vi, nothing
 end
 
 """
-    default_varinfo(rng, model, sampler[, context])
+    default_varinfo(rng, model, sampler)
 
 Return a default varinfo object for the given `model` and `sampler`.
 
@@ -71,22 +71,13 @@ Return a default varinfo object for the given `model` and `sampler`.
 - `rng::Random.AbstractRNG`: Random number generator.
 - `model::Model`: Model for which we want to create a varinfo object.
 - `sampler::AbstractSampler`: Sampler which will make use of the varinfo object.
-- `context::AbstractContext`: Context in which the model is evaluated.
 
 # Returns
 - `AbstractVarInfo`: Default varinfo object for the given `model` and `sampler`.
 """
 function default_varinfo(rng::Random.AbstractRNG, model::Model, sampler::AbstractSampler)
-    return default_varinfo(rng, model, sampler, DefaultContext())
-end
-function default_varinfo(
-    rng::Random.AbstractRNG,
-    model::Model,
-    sampler::AbstractSampler,
-    context::AbstractContext,
-)
     init_sampler = initialsampler(sampler)
-    return typed_varinfo(rng, model, init_sampler, context)
+    return typed_varinfo(rng, model, init_sampler)
 end
 
 function AbstractMCMC.sample(
@@ -119,7 +110,7 @@ function AbstractMCMC.step(
         # This is a quick fix for https://github.com/TuringLang/Turing.jl/issues/1588
         # and https://github.com/TuringLang/Turing.jl/issues/1563
         # to avoid that existing variables are resampled
-        vi = last(evaluate!!(model, vi, DefaultContext()))
+        vi = last(evaluate!!(model, vi))
     end
 
     return initialstep(rng, model, spl, vi; initial_params, kwargs...)

--- a/src/test_utils/ad.jl
+++ b/src/test_utils/ad.jl
@@ -60,8 +60,6 @@ struct ADResult{Tparams<:AbstractFloat,Tresult<:AbstractFloat}
     model::Model
     "The VarInfo that was used"
     varinfo::AbstractVarInfo
-    "The evaluation context that was used"
-    context::AbstractContext
     "The values at which the model was evaluated"
     params::Vector{Tparams}
     "The AD backend that was tested"
@@ -92,7 +90,6 @@ end
         grad_atol=1e-6,
         varinfo::AbstractVarInfo=link(VarInfo(model), model),
         params::Union{Nothing,Vector{<:AbstractFloat}}=nothing,
-        context::AbstractContext=DefaultContext(),
         reference_adtype::ADTypes.AbstractADType=REFERENCE_ADTYPE,
         expected_value_and_grad::Union{Nothing,Tuple{AbstractFloat,Vector{<:AbstractFloat}}}=nothing,
         verbose=true,
@@ -146,13 +143,7 @@ Everything else is optional, and can be categorised into several groups:
    prep_params)`. You could then evaluate the gradient at a different set of
    parameters using the `params` keyword argument.
 
-3. _How to specify the evaluation context._
-
-   A `DynamicPPL.AbstractContext` can be passed as the `context` keyword
-   argument to control the evaluation context. This defaults to
-   `DefaultContext()`.
-
-4. _How to specify the results to compare against._ (Only if `test=true`.)
+3. _How to specify the results to compare against._ (Only if `test=true`.)
 
    Once logp and its gradient has been calculated with the specified `adtype`,
    it must be tested for correctness.
@@ -167,12 +158,12 @@ Everything else is optional, and can be categorised into several groups:
    The default reference backend is ForwardDiff. If none of these parameters are
    specified, ForwardDiff will be used to calculate the ground truth.
 
-5. _How to specify the tolerances._ (Only if `test=true`.)
+4. _How to specify the tolerances._ (Only if `test=true`.)
 
    The tolerances for the value and gradient can be set using `value_atol` and
    `grad_atol`. These default to 1e-6.
 
-6. _Whether to output extra logging information._
+5. _Whether to output extra logging information._
 
    By default, this function prints messages when it runs. To silence it, set
    `verbose=false`.
@@ -195,7 +186,6 @@ function run_ad(
     grad_atol::AbstractFloat=1e-6,
     varinfo::AbstractVarInfo=link(VarInfo(model), model),
     params::Union{Nothing,Vector{<:AbstractFloat}}=nothing,
-    context::AbstractContext=DefaultContext(),
     reference_adtype::AbstractADType=REFERENCE_ADTYPE,
     expected_value_and_grad::Union{Nothing,Tuple{AbstractFloat,Vector{<:AbstractFloat}}}=nothing,
     verbose=true,
@@ -207,7 +197,7 @@ function run_ad(
 
     verbose && @info "Running AD on $(model.f) with $(adtype)\n"
     verbose && println("       params : $(params)")
-    ldf = LogDensityFunction(model, varinfo, context; adtype=adtype)
+    ldf = LogDensityFunction(model, varinfo; adtype=adtype)
 
     value, grad = logdensity_and_gradient(ldf, params)
     grad = collect(grad)
@@ -216,7 +206,7 @@ function run_ad(
     if test
         # Calculate ground truth to compare against
         value_true, grad_true = if expected_value_and_grad === nothing
-            ldf_reference = LogDensityFunction(model, varinfo, context; adtype=reference_adtype)
+            ldf_reference = LogDensityFunction(model, varinfo; adtype=reference_adtype)
             logdensity_and_gradient(ldf_reference, params)
         else
             expected_value_and_grad
@@ -245,7 +235,6 @@ function run_ad(
     return ADResult(
         model,
         varinfo,
-        context,
         params,
         adtype,
         value_atol,

--- a/src/test_utils/model_interface.jl
+++ b/src/test_utils/model_interface.jl
@@ -92,7 +92,9 @@ Even though it is recommended to implement this by hand for a particular `Model`
 a default implementation using [`SimpleVarInfo{<:Dict}`](@ref) is provided.
 """
 function varnames(model::Model)
-    return collect(keys(last(DynamicPPL.sample!!(model, SimpleVarInfo(Dict())))))
+    return collect(
+        keys(last(DynamicPPL.evaluate_and_sample!!(model, SimpleVarInfo(Dict()))))
+    )
 end
 
 """

--- a/src/test_utils/model_interface.jl
+++ b/src/test_utils/model_interface.jl
@@ -92,9 +92,8 @@ Even though it is recommended to implement this by hand for a particular `Model`
 a default implementation using [`SimpleVarInfo{<:Dict}`](@ref) is provided.
 """
 function varnames(model::Model)
-    return collect(
-        keys(last(DynamicPPL.evaluate!!(model, SimpleVarInfo(Dict()), SamplingContext())))
-    )
+    new_model = contextualize(model, SamplingContext(model.context))
+    return collect(keys(last(DynamicPPL.evaluate!!(new_model, SimpleVarInfo(Dict())))))
 end
 
 """

--- a/src/test_utils/model_interface.jl
+++ b/src/test_utils/model_interface.jl
@@ -92,8 +92,7 @@ Even though it is recommended to implement this by hand for a particular `Model`
 a default implementation using [`SimpleVarInfo{<:Dict}`](@ref) is provided.
 """
 function varnames(model::Model)
-    new_model = contextualize(model, SamplingContext(model.context))
-    return collect(keys(last(DynamicPPL.evaluate!!(new_model, SimpleVarInfo(Dict())))))
+    return collect(keys(last(DynamicPPL.sample!!(model, SimpleVarInfo(Dict())))))
 end
 
 """

--- a/src/test_utils/varinfo.jl
+++ b/src/test_utils/varinfo.jl
@@ -48,7 +48,7 @@ function setup_varinfos(
     )) do vi
         # Set them all to the same values and evaluate logp.
         vi = update_values!!(vi, example_values, varnames)
-        last(DynamicPPL.evaluate!!(model, vi, DefaultContext()))
+        last(DynamicPPL.evaluate!!(model, vi))
     end
 
     if include_threadsafe

--- a/src/threadsafe.jl
+++ b/src/threadsafe.jl
@@ -116,14 +116,17 @@ end
 # consistency between `vi.accs_by_thread` field and `getacc(vi.varinfo)`, which accumulates
 # to define `getacc(vi)`.
 function link!!(t::DynamicTransformation, vi::ThreadSafeVarInfo, model::Model)
-    return settrans!!(last(evaluate!!(model, vi, DynamicTransformationContext{false}())), t)
+    model = contextualize(
+        model, setleafcontext(model.context, DynamicTransformationContext{false}())
+    )
+    return settrans!!(last(evaluate!!(model, vi)), t)
 end
 
 function invlink!!(::DynamicTransformation, vi::ThreadSafeVarInfo, model::Model)
-    return settrans!!(
-        last(evaluate!!(model, vi, DynamicTransformationContext{true}())),
-        NoTransformation(),
+    model = contextualize(
+        model, setleafcontext(model.context, DynamicTransformationContext{true}())
     )
+    return settrans!!(last(evaluate!!(model, vi)), NoTransformation())
 end
 
 function link(t::DynamicTransformation, vi::ThreadSafeVarInfo, model::Model)

--- a/src/transforming.jl
+++ b/src/transforming.jl
@@ -51,16 +51,17 @@ function _transform!!(
     vi::AbstractVarInfo,
     model::Model,
 )
-    # To transform using DynamicTransformationContext, we evaluate the model, but we do not
-    # need to use any accumulators other than LogPriorAccumulator (which is affected by the Jacobian of
-    # the transformation).
+    # To transform using DynamicTransformationContext, we evaluate the model using that as the leaf context:
+    model = contextualize(model, setleafcontext(model.context, ctx))
+    # but we do not need to use any accumulators other than LogPriorAccumulator
+    # (which is affected by the Jacobian of the transformation).
     accs = getaccs(vi)
     has_logprior = haskey(accs, Val(:LogPrior))
     if has_logprior
         old_logprior = getacc(accs, Val(:LogPrior))
         vi = setaccs!!(vi, (old_logprior,))
     end
-    vi = settrans!!(last(evaluate!!(model, vi, ctx)), t)
+    vi = settrans!!(last(evaluate!!(model, vi)), t)
     # Restore the accumulators.
     if has_logprior
         new_logprior = getacc(vi, Val(:LogPrior))

--- a/src/values_as_in_model.jl
+++ b/src/values_as_in_model.jl
@@ -52,7 +52,7 @@ end
 accumulate_observe!!(acc::ValuesAsInModelAccumulator, right, left, vn) = acc
 
 """
-    values_as_in_model(model::Model, include_colon_eq::Bool, varinfo::AbstractVarInfo[, context::AbstractContext])
+    values_as_in_model(model::Model, include_colon_eq::Bool, varinfo::AbstractVarInfo)
 
 Get the values of `varinfo` as they would be seen in the model.
 
@@ -69,8 +69,6 @@ space at the cost of additional model evaluations.
 - `model::Model`: model to extract realizations from.
 - `include_colon_eq::Bool`: whether to also include variables on the LHS of `:=`.
 - `varinfo::AbstractVarInfo`: variable information to use for the extraction.
-- `context::AbstractContext`: evaluation context to use in the extraction. Defaults
-   to `DynamicPPL.DefaultContext()`.
 
 # Examples
 
@@ -124,14 +122,8 @@ julia> # Approach 2: Extract realizations using `values_as_in_model`.
 true
 ```
 """
-function values_as_in_model(
-    model::Model,
-    include_colon_eq::Bool,
-    varinfo::AbstractVarInfo,
-    context::AbstractContext=DefaultContext(),
-)
-    accs = getaccs(varinfo)
+function values_as_in_model(model::Model, include_colon_eq::Bool, varinfo::AbstractVarInfo)
     varinfo = setaccs!!(deepcopy(varinfo), (ValuesAsInModelAccumulator(include_colon_eq),))
-    varinfo = last(evaluate!!(model, varinfo, context))
+    varinfo = last(evaluate!!(model, varinfo))
     return getacc(varinfo, Val(:ValuesAsInModel)).values
 end

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -197,7 +197,7 @@ Construct a VarInfo object for the given `model`, which has just a single
 function untyped_varinfo(
     rng::Random.AbstractRNG, model::Model, sampler::AbstractSampler=SampleFromPrior()
 )
-    return last(sample!!(rng, model, VarInfo(Metadata()), sampler))
+    return last(evaluate_and_sample!!(rng, model, VarInfo(Metadata()), sampler))
 end
 function untyped_varinfo(model::Model, sampler::AbstractSampler=SampleFromPrior())
     return untyped_varinfo(Random.default_rng(), model, sampler)

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -186,8 +186,8 @@ end
 """
     untyped_varinfo([rng, ]model[, sampler])
 
-Return a VarInfo object for the given `model` and `context`, which has just a
-single `Metadata` as its metadata field.
+Construct a VarInfo object for the given `model`, which has just a single
+`Metadata` as its metadata field.
 
 # Arguments
 - `rng::Random.AbstractRNG`: The random number generator to use during model evaluation
@@ -197,9 +197,7 @@ single `Metadata` as its metadata field.
 function untyped_varinfo(
     rng::Random.AbstractRNG, model::Model, sampler::AbstractSampler=SampleFromPrior()
 )
-    varinfo = VarInfo(Metadata())
-    new_model = contextualize(model, SamplingContext(rng, sampler, model.context))
-    return last(evaluate!!(new_model, varinfo))
+    return last(sample!!(rng, model, VarInfo(Metadata()), sampler))
 end
 function untyped_varinfo(model::Model, sampler::AbstractSampler=SampleFromPrior())
     return untyped_varinfo(Random.default_rng(), model, sampler)
@@ -311,8 +309,8 @@ end
 """
     typed_vector_varinfo([rng, ]model[, sampler])
 
-Return a VarInfo object for the given `model` and `context`, which has a
-NamedTuple of `VarNamedVector`s as its metadata field.
+Return a VarInfo object for the given `model`, which has a NamedTuple of
+`VarNamedVector`s as its metadata field.
 
 # Arguments
 - `rng::Random.AbstractRNG`: The random number generator to use during model evaluation

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -110,9 +110,8 @@ using DynamicPPL: LogDensityFunction
         # Compiling the ReverseDiff tape used to fail here
         spl = Sampler(MyEmptyAlg())
         vi = VarInfo(model)
-        ldf = LogDensityFunction(
-            model, vi, SamplingContext(spl); adtype=AutoReverseDiff(; compile=true)
-        )
+        sampling_model = contextualize(model, SamplingContext(model.context))
+        ldf = LogDensityFunction(sampling_model, vi; adtype=AutoReverseDiff(; compile=true))
         @test LogDensityProblems.logdensity_and_gradient(ldf, vi[:]) isa Any
     end
 

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -185,10 +185,7 @@ module Issue537 end
         @model function testmodel_missing3(x)
             x[1] ~ Bernoulli(0.5)
             global varinfo_ = __varinfo__
-            global sampler_ = __context__.sampler
             global model_ = __model__
-            global context_ = __context__
-            global rng_ = __context__.rng
             global lp = getlogjoint(__varinfo__)
             return x
         end
@@ -196,18 +193,18 @@ module Issue537 end
         varinfo = VarInfo(model)
         @test getlogjoint(varinfo) == lp
         @test varinfo_ isa AbstractVarInfo
-        @test model_ === model
-        @test context_ isa SamplingContext
-        @test rng_ isa Random.AbstractRNG
+        # During the model evaluation, its context is wrapped in a
+        # SamplingContext, so `model_` is not going to be equal to `model`.
+        # We can still check equality of `f` though.
+        @test model_.f === model.f
+        @test model_.context isa SamplingContext
+        @test model_.context.rng isa Random.AbstractRNG
 
         # disable warnings
         @model function testmodel_missing4(x)
             x[1] ~ Bernoulli(0.5)
             global varinfo_ = __varinfo__
-            global sampler_ = __context__.sampler
             global model_ = __model__
-            global context_ = __context__
-            global rng_ = __context__.rng
             global lp = getlogjoint(__varinfo__)
             return x
         end false
@@ -601,13 +598,13 @@ module Issue537 end
         # an attempt at a `NamedTuple` of the form `(x = 1, __varinfo__)`.
         @model empty_model() = return x = 1
         empty_vi = VarInfo()
-        retval_and_vi = DynamicPPL.evaluate!!(empty_model(), empty_vi, SamplingContext())
+        retval_and_vi = DynamicPPL.sample!!(empty_model(), empty_vi)
         @test retval_and_vi isa Tuple{Int,typeof(empty_vi)}
 
         # Even if the return-value is `AbstractVarInfo`, we should return
         # a `Tuple` with `AbstractVarInfo` in the second component too.
         @model demo() = return __varinfo__
-        retval, svi = DynamicPPL.evaluate!!(demo(), SimpleVarInfo(), SamplingContext())
+        retval, svi = DynamicPPL.sample!!(demo(), SimpleVarInfo())
         @test svi == SimpleVarInfo()
         if Threads.nthreads() > 1
             @test retval isa DynamicPPL.ThreadSafeVarInfo{<:SimpleVarInfo}
@@ -623,11 +620,11 @@ module Issue537 end
             f(x) = return x^2
             return f(1.0)
         end
-        retval, svi = DynamicPPL.evaluate!!(demo(), SimpleVarInfo(), SamplingContext())
+        retval, svi = DynamicPPL.sample!!(demo(), SimpleVarInfo())
         @test retval isa Float64
 
         @model demo() = x ~ Normal()
-        retval, svi = DynamicPPL.evaluate!!(demo(), SimpleVarInfo(), SamplingContext())
+        retval, svi = DynamicPPL.sample!!(demo(), SimpleVarInfo())
 
         # Return-value when using `to_submodel`
         @model inner() = x ~ Normal()

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -598,13 +598,13 @@ module Issue537 end
         # an attempt at a `NamedTuple` of the form `(x = 1, __varinfo__)`.
         @model empty_model() = return x = 1
         empty_vi = VarInfo()
-        retval_and_vi = DynamicPPL.sample!!(empty_model(), empty_vi)
+        retval_and_vi = DynamicPPL.evaluate_and_sample!!(empty_model(), empty_vi)
         @test retval_and_vi isa Tuple{Int,typeof(empty_vi)}
 
         # Even if the return-value is `AbstractVarInfo`, we should return
         # a `Tuple` with `AbstractVarInfo` in the second component too.
         @model demo() = return __varinfo__
-        retval, svi = DynamicPPL.sample!!(demo(), SimpleVarInfo())
+        retval, svi = DynamicPPL.evaluate_and_sample!!(demo(), SimpleVarInfo())
         @test svi == SimpleVarInfo()
         if Threads.nthreads() > 1
             @test retval isa DynamicPPL.ThreadSafeVarInfo{<:SimpleVarInfo}
@@ -620,11 +620,11 @@ module Issue537 end
             f(x) = return x^2
             return f(1.0)
         end
-        retval, svi = DynamicPPL.sample!!(demo(), SimpleVarInfo())
+        retval, svi = DynamicPPL.evaluate_and_sample!!(demo(), SimpleVarInfo())
         @test retval isa Float64
 
         @model demo() = x ~ Normal()
-        retval, svi = DynamicPPL.sample!!(demo(), SimpleVarInfo())
+        retval, svi = DynamicPPL.evaluate_and_sample!!(demo(), SimpleVarInfo())
 
         # Return-value when using `to_submodel`
         @model inner() = x ~ Normal()

--- a/test/context_implementations.jl
+++ b/test/context_implementations.jl
@@ -5,12 +5,12 @@
             μ ~ MvNormal(zeros(2), 4 * I)
             z = Vector{Int}(undef, length(x))
             z ~ product_distribution(Categorical.(fill([0.5, 0.5], length(x))))
-            for i in 1:length(x)
+            for i in eachindex(x)
                 x[i] ~ Normal(μ[z[i]], 0.1)
             end
         end
 
-        test([1, 1, -1])(VarInfo(), SampleFromPrior(), DefaultContext())
+        test([1, 1, -1])(VarInfo())
     end
 
     @testset "dot tilde with varying sizes" begin

--- a/test/contexts.jl
+++ b/test/contexts.jl
@@ -184,9 +184,10 @@ Base.IteratorEltype(::Type{<:AbstractContext}) = Base.EltypeUnknown()
         @testset "evaluation: $(model.f)" for model in DynamicPPL.TestUtils.DEMO_MODELS
             prefix_vn = @varname(my_prefix)
             context = DynamicPPL.PrefixContext(prefix_vn, SamplingContext())
+            sampling_model = contextualize(model, context)
             # Sample with the context.
             varinfo = DynamicPPL.VarInfo()
-            DynamicPPL.evaluate!!(model, varinfo, context)
+            DynamicPPL.evaluate!!(sampling_model, varinfo)
             # Extract the resulting varnames
             vns_actual = Set(keys(varinfo))
 

--- a/test/debug_utils.jl
+++ b/test/debug_utils.jl
@@ -1,7 +1,7 @@
 @testset "check_model" begin
     @testset "context interface" begin
         @testset "$(model.f)" for model in DynamicPPL.TestUtils.DEMO_MODELS
-            context = DynamicPPL.DebugUtils.DebugContext(model)
+            context = DynamicPPL.DebugUtils.DebugContext()
             DynamicPPL.TestUtils.test_context(context, model)
         end
     end
@@ -35,9 +35,7 @@
             buggy_model = buggy_demo_model()
 
             @test_logs (:warn,) (:warn,) check_model(buggy_model)
-            issuccess = check_model(
-                buggy_model; context=SamplingContext(), record_varinfo=false
-            )
+            issuccess = check_model(buggy_model; record_varinfo=false)
             @test !issuccess
             @test_throws ErrorException check_model(buggy_model; error_on_failure=true)
         end
@@ -81,9 +79,7 @@
             buggy_model = buggy_subsumes_demo_model()
 
             @test_logs (:warn,) (:warn,) check_model(buggy_model)
-            issuccess = check_model(
-                buggy_model; context=SamplingContext(), record_varinfo=false
-            )
+            issuccess = check_model(buggy_model; record_varinfo=false)
             @test !issuccess
             @test_throws ErrorException check_model(buggy_model; error_on_failure=true)
         end
@@ -98,9 +94,7 @@
             buggy_model = buggy_subsumes_demo_model()
 
             @test_logs (:warn,) (:warn,) check_model(buggy_model)
-            issuccess = check_model(
-                buggy_model; context=SamplingContext(), record_varinfo=false
-            )
+            issuccess = check_model(buggy_model; record_varinfo=false)
             @test !issuccess
             @test_throws ErrorException check_model(buggy_model; error_on_failure=true)
         end
@@ -115,9 +109,7 @@
             buggy_model = buggy_subsumes_demo_model()
 
             @test_logs (:warn,) (:warn,) check_model(buggy_model)
-            issuccess = check_model(
-                buggy_model; context=SamplingContext(), record_varinfo=false
-            )
+            issuccess = check_model(buggy_model; record_varinfo=false)
             @test !issuccess
             @test_throws ErrorException check_model(buggy_model; error_on_failure=true)
         end

--- a/test/ext/DynamicPPLForwardDiffExt.jl
+++ b/test/ext/DynamicPPLForwardDiffExt.jl
@@ -14,17 +14,16 @@ using Test: @test, @testset
     @model f() = x ~ MvNormal(zeros(MODEL_SIZE), I)
     model = f()
     varinfo = VarInfo(model)
-    context = DefaultContext()
 
     @testset "Chunk size setting" for chunksize in (nothing, 0)
         base_adtype = AutoForwardDiff(; chunksize=chunksize)
-        new_adtype = DynamicPPL.tweak_adtype(base_adtype, model, varinfo, context)
+        new_adtype = DynamicPPL.tweak_adtype(base_adtype, model, varinfo)
         @test new_adtype isa AutoForwardDiff{MODEL_SIZE}
     end
 
     @testset "Tag setting" begin
         base_adtype = AutoForwardDiff()
-        new_adtype = DynamicPPL.tweak_adtype(base_adtype, model, varinfo, context)
+        new_adtype = DynamicPPL.tweak_adtype(base_adtype, model, varinfo)
         @test new_adtype.tag isa ForwardDiff.Tag{DynamicPPL.DynamicPPLTag}
     end
 end

--- a/test/ext/DynamicPPLJETExt.jl
+++ b/test/ext/DynamicPPLJETExt.jl
@@ -62,6 +62,7 @@
 
     @testset "demo models" begin
         @testset "$(model.f)" for model in DynamicPPL.TestUtils.DEMO_MODELS
+            sampling_model = contextualize(model, SamplingContext(model.context))
             # Use debug logging below.
             varinfo = DynamicPPL.Experimental.determine_suitable_varinfo(model)
             # Check that the inferred varinfo is indeed suitable for evaluation and sampling
@@ -71,7 +72,7 @@
             JET.test_call(f_eval, argtypes_eval)
 
             f_sample, argtypes_sample = DynamicPPL.DebugUtils.gen_evaluator_call_with_types(
-                model, varinfo, DynamicPPL.SamplingContext()
+                sampling_model, varinfo
             )
             JET.test_call(f_sample, argtypes_sample)
             # For our demo models, they should all result in typed.
@@ -85,7 +86,7 @@
                 )
                 JET.test_call(f_eval, argtypes_eval)
                 f_sample, argtypes_sample = DynamicPPL.DebugUtils.gen_evaluator_call_with_types(
-                    model, typed_vi, DynamicPPL.SamplingContext()
+                    sampling_model, typed_vi
                 )
                 JET.test_call(f_sample, argtypes_sample)
             end

--- a/test/linking.jl
+++ b/test/linking.jl
@@ -78,7 +78,7 @@ end
         vis = DynamicPPL.TestUtils.setup_varinfos(model, example_values, (@varname(m),))
         @testset "$(short_varinfo_name(vi))" for vi in vis
             # Evaluate once to ensure we have `logp` value.
-            vi = last(DynamicPPL.evaluate!!(model, vi, DefaultContext()))
+            vi = last(DynamicPPL.evaluate!!(model, vi))
             vi_linked = if mutable
                 DynamicPPL.link!!(deepcopy(vi), model)
             else

--- a/test/model.jl
+++ b/test/model.jl
@@ -162,12 +162,12 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
             for i in 1:10
                 Random.seed!(100 + i)
                 vi = VarInfo()
-                DynamicPPL.sample!!(Random.default_rng(), model, vi, sampler)
+                DynamicPPL.evaluate_and_sample!!(Random.default_rng(), model, vi, sampler)
                 vals = vi[:]
 
                 Random.seed!(100 + i)
                 vi = VarInfo()
-                DynamicPPL.sample!!(Random.default_rng(), model, vi, sampler)
+                DynamicPPL.evaluate_and_sample!!(Random.default_rng(), model, vi, sampler)
                 @test vi[:] == vals
             end
         end
@@ -332,7 +332,7 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
             @test logjoint(model, x) !=
                 DynamicPPL.TestUtils.logjoint_true_with_logabsdet_jacobian(model, x...)
             # Ensure `varnames` is implemented.
-            vi = last(DynamicPPL.sample!!(model, SimpleVarInfo(OrderedDict())))
+            vi = last(DynamicPPL.evaluate_and_sample!!(model, SimpleVarInfo(OrderedDict())))
             @test all(collect(keys(vi)) .== DynamicPPL.TestUtils.varnames(model))
             # Ensure `posterior_mean` is implemented.
             @test DynamicPPL.TestUtils.posterior_mean(model) isa typeof(x)
@@ -591,7 +591,10 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
             xs_train = 1:0.1:10
             ys_train = ground_truth_β .* xs_train + rand(Normal(0, 0.1), length(xs_train))
             m_lin_reg = linear_reg(xs_train, ys_train)
-            chain = [last(DynamicPPL.sample!!(m_lin_reg, VarInfo())) for _ in 1:10000]
+            chain = [
+                last(DynamicPPL.evaluate_and_sample!!(m_lin_reg, VarInfo())) for
+                _ in 1:10000
+            ]
 
             # chain is generated from the prior
             @test mean([chain[i][@varname(β)] for i in eachindex(chain)]) ≈ 1.0 atol = 0.1

--- a/test/model.jl
+++ b/test/model.jl
@@ -162,12 +162,12 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
             for i in 1:10
                 Random.seed!(100 + i)
                 vi = VarInfo()
-                model(Random.default_rng(), vi, sampler)
+                DynamicPPL.sample!!(Random.default_rng(), model, vi, sampler)
                 vals = vi[:]
 
                 Random.seed!(100 + i)
                 vi = VarInfo()
-                model(Random.default_rng(), vi, sampler)
+                DynamicPPL.sample!!(Random.default_rng(), model, vi, sampler)
                 @test vi[:] == vals
             end
         end
@@ -223,7 +223,7 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
 
         # Second component of return-value of `evaluate!!` should
         # be a `DynamicPPL.AbstractVarInfo`.
-        evaluate_retval = DynamicPPL.evaluate!!(model, vi, DefaultContext())
+        evaluate_retval = DynamicPPL.evaluate!!(model, vi)
         @test evaluate_retval[2] isa DynamicPPL.AbstractVarInfo
 
         # Should not return `AbstractVarInfo` when we call the model.
@@ -332,11 +332,7 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
             @test logjoint(model, x) !=
                 DynamicPPL.TestUtils.logjoint_true_with_logabsdet_jacobian(model, x...)
             # Ensure `varnames` is implemented.
-            vi = last(
-                DynamicPPL.evaluate!!(
-                    model, SimpleVarInfo(OrderedDict()), SamplingContext()
-                ),
-            )
+            vi = last(DynamicPPL.sample!!(model, SimpleVarInfo(OrderedDict())))
             @test all(collect(keys(vi)) .== DynamicPPL.TestUtils.varnames(model))
             # Ensure `posterior_mean` is implemented.
             @test DynamicPPL.TestUtils.posterior_mean(model) isa typeof(x)
@@ -397,7 +393,6 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
             models_to_test = [
                 DynamicPPL.TestUtils.DEMO_MODELS..., DynamicPPL.TestUtils.demo_lkjchol(2)
             ]
-            context = DefaultContext()
             @testset "$(model.f)" for model in models_to_test
                 vns = DynamicPPL.TestUtils.varnames(model)
                 example_values = DynamicPPL.TestUtils.rand_prior_true(model)
@@ -407,13 +402,13 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
                 )
                 @testset "$(short_varinfo_name(varinfo))" for varinfo in varinfos
                     @test begin
-                        @inferred(DynamicPPL.evaluate!!(model, varinfo, context))
+                        @inferred(DynamicPPL.evaluate!!(model, varinfo))
                         true
                     end
 
                     varinfo_linked = DynamicPPL.link(varinfo, model)
                     @test begin
-                        @inferred(DynamicPPL.evaluate!!(model, varinfo_linked, context))
+                        @inferred(DynamicPPL.evaluate!!(model, varinfo_linked))
                         true
                     end
                 end
@@ -492,7 +487,7 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
         @testset "$(short_varinfo_name(varinfo))" for varinfo in varinfos
             varinfo_linked = DynamicPPL.link(varinfo, model)
             varinfo_linked_result = last(
-                DynamicPPL.evaluate!!(model, deepcopy(varinfo_linked), DefaultContext())
+                DynamicPPL.evaluate!!(model, deepcopy(varinfo_linked))
             )
             @test getlogjoint(varinfo_linked) ≈ getlogjoint(varinfo_linked_result)
         end
@@ -596,7 +591,7 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
             xs_train = 1:0.1:10
             ys_train = ground_truth_β .* xs_train + rand(Normal(0, 0.1), length(xs_train))
             m_lin_reg = linear_reg(xs_train, ys_train)
-            chain = [evaluate!!(m_lin_reg)[2] for _ in 1:10000]
+            chain = [last(DynamicPPL.sample!!(m_lin_reg, VarInfo())) for _ in 1:10000]
 
             # chain is generated from the prior
             @test mean([chain[i][@varname(β)] for i in eachindex(chain)]) ≈ 1.0 atol = 0.1

--- a/test/simple_varinfo.jl
+++ b/test/simple_varinfo.jl
@@ -98,7 +98,7 @@
             for vn in DynamicPPL.TestUtils.varnames(model)
                 vi = DynamicPPL.setindex!!(vi, get(values_constrained, vn), vn)
             end
-            vi = last(DynamicPPL.evaluate!!(model, vi, DefaultContext()))
+            vi = last(DynamicPPL.evaluate!!(model, vi))
 
             # `link!!`
             vi_linked = link!!(deepcopy(vi), model)
@@ -158,7 +158,7 @@
 
             ### Sampling ###
             # Sample a new varinfo!
-            _, svi_new = DynamicPPL.evaluate!!(model, svi, SamplingContext())
+            _, svi_new = DynamicPPL.sample!!(model, svi)
 
             # Realization for `m` should be different wp. 1.
             for vn in DynamicPPL.TestUtils.varnames(model)
@@ -226,9 +226,9 @@
 
         # Initialize.
         svi_nt = DynamicPPL.settrans!!(SimpleVarInfo(), true)
-        svi_nt = last(DynamicPPL.evaluate!!(model, svi_nt, SamplingContext()))
+        svi_nt = last(DynamicPPL.sample!!(model, svi_nt))
         svi_vnv = DynamicPPL.settrans!!(SimpleVarInfo(DynamicPPL.VarNamedVector()), true)
-        svi_vnv = last(DynamicPPL.evaluate!!(model, svi_vnv, SamplingContext()))
+        svi_vnv = last(DynamicPPL.sample!!(model, svi_vnv))
 
         for svi in (svi_nt, svi_vnv)
             # Sample with large variations in unconstrained space.
@@ -236,7 +236,7 @@
                 for vn in keys(svi)
                     svi = DynamicPPL.setindex!!(svi, 10 * randn(), vn)
                 end
-                retval, svi = DynamicPPL.evaluate!!(model, svi, DefaultContext())
+                retval, svi = DynamicPPL.evaluate!!(model, svi)
                 @test retval.m == svi[@varname(m)]  # `m` is unconstrained
                 @test retval.x ≠ svi[@varname(x)]   # `x` is constrained depending on `m`
 
@@ -273,7 +273,7 @@
             )
 
             # Resulting varinfo should no longer be transformed.
-            vi_result = last(DynamicPPL.evaluate!!(model, deepcopy(vi), SamplingContext()))
+            vi_result = last(DynamicPPL.sample!!(model, deepcopy(vi)))
             @test !DynamicPPL.istrans(vi_result)
 
             # Set the values to something that is out of domain if we're in constrained space.
@@ -281,9 +281,7 @@
                 vi_linked = DynamicPPL.setindex!!(vi_linked, -rand(), vn)
             end
 
-            retval, vi_linked_result = DynamicPPL.evaluate!!(
-                model, deepcopy(vi_linked), DefaultContext()
-            )
+            retval, vi_linked_result = DynamicPPL.evaluate!!(model, deepcopy(vi_linked))
 
             @test DynamicPPL.tovec(DynamicPPL.getindex_internal(vi_linked, @varname(s))) ≠
                 DynamicPPL.tovec(retval.s)  # `s` is unconstrained in original

--- a/test/simple_varinfo.jl
+++ b/test/simple_varinfo.jl
@@ -158,7 +158,7 @@
 
             ### Sampling ###
             # Sample a new varinfo!
-            _, svi_new = DynamicPPL.sample!!(model, svi)
+            _, svi_new = DynamicPPL.evaluate_and_sample!!(model, svi)
 
             # Realization for `m` should be different wp. 1.
             for vn in DynamicPPL.TestUtils.varnames(model)
@@ -226,9 +226,9 @@
 
         # Initialize.
         svi_nt = DynamicPPL.settrans!!(SimpleVarInfo(), true)
-        svi_nt = last(DynamicPPL.sample!!(model, svi_nt))
+        svi_nt = last(DynamicPPL.evaluate_and_sample!!(model, svi_nt))
         svi_vnv = DynamicPPL.settrans!!(SimpleVarInfo(DynamicPPL.VarNamedVector()), true)
-        svi_vnv = last(DynamicPPL.sample!!(model, svi_vnv))
+        svi_vnv = last(DynamicPPL.evaluate_and_sample!!(model, svi_vnv))
 
         for svi in (svi_nt, svi_vnv)
             # Sample with large variations in unconstrained space.
@@ -273,7 +273,7 @@
             )
 
             # Resulting varinfo should no longer be transformed.
-            vi_result = last(DynamicPPL.sample!!(model, deepcopy(vi)))
+            vi_result = last(DynamicPPL.evaluate_and_sample!!(model, deepcopy(vi)))
             @test !DynamicPPL.istrans(vi_result)
 
             # Set the values to something that is out of domain if we're in constrained space.

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -491,7 +491,7 @@ end
         # Check that instantiating the model does not perform linking
         vi = VarInfo()
         meta = vi.metadata
-        model(vi, SampleFromUniform())
+        model(vi)
         @test all(x -> !istrans(vi, x), meta.vns)
 
         # Check that linking and invlinking set the `trans` flag accordingly
@@ -565,7 +565,7 @@ end
         vi = DynamicPPL.untyped_varinfo(model)
         vi = DynamicPPL.settrans!!(vi, true, vn)
         # Sample in unconstrained space.
-        vi = last(DynamicPPL.evaluate!!(model, vi, SamplingContext()))
+        vi = last(DynamicPPL.sample!!(model, vi))
         f = DynamicPPL.from_linked_internal_transform(vi, vn, dist)
         x = f(DynamicPPL.getindex_internal(vi, vn))
         @test getlogjoint(vi) ≈ Bijectors.logpdf_with_trans(dist, x, true)
@@ -574,7 +574,7 @@ end
         vi = DynamicPPL.typed_varinfo(model)
         vi = DynamicPPL.settrans!!(vi, true, vn)
         # Sample in unconstrained space.
-        vi = last(DynamicPPL.evaluate!!(model, vi, SamplingContext()))
+        vi = last(DynamicPPL.sample!!(model, vi))
         f = DynamicPPL.from_linked_internal_transform(vi, vn, dist)
         x = f(DynamicPPL.getindex_internal(vi, vn))
         @test getlogjoint(vi) ≈ Bijectors.logpdf_with_trans(dist, x, true)
@@ -583,7 +583,7 @@ end
         vi = DynamicPPL.typed_varinfo(model)
         vi = DynamicPPL.settrans!!(vi, true, vn)
         # Sample in unconstrained space.
-        vi = last(DynamicPPL.evaluate!!(model, vi, SamplingContext()))
+        vi = last(DynamicPPL.sample!!(model, vi))
         f = DynamicPPL.from_linked_internal_transform(vi, vn, dist)
         x = f(DynamicPPL.getindex_internal(vi, vn))
         @test getlogjoint(vi) ≈ Bijectors.logpdf_with_trans(dist, x, true)
@@ -592,7 +592,7 @@ end
         ## `SimpleVarInfo{<:NamedTuple}`
         vi = DynamicPPL.settrans!!(SimpleVarInfo(), true)
         # Sample in unconstrained space.
-        vi = last(DynamicPPL.evaluate!!(model, vi, SamplingContext()))
+        vi = last(DynamicPPL.sample!!(model, vi))
         f = DynamicPPL.from_linked_internal_transform(vi, vn, dist)
         x = f(DynamicPPL.getindex_internal(vi, vn))
         @test getlogjoint(vi) ≈ Bijectors.logpdf_with_trans(dist, x, true)
@@ -600,7 +600,7 @@ end
         ## `SimpleVarInfo{<:Dict}`
         vi = DynamicPPL.settrans!!(SimpleVarInfo(Dict()), true)
         # Sample in unconstrained space.
-        vi = last(DynamicPPL.evaluate!!(model, vi, SamplingContext()))
+        vi = last(DynamicPPL.sample!!(model, vi))
         f = DynamicPPL.from_linked_internal_transform(vi, vn, dist)
         x = f(DynamicPPL.getindex_internal(vi, vn))
         @test getlogjoint(vi) ≈ Bijectors.logpdf_with_trans(dist, x, true)
@@ -608,7 +608,7 @@ end
         ## `SimpleVarInfo{<:VarNamedVector}`
         vi = DynamicPPL.settrans!!(SimpleVarInfo(DynamicPPL.VarNamedVector()), true)
         # Sample in unconstrained space.
-        vi = last(DynamicPPL.evaluate!!(model, vi, SamplingContext()))
+        vi = last(DynamicPPL.sample!!(model, vi))
         f = DynamicPPL.from_linked_internal_transform(vi, vn, dist)
         x = f(DynamicPPL.getindex_internal(vi, vn))
         @test getlogjoint(vi) ≈ Bijectors.logpdf_with_trans(dist, x, true)
@@ -690,7 +690,7 @@ end
                     end
 
                     # Evaluate the model once to update the logp of the varinfo.
-                    varinfo = last(DynamicPPL.evaluate!!(model, varinfo, DefaultContext()))
+                    varinfo = last(DynamicPPL.evaluate!!(model, varinfo))
 
                     varinfo_linked = if mutating
                         DynamicPPL.link!!(deepcopy(varinfo), model)
@@ -993,9 +993,7 @@ end
         # Sampling from `model2` should hit the `istrans(vi) == true` branches
         # because all the existing variables are linked.
         model2 = demo(2)
-        varinfo2 = last(
-            DynamicPPL.evaluate!!(model2, deepcopy(varinfo1), SamplingContext())
-        )
+        varinfo2 = last(DynamicPPL.sample!!(model2, deepcopy(varinfo1)))
         for vn in [@varname(x[1]), @varname(x[2])]
             @test DynamicPPL.istrans(varinfo2, vn)
         end
@@ -1014,9 +1012,7 @@ end
         # Sampling from `model2` should hit the `istrans(vi) == true` branches
         # because all the existing variables are linked.
         model2 = demo_dot(2)
-        varinfo2 = last(
-            DynamicPPL.evaluate!!(model2, deepcopy(varinfo1), SamplingContext())
-        )
+        varinfo2 = last(DynamicPPL.sample!!(model2, deepcopy(varinfo1)))
         for vn in [@varname(x), @varname(y[1])]
             @test DynamicPPL.istrans(varinfo2, vn)
         end

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -488,10 +488,17 @@ end
         end
         model = gdemo([1.0, 1.5], [2.0, 2.5])
 
-        # Check that instantiating the model does not perform linking
+        # Check that instantiating the model using SampleFromUniform does not
+        # perform linking
+        # Note (penelopeysm): The purpose of using SampleFromUniform (SFU)
+        # specifically in this test is because SFU samples from the linked 
+        # distribution i.e. in unconstrained space. However, it does this not
+        # by linking the varinfo but by transforming the distributions on the
+        # fly. That's why it's worth specifically checking that it can do this
+        # without having to change the VarInfo object.
         vi = VarInfo()
         meta = vi.metadata
-        model(vi)
+        _, vi = DynamicPPL.sample!!(model, vi, SampleFromUniform())
         @test all(x -> !istrans(vi, x), meta.vns)
 
         # Check that linking and invlinking set the `trans` flag accordingly

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -498,7 +498,7 @@ end
         # without having to change the VarInfo object.
         vi = VarInfo()
         meta = vi.metadata
-        _, vi = DynamicPPL.sample!!(model, vi, SampleFromUniform())
+        _, vi = DynamicPPL.evaluate_and_sample!!(model, vi, SampleFromUniform())
         @test all(x -> !istrans(vi, x), meta.vns)
 
         # Check that linking and invlinking set the `trans` flag accordingly
@@ -572,7 +572,7 @@ end
         vi = DynamicPPL.untyped_varinfo(model)
         vi = DynamicPPL.settrans!!(vi, true, vn)
         # Sample in unconstrained space.
-        vi = last(DynamicPPL.sample!!(model, vi))
+        vi = last(DynamicPPL.evaluate_and_sample!!(model, vi))
         f = DynamicPPL.from_linked_internal_transform(vi, vn, dist)
         x = f(DynamicPPL.getindex_internal(vi, vn))
         @test getlogjoint(vi) ≈ Bijectors.logpdf_with_trans(dist, x, true)
@@ -581,7 +581,7 @@ end
         vi = DynamicPPL.typed_varinfo(model)
         vi = DynamicPPL.settrans!!(vi, true, vn)
         # Sample in unconstrained space.
-        vi = last(DynamicPPL.sample!!(model, vi))
+        vi = last(DynamicPPL.evaluate_and_sample!!(model, vi))
         f = DynamicPPL.from_linked_internal_transform(vi, vn, dist)
         x = f(DynamicPPL.getindex_internal(vi, vn))
         @test getlogjoint(vi) ≈ Bijectors.logpdf_with_trans(dist, x, true)
@@ -590,7 +590,7 @@ end
         vi = DynamicPPL.typed_varinfo(model)
         vi = DynamicPPL.settrans!!(vi, true, vn)
         # Sample in unconstrained space.
-        vi = last(DynamicPPL.sample!!(model, vi))
+        vi = last(DynamicPPL.evaluate_and_sample!!(model, vi))
         f = DynamicPPL.from_linked_internal_transform(vi, vn, dist)
         x = f(DynamicPPL.getindex_internal(vi, vn))
         @test getlogjoint(vi) ≈ Bijectors.logpdf_with_trans(dist, x, true)
@@ -599,7 +599,7 @@ end
         ## `SimpleVarInfo{<:NamedTuple}`
         vi = DynamicPPL.settrans!!(SimpleVarInfo(), true)
         # Sample in unconstrained space.
-        vi = last(DynamicPPL.sample!!(model, vi))
+        vi = last(DynamicPPL.evaluate_and_sample!!(model, vi))
         f = DynamicPPL.from_linked_internal_transform(vi, vn, dist)
         x = f(DynamicPPL.getindex_internal(vi, vn))
         @test getlogjoint(vi) ≈ Bijectors.logpdf_with_trans(dist, x, true)
@@ -607,7 +607,7 @@ end
         ## `SimpleVarInfo{<:Dict}`
         vi = DynamicPPL.settrans!!(SimpleVarInfo(Dict()), true)
         # Sample in unconstrained space.
-        vi = last(DynamicPPL.sample!!(model, vi))
+        vi = last(DynamicPPL.evaluate_and_sample!!(model, vi))
         f = DynamicPPL.from_linked_internal_transform(vi, vn, dist)
         x = f(DynamicPPL.getindex_internal(vi, vn))
         @test getlogjoint(vi) ≈ Bijectors.logpdf_with_trans(dist, x, true)
@@ -615,7 +615,7 @@ end
         ## `SimpleVarInfo{<:VarNamedVector}`
         vi = DynamicPPL.settrans!!(SimpleVarInfo(DynamicPPL.VarNamedVector()), true)
         # Sample in unconstrained space.
-        vi = last(DynamicPPL.sample!!(model, vi))
+        vi = last(DynamicPPL.evaluate_and_sample!!(model, vi))
         f = DynamicPPL.from_linked_internal_transform(vi, vn, dist)
         x = f(DynamicPPL.getindex_internal(vi, vn))
         @test getlogjoint(vi) ≈ Bijectors.logpdf_with_trans(dist, x, true)
@@ -1000,7 +1000,7 @@ end
         # Sampling from `model2` should hit the `istrans(vi) == true` branches
         # because all the existing variables are linked.
         model2 = demo(2)
-        varinfo2 = last(DynamicPPL.sample!!(model2, deepcopy(varinfo1)))
+        varinfo2 = last(DynamicPPL.evaluate_and_sample!!(model2, deepcopy(varinfo1)))
         for vn in [@varname(x[1]), @varname(x[2])]
             @test DynamicPPL.istrans(varinfo2, vn)
         end
@@ -1019,7 +1019,7 @@ end
         # Sampling from `model2` should hit the `istrans(vi) == true` branches
         # because all the existing variables are linked.
         model2 = demo_dot(2)
-        varinfo2 = last(DynamicPPL.sample!!(model2, deepcopy(varinfo1)))
+        varinfo2 = last(DynamicPPL.evaluate_and_sample!!(model2, deepcopy(varinfo1)))
         for vn in [@varname(x), @varname(y[1])]
             @test DynamicPPL.istrans(varinfo2, vn)
         end

--- a/test/varnamedvector.jl
+++ b/test/varnamedvector.jl
@@ -603,18 +603,14 @@ end
             DynamicPPL.TestUtils.test_values(varinfo, value_true, vns)
 
             # Is evaluation correct?
-            varinfo_eval = last(
-                DynamicPPL.evaluate!!(model, deepcopy(varinfo), DefaultContext())
-            )
+            varinfo_eval = last(DynamicPPL.evaluate!!(model, deepcopy(varinfo)))
             # Log density should be the same.
             @test getlogjoint(varinfo_eval) ≈ logp_true
             # Values should be the same.
             DynamicPPL.TestUtils.test_values(varinfo_eval, value_true, vns)
 
             # Is sampling correct?
-            varinfo_sample = last(
-                DynamicPPL.evaluate!!(model, deepcopy(varinfo), SamplingContext())
-            )
+            varinfo_sample = last(DynamicPPL.sample!!(model, deepcopy(varinfo)))
             # Log density should be different.
             @test getlogjoint(varinfo_sample) != getlogjoint(varinfo)
             # Values should be different.

--- a/test/varnamedvector.jl
+++ b/test/varnamedvector.jl
@@ -610,7 +610,9 @@ end
             DynamicPPL.TestUtils.test_values(varinfo_eval, value_true, vns)
 
             # Is sampling correct?
-            varinfo_sample = last(DynamicPPL.sample!!(model, deepcopy(varinfo)))
+            varinfo_sample = last(
+                DynamicPPL.evaluate_and_sample!!(model, deepcopy(varinfo))
+            )
             # Log density should be different.
             @test getlogjoint(varinfo_sample) != getlogjoint(varinfo)
             # Values should be different.


### PR DESCRIPTION
## Summary

This PR modifies the _model evaluation function_, `model.f` for some `model::DynamicPPL.Model`, to not take a context as its third argument. Thus, its signature looks like `f(model, varinfo, args...; kwargs...)` where `args` and `kwargs` are forwarded from the function that defines the model.

During model evaluation, the tilde-pipeline would always dispatch on the `__context__` argument, and would completely ignore the `__model__.context`. It has now been changed so that it dispatches on `__model__.context`.

As a result of this, we can remove the `context` argument from most model evaluation code as well as LogDensityFunction. This simplifies a lot of code.

There are a handful of minor follow-up points:

### Combination of `__context__` and `__model__.context`

Inside the _model evaluation function_, the model's context was previously being ignored. However, if one were to call `evaluate!!(model, varinfo, context)`, the model's context does not get ignored: it is combined together with `context` in order to form a larger context stack, which _then_ becomes the actual evaluation context.

https://github.com/TuringLang/DynamicPPL.jl/blob/3e54c2d8c5f790d8ba83061671e22783dadbc164/src/model.jl#L942-L944

After this PR, the intention is that if you want to keep that combining behaviour, you should do it manually. However, several 'outs' are provided:

1. `sample!!(rng, model, varinfo, sampler)` is provided. This wraps `model.context` in a `SamplingContext(rng, sampler)` before calling `evaluate!!`. This takes care of most invocations of `evaluate!!` where this combining behaviour was being used.

   (As a bonus, this also helps us remove the rng and sampler arguments from `evaluate!!`, which greatly simplifies that function: #720)

2. `evaluate!!(model, varinfo, context)` still exists, but is dep-warned.

3. `_evaluate!!(model, varinfo, context)` still exists with the same behaviour without a depwarn. This is only retained because submodels depend on this and I would like to leave this change for a subsequent PR, as that needs to be reasoned about more deeply.

### Models as callables

Previously, `(model::Model)(args...)` would forward to `evaluate!!(args...)`. I think this behaviour is quite dangerous (https://github.com/TuringLang/DynamicPPL.jl/pull/629) and even in that PR it was mentioned that we should be more explicit about what args we take, which I fully agree with.

Along with cleaning up `evaluate!!`, this PR also cleans up models as callables such that the only allowed signatures are `model()`, `model(rng)`, `model(varinfo)`, and `model(rng, varinfo)`. Thus you are no longer allowed to specify a context (you should `contextualize` the model instead), or a sampler (the default sampler was `SampleFromPrior()` and given that `model(...)` was always being used to sample from the prior, it seems _hugely_ unlikely that anybody was really passing a different sampler, and if they were, they can jolly well call `first(DynamicPPL.sample!!(rng, model, varinfo, sampler))`).

### Remaining test failure

The remaining test failure (Julia-pre) is unrelated to this PR.

Closes #720
Closes #951 