### PR TITLE
Improve API for AD testing

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -18,7 +18,6 @@ There is now also an `rng` keyword argument to help seed parameter generation.
 
 Finally, instead of specifying `value_atol` and `grad_atol`, you can now specify `atol` and `rtol` which are used for both value and gradient.
 Their semantics are the same as in Julia's `isapprox`; two values are equal if they satisfy either `atol` or `rtol`.
-Note that gradients are always compared elementwise (instead of using the norm, which is what `isapprox` does).
 
 ### Accumulators
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,12 @@
 
 The `@submodel` macro is fully removed; please use `to_submodel` instead.
 
+### `DynamicPPL.TestUtils.AD.run_ad`
+
+The three keyword arguments, `test`, `reference_backend`, and `expected_value_and_grad` have been merged into a single `test` keyword argument.
+Please see the API documentation for more details.
+(The old `test=true` and `test=false` values are still valid, and you only need to adjust the invocation if you were explicitly passing the `reference_backend` or `expected_value_and_grad` arguments.)
+
 ### Accumulators
 
 This release overhauls how VarInfo objects track variables such as the log joint probability. The new approach is to use what we call accumulators: Objects that the VarInfo carries on it that may change their state at each `tilde_assume!!` and `tilde_observe!!` call based on the value of the variable in question. They replace both variables that were previously hard-coded in the `VarInfo` object (`logp` and `num_produce`) and some contexts. This brings with it a number of breaking changes:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,12 @@ The three keyword arguments, `test`, `reference_backend`, and `expected_value_an
 Please see the API documentation for more details.
 (The old `test=true` and `test=false` values are still valid, and you only need to adjust the invocation if you were explicitly passing the `reference_backend` or `expected_value_and_grad` arguments.)
 
+There is now also an `rng` keyword argument to help seed parameter generation.
+
+Finally, instead of specifying `value_atol` and `grad_atol`, you can now specify `atol` and `rtol` which are used for both value and gradient.
+Their semantics are the same as in Julia's `isapprox`; two values are equal if they satisfy either `atol` or `rtol`.
+Note that gradients are always compared elementwise (instead of using the norm, which is what `isapprox` does).
+
 ### Accumulators
 
 This release overhauls how VarInfo objects track variables such as the log joint probability. The new approach is to use what we call accumulators: Objects that the VarInfo carries on it that may change their state at each `tilde_assume!!` and `tilde_observe!!` call based on the value of the variable in question. They replace both variables that were previously hard-coded in the `VarInfo` object (`logp` and `num_produce`) and some contexts. This brings with it a number of breaking changes:

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -211,6 +211,21 @@ To test and/or benchmark the performance of an AD backend on a model, DynamicPPL
 
 ```@docs
 DynamicPPL.TestUtils.AD.run_ad
+```
+
+THe default test setting is to compare against ForwardDiff.
+You can have more fine-grained control over how to test the AD backend using the following types:
+
+```@docs
+DynamicPPL.TestUtils.AD.AbstractADCorrectnessTestSetting
+DynamicPPL.TestUtils.AD.WithBackend
+DynamicPPL.TestUtils.AD.WithExpectedResult
+DynamicPPL.TestUtils.AD.NoTest
+```
+
+These are returned / thrown by the `run_ad` function:
+
+```@docs
 DynamicPPL.TestUtils.AD.ADResult
 DynamicPPL.TestUtils.AD.ADIncorrectException
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -213,7 +213,7 @@ To test and/or benchmark the performance of an AD backend on a model, DynamicPPL
 DynamicPPL.TestUtils.AD.run_ad
 ```
 
-THe default test setting is to compare against ForwardDiff.
+The default test setting is to compare against ForwardDiff.
 You can have more fine-grained control over how to test the AD backend using the following types:
 
 ```@docs

