### PR TITLE
Remove unneeded argument from default_accumulators()

### DIFF
--- a/src/default_accumulators.jl
+++ b/src/default_accumulators.jl
@@ -165,9 +165,7 @@ function accumulate_observe!!(acc::LogLikelihoodAccumulator, right, left, vn)
     return acclogp(acc, Distributions.loglikelihood(right, left))
 end
 
-function default_accumulators(
-    ::Type{FloatT}=LogProbType, ::Type{IntT}=Int
-) where {FloatT,IntT}
+function default_accumulators(::Type{FloatT}=LogProbType) where {FloatT}
     return AccumulatorTuple(
         LogPriorAccumulator{FloatT}(),
         LogJacobianAccumulator{FloatT}(),


### PR DESCRIPTION
`default_accumulators()` no longer needs an integer type because it was only used for num_produce which is now gone.

This is too trivial a change so I won't bother making a release