### PR TITLE
Fix potential undefined variable in model compiler output

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # DynamicPPL Changelog
 
+## 0.38.7
+
+Made a small tweak to DynamicPPL's compiler output to avoid potential undefined variables when resuming model functions midway through (e.g. with Libtask in Turing's SMC/PG samplers).
+
 ## 0.38.6
 
 Renamed keyword argument `only_ddpl` to `only_dppl` for `Experimental.is_suitable_varinfo`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.38.6"
+version = "0.38.7"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -461,9 +461,16 @@ function generate_tilde(left, right)
         elseif $isassumption
             $(generate_tilde_assume(left, dist, vn))
         else
-            # If `vn` is not in `argnames`, we need to make sure that the variable is defined.
-            if !$(DynamicPPL.inargnames)($vn, __model__)
-                $left = $(DynamicPPL.getconditioned_nested)(
+            # If `vn` is not in `argnames`, then it's definitely been conditioned on (if
+            # it's not in `argnames` and wasn't conditioned on, then `isassumption` would
+            # be true).
+            $left = if $(DynamicPPL.inargnames)($vn, __model__)
+                # This is a no-op and looks redundant, but defining the compiler output this
+                # way ensures that the variable `$left` is always defined. See
+                # https://github.com/TuringLang/DynamicPPL.jl/pull/1110.
+                $left
+            else
+                $(DynamicPPL.getconditioned_nested)(
                     __model__.context, $(DynamicPPL.prefix)(__model__.context, $vn)
                 )
             end


### PR DESCRIPTION
Fixes https://github.com/TuringLang/Libtask.jl/issues/200.

# What does this change?

To see what's different, consider the output of

```julia
@macroexpand @model function f(x)
    b ~ Normal()
    y ~ MvNormal([b], I)
end
```

Before this PR, this gives something like this for the `y ~ MvNormal(...)` line:

```julia
if isfixed(...)
elseif isassumption(...)
    ...
else
    if !((DynamicPPL.inargnames)(@varname(y), __model__))
        y = (DynamicPPL.getconditioned_nested)(__model__.context, (prefix)(__model__.context, @varname(y)))
    end
    DynamicPPL.tilde_observe!!(..., DynamicPPL.check_tilde_rhs(...), ..., y, ...)
    ...
end
```

This PR changes it to something like this:

```julia
if isfixed(...)
elseif isassumption(...)
    ...
else
    y = if !((DynamicPPL.inargnames)(@varname(y), __model__))
        (DynamicPPL.getconditioned_nested)(__model__.context, (prefix)(__model__.context, @varname(y)))
    else
        y
    end
    DynamicPPL.tilde_observe!!(..., DynamicPPL.check_tilde_rhs(...), ..., y, ...)
    ...
end
```

From DynamicPPL's point of view this is entirely equivalent, and indeed both model functions work perfectly fine, if you execute them one time from front to back.

# Why?

The problem (as seen in https://github.com/TuringLang/Libtask.jl/issues/200) comes with two things:

Firstly, when the Julia code in the first example is lowered to SSA IR, the compiler inserts a check right before `tilde_observe!!` which throws an error if `!inargnames(...)` was true and if `y` is undefined. I don't know exactly why this is needed, but it makes sense that if the `y = DynamicPPL.getconditioned...` line was executed, then `y` must be defined.

The IR looks something like this. The check is in the second-last line, and the value of `%58` is (ultimately) derived from `%52`, which is `!inargnames(...)`.

```julia
  25 ─ %52 = (DynamicPPL.inargnames)(%22, _2)::Any
  │    %53 = !%52::Any
  └───       goto #27 if not %53
  26 ─ %55 = Base.getfield(_2, :context)::DynamicPPL.ConditionContext{..}
  └─── %56 = (DynamicPPL.getconditioned_nested)(%55, %22)::Any
  27 ┄ %57 = φ (#26 => %56, #25 => #undef)::Any
  │    %58 = φ (#26 => true, #25 => false)::Bool
  │    %59 = Base.getfield(_2, :context)::DynamicPPL.ConditionContext{...}
  │    %60 = (DynamicPPL.check_tilde_rhs)(%14)::Any
  │          $(Expr(:throw_undef_if_not, :y, :(%58)))::Any
  │    %62 = (DynamicPPL.tilde_observe!!)(%59, %60, %57, %22, %12)::Tuple{Any, Any}
```

Secondly, when Libtask makes a resumable task out of this, it doesn't know whether `check_tilde_rhs` "produces". (See also footnote.) That means that it has to insert a resume point between the `check_tilde_rhs` and the call to `:throw_undef_if_not`.

The problem with this is, if `check_tilde_rhs` _indeed_ produces, then when we resume the function, we'll jump straight to the `throw_undef_if_not` call. But if we jump in here, `%58` is not defined, because we haven't run the `inargnames` check!

With this PR, it ensures that `y` is always defined regardless of whether it's inargnames or not. That means that the compiler doesn't insert the `throw_undef_if_not` line into the IR, and it means that Libtask doesn't fall over.

# Notes

1. It seems odd to me that Libtask checks whether `check_tilde_rhs` returns a `ProducedValue`. I thought that this was opt-in, i.e. by default it should assume that `check_tilde_rhs` doesn't return a `ProducedValue` unless we declared it with `might_produce`. But this requires more knowledge of Libtask internals than I have right now.

2. Identifying the root cause also allows us to [construct a Turing-free MWE for the same issue](https://github.com/TuringLang/Libtask.jl/issues/204). One could argue that this is really an upstream bug, but fixing that will probably be substantially more difficult (and perhaps impossible).

3. In either case, I think it's just a good idea to fix it in DynamicPPL anyway because having variables that are only sometimes defined is not good (JET has also started to complain about these more often). I have a suspicion that the compiler's `throw_undef_if_not` is precisely what stops JET from complaining about it in this case (since we do run JET tests on model outputs).

4. One might wonder why Libtask only errored with specific models. I think that it's because for simpler models, the `inargnames` check (or possibly something at an even higher level, like `isassumption`) can be completely compiled away and so the emitted IR doesn't have this structure.