### PR TITLE
tidy integration test workflow

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: julia-actions/setup-julia@v2
         with:
-          version: 1.11
+          version: 1
 
       - uses: julia-actions/julia-buildpkg@v1
 


### PR DESCRIPTION
there was a check against 1.12.0, but 1.12.1 dropped already so this shouldn't be the case. the tests used to be failing but that's because it was loading mooncake, which i disabled in https://github.com/TuringLang/Turing.jl/pull/2705, so fingers crossed the integration test passes this time