### PR TITLE
Fix missing field tests for 1.12

### DIFF
--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -211,10 +211,12 @@ end
             ),
         )
         @test getlogprior(vi) == lp_a + lp_b
-        @test_throws "has no field LogLikelihood" getloglikelihood(vi)
-        @test_throws "has no field LogLikelihood" getlogp(vi)
-        @test_throws "has no field LogLikelihood" getlogjoint(vi)
-        @test_throws "has no field NumProduce" get_num_produce(vi)
+        # need regex because 1.11 and 1.12 throw different errors (in 1.12 the
+        # missing field is surrounded by backticks)
+        @test_throws r"has no field `?LogLikelihood" getloglikelihood(vi)
+        @test_throws r"has no field `?LogLikelihood" getlogp(vi)
+        @test_throws r"has no field `?LogLikelihood" getlogjoint(vi)
+        @test_throws r"has no field `?NumProduce" get_num_produce(vi)
         @test begin
             vi = acclogprior!!(vi, 1.0)
             getlogprior(vi) == lp_a + lp_b + 1.0
@@ -229,20 +231,24 @@ end
                 m, DynamicPPL.setaccs!!(deepcopy(vi), (NumProduceAccumulator(),))
             ),
         )
-        @test_throws "has no field LogPrior" getlogprior(vi)
-        @test_throws "has no field LogLikelihood" getloglikelihood(vi)
-        @test_throws "has no field LogPrior" getlogp(vi)
-        @test_throws "has no field LogPrior" getlogjoint(vi)
+        # need regex because 1.11 and 1.12 throw different errors (in 1.12 the
+        # missing field is surrounded by backticks)
+        @test_throws r"has no field `?LogPrior" getlogprior(vi)
+        @test_throws r"has no field `?LogLikelihood" getloglikelihood(vi)
+        @test_throws r"has no field `?LogPrior" getlogp(vi)
+        @test_throws r"has no field `?LogPrior" getlogjoint(vi)
         @test get_num_produce(vi) == 2
 
         # Test evaluating without any accumulators.
         vi = last(DynamicPPL.evaluate!!(m, DynamicPPL.setaccs!!(deepcopy(vi), ())))
-        @test_throws "has no field LogPrior" getlogprior(vi)
-        @test_throws "has no field LogLikelihood" getloglikelihood(vi)
-        @test_throws "has no field LogPrior" getlogp(vi)
-        @test_throws "has no field LogPrior" getlogjoint(vi)
-        @test_throws "has no field NumProduce" get_num_produce(vi)
-        @test_throws "has no field NumProduce" reset_num_produce!!(vi)
+        # need regex because 1.11 and 1.12 throw different errors (in 1.12 the
+        # missing field is surrounded by backticks)
+        @test_throws r"has no field `?LogPrior" getlogprior(vi)
+        @test_throws r"has no field `?LogLikelihood" getloglikelihood(vi)
+        @test_throws r"has no field `?LogPrior" getlogp(vi)
+        @test_throws r"has no field `?LogPrior" getlogjoint(vi)
+        @test_throws r"has no field `?NumProduce" get_num_produce(vi)
+        @test_throws r"has no field `?NumProduce" reset_num_produce!!(vi)
     end
 
     @testset "flags" begin


### PR DESCRIPTION
Julia 1.12 improved the error message obtained when trying to access the field of a NamedTuple that didn't exist:

(1.11)

```julia
julia> (; a=1).b
ERROR: type NamedTuple has no field b
Stacktrace:
 [1] getproperty(x::@NamedTuple{a::Int64}, f::Symbol)
   @ Base ./Base.jl:49
 [2] top-level scope
   @ REPL[1]:1
```

(1.12)

```julia
julia> (; a=1).b
ERROR: FieldError: type NamedTuple has no field `b`, available fields: `a`
Stacktrace:
 [1] getproperty(x::@NamedTuple{a::Int64}, f::Symbol)
   @ Base ./Base_compiler.jl:54
 [2] top-level scope
   @ REPL[1]:1
```

This PR fixes a test that was checking the error message being thrown.