### PR TITLE
Add `Const` annotation for Enzyme

### DIFF
--- a/test/integration/enzyme/main.jl
+++ b/test/integration/enzyme/main.jl
@@ -2,12 +2,14 @@ using DynamicPPL.TestUtils: DEMO_MODELS
 using DynamicPPL.TestUtils.AD: run_ad
 using ADTypes: AutoEnzyme
 using Test: @test, @testset
-import Enzyme: set_runtime_activity, Forward, Reverse
+import Enzyme: set_runtime_activity, Forward, Reverse, Const
 using ForwardDiff: ForwardDiff  # run_ad uses FD for correctness test
 
 ADTYPES = Dict(
-    "EnzymeForward" => AutoEnzyme(; mode=set_runtime_activity(Forward)),
-    "EnzymeReverse" => AutoEnzyme(; mode=set_runtime_activity(Reverse)),
+    "EnzymeForward" =>
+        AutoEnzyme(; mode=set_runtime_activity(Forward), function_annotation=Const),
+    "EnzymeReverse" =>
+        AutoEnzyme(; mode=set_runtime_activity(Reverse), function_annotation=Const),
 )
 
 @testset "$ad_key" for (ad_key, ad_type) in ADTYPES


### PR DESCRIPTION
This makes Enzyme happy enough to start an attempt at doing AD. It still fails (on DPPL 0.37), but that's already been reported upstream.

Once it starts passing, though, I'll need to benchmark it to see whether the closure is better or not.