### PR TITLE
Fix CI for 1.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,10 @@ jobs:
           - version: 'min'
             os: ubuntu-latest
             num_threads: 2
+          # 1.11
+          - version: '1.11'
+            os: ubuntu-latest
+            num_threads: 2
           # Single-threaded
           - version: '1'
             os: ubuntu-latest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,9 +36,9 @@ using DynamicPPL: getargs_dottilde, getargs_tilde
 const GROUP = get(ENV, "GROUP", "All")
 const AQUA = get(ENV, "AQUA", "true") == "true"
 
-# Detect if prerelease version, if so, we skip some tests
-const IS_PRERELEASE = !isempty(VERSION.prerelease)
-if !IS_PRERELEASE
+# Skip Mooncake if it doesn't work
+const MOONCAKE_SUPPORTED = VERSION < v"1.12.0"
+if MOONCAKE_SUPPORTED
     Pkg.add("Mooncake")
     using Mooncake: Mooncake
 end


### PR DESCRIPTION
1.11 tests have been silently bumped to 1.12. This PR:

- Adds one set of 1.11 tests
- Disables Mooncake on 1.12, since it doesn't work yet