--- a/src/test_utils/ad.jl
+++ b/src/test_utils/ad.jl
@@ -103,9 +103,9 @@ struct ADResult{Tparams<:AbstractFloat,Tresult<:AbstractFloat,Ttol<:AbstractFloa
     "The expected gradient of logp"
     grad_expected::Union{Nothing,Vector{Tresult}}
     "The value of logp (calculated using `adtype`)"
-    value_actual::Union{Nothing,Tresult}
+    value_actual::Tresult
     "The gradient of logp (calculated using `adtype`)"
-    grad_actual::Union{Nothing,Vector{Tresult}}
+    grad_actual::Vector{Tresult}
     "If benchmarking was requested, the time taken by the AD backend to calculate the gradient of logp, divided by the time taken to evaluate logp itself"
     time_vs_primal::Union{Nothing,Tresult}
 end

--- a/src/test_utils/ad.jl
+++ b/src/test_utils/ad.jl
@@ -6,7 +6,7 @@ import DifferentiationInterface as DI
 using DocStringExtensions
 using DynamicPPL: Model, LogDensityFunction, VarInfo, AbstractVarInfo, link
 using LogDensityProblems: logdensity, logdensity_and_gradient
-using Random: Random, Xoshiro
+using Random: AbstractRNG, default_rng
 using Statistics: median
 using Test: @test
 
@@ -160,8 +160,8 @@ Everything else is optional, and can be categorised into several groups:
 
    Note that if the VarInfo is not specified (and thus automatically generated)
    the parameters in it will have been sampled from the prior of the model. If
-   you want to seed the parameter generation, the easiest way is to pass a
-   `rng` argument to the VarInfo constructor (i.e. do `VarInfo(rng, model)`).
+   you want to seed the parameter generation for the VarInfo, you can pass the
+   `rng` keyword argument, which will then be used to create the VarInfo.
 
    Finally, note that these only reflect the parameters used for _evaluating_
    the gradient. If you also want to control the parameters used for
@@ -214,7 +214,8 @@ function run_ad(
     benchmark::Bool=false,
     value_atol::AbstractFloat=1e-6,
     grad_atol::AbstractFloat=1e-6,
-    varinfo::AbstractVarInfo=link(VarInfo(model), model),
+    rng::AbstractRNG=default_rng(),
+    varinfo::AbstractVarInfo=link(VarInfo(rng, model), model),
     params::Union{Nothing,Vector{<:AbstractFloat}}=nothing,
     verbose=true,
 )::ADResult

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -52,17 +52,17 @@ using DynamicPPL.TestUtils.AD: run_ad, WithExpectedResult, NoTest
                     if is_mooncake && is_1_11 && is_svi_vnv
                         # https://github.com/compintell/Mooncake.jl/issues/470
                         @test_throws ArgumentError DynamicPPL.LogDensityFunction(
-                            ref_ldf, adtype
+                            m, linked_varinfo; adtype=adtype
                         )
                     elseif is_mooncake && is_1_10 && is_svi_vnv
                         # TODO: report upstream
                         @test_throws UndefRefError DynamicPPL.LogDensityFunction(
-                            ref_ldf, adtype
+                            m, linked_varinfo; adtype=adtype
                         )
                     elseif is_mooncake && is_1_10 && is_svi_od
                         # TODO: report upstream
                         @test_throws Mooncake.MooncakeRuleCompilationError DynamicPPL.LogDensityFunction(
-                            ref_ldf, adtype
+                            m, linked_varinfo; adtype=adtype
                         )
                     else
                         @test run_ad(


### PR DESCRIPTION
This PR makes some fairly overdue improvements to the API of `DynamicPPL.TestUtils.AD.run_ad`.

**`rng` argument**

A `rng` keyword argument is provided to make it easier to seed the parameters used for running AD. Previously, if you wanted to make sure that two calls to `run_ad` used the same parameters (but you didn't care _what_ parameters they were, just that they were the same!), you had to do:

```julia
rng = Xoshiro(468)
v = DynamicPPL.link(VarInfo(rng, model), model)
xs = v[:]

run_ad(model, adtype1; varinfo=v, params=xs)
run_ad(model, adtype2; varinfo=v, params=xs)
```

Now you can do:

```julia
run_ad(model, adtype1; rng=Xoshiro(468))
run_ad(model, adtype2; rng=Xoshiro(468))
```

I made `rng` a keyword argument rather than a positional argument because I consider `rng`-as-first-argument to be a multiple dispatch abuse anti-pattern, i.e., it serves no purpose except to force someone to declare a new method.

Closes #962

**Correctness testing**

Previously the `test`, `reference_backend`, and `expected_value_and_grad` keyword arguments all served the same purpose and it was not clear when one would supersede the other (e.g. if you put `test=false`, `reference_backend=AutoForwardDiff()`, and `expected_value_and_grad=(value, grad)` it was unclear whether it would skip testing, compare against ForwardDiff, or compare against the explicitly specified values).

I originally made this design choice to avoid having to make my own types (which would be some boilerplate and annoying for downstream users to import), but over the course of using this function (especially in ADTests) I have found the annoyance of not having a clear API to be bigger than the annoyance of adding some more imports.

This PR fixes it so that you can't specify multiple of these at the same time.

**Tolerances**

Previously, it was only possible to specify the `atol` used for testing; `rtol` could not be configured (and would default to zero, because that's what `isapprox` does when given a non-zero atol). This caused problems such as https://github.com/TuringLang/ADTests/issues/33. This PR fixes it such that testing happens with nonzero atol and rtol (which can both be configured).

Closes #963 