### PR TITLE
Fix MooncakeExt for 0.4.147

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # DynamicPPL Changelog
 
+## 0.37.1
+
+Update DynamicPPLMooncakeExt to work with Mooncake 0.4.147.
+
 ## 0.37.0
 
 DynamicPPL 0.37 comes with a substantial reworking of its internals.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.37.0"
+version = "0.37.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -67,7 +67,7 @@ LinearAlgebra = "1.6"
 LogDensityProblems = "2"
 MCMCChains = "6, 7"
 MacroTools = "0.5.6"
-Mooncake = "0.4.95"
+Mooncake = "0.4.147"
 OrderedCollections = "1"
 Printf = "1.10"
 Random = "1.6"

--- a/ext/DynamicPPLMooncakeExt.jl
+++ b/ext/DynamicPPLMooncakeExt.jl
@@ -4,6 +4,6 @@ using DynamicPPL: DynamicPPL, istrans
 using Mooncake: Mooncake
 
 # This is purely an optimisation.
-Mooncake.@zero_adjoint Mooncake.DefaultCtx Tuple{typeof(istrans),Vararg}
+Mooncake.@zero_derivative Mooncake.DefaultCtx Tuple{typeof(istrans),Vararg}
 
 end # module


### PR DESCRIPTION
`@zero_adjoint` only works for reverse-mode, the replacement is `@zero_derivative` which works for both forwards- and reverse-mode. See https://chalk-lab.github.io/Mooncake.jl/stable/developer_documentation/internal_docstrings/#Mooncake.@zero_adjoint-Tuple{Any,%20Any}

This is required because `Mooncake.TestUtil.test_rule` by default now tests both forwards- and reverse-mode, so to get the following test to pass we need to change the original definition.

https://github.com/TuringLang/DynamicPPL.jl/blob/6742812d664beb0a6e30ff56c005941ea4bd8fab/test/ext/DynamicPPLMooncakeExt.jl#L1-L5