### PR TITLE
Improve returned() documentation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # DynamicPPL Changelog
 
+## 0.36.13
+
+Added documentation for the `returned(::Model, ::MCMCChains.Chains)` method.
+
 ## 0.36.12
 
 Removed several unexported functions.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.36.12"
+version = "0.36.13"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -166,9 +166,10 @@ It is possible to manually increase (or decrease) the accumulated log density fr
 @addlogprob!
 ```
 
-Return values of the model function for a collection of samples can be obtained with [`returned(model, chain)`](@ref).
+Return values of the model function can be obtained with [`returned(model, sample)`](@ref), where `sample` is either a `MCMCChains.Chains` object (which represents a collection samples) or a single sample represented as a `NamedTuple`.
 
 ```@docs
+returned(::DynamicPPL.Model, ::MCMCChains.Chains)
 returned(::DynamicPPL.Model, ::NamedTuple)
 ```
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -166,7 +166,7 @@ It is possible to manually increase (or decrease) the accumulated log density fr
 @addlogprob!
 ```
 
-Return values of the model function can be obtained with [`returned(model, sample)`](@ref), where `sample` is either a `MCMCChains.Chains` object (which represents a collection samples) or a single sample represented as a `NamedTuple`.
+Return values of the model function can be obtained with [`returned(model, sample)`](@ref), where `sample` is either a `MCMCChains.Chains` object (which represents a collection of samples) or a single sample represented as a `NamedTuple`.
 
 ```@docs
 returned(::DynamicPPL.Model, ::MCMCChains.Chains)


### PR DESCRIPTION
The specific method `returned(::Model, ::MCMCChains.Chains)` wasn't documented, even though this is probably the primary usage of `returned`. This fixes it.

Bumped patch so that the `stable` version of the online docs can be updated (otherwise it'll only live in the `dev` docs).