### PR TITLE
Allow gradient on LDF to be called with e.g. views

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # DynamicPPL Changelog
 
+## 0.39.1
+
+`LogDensityFunction` now allows you to call `logdensity_and_gradient(ldf, x)` with `AbstractVector`s `x` that are not plain Vectors (they will be converted internally before calculating the gradient).
+
 ## 0.39.0
 
 ### Breaking changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.39.0"
+version = "0.39.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/test/logdensityfunction.jl
+++ b/test/logdensityfunction.jl
@@ -186,6 +186,25 @@ end
         end
     end
 
+    @testset "logdensity_and_gradient with views" begin
+        # This test ensures that you can call `logdensity_and_gradient` with an array 
+        # type that isn't the same as the one used in the gradient preparation.
+        @model function f()
+            x ~ Normal()
+            return y ~ Normal()
+        end
+        @testset "$adtype" for adtype in test_adtypes
+            x = randn(2)
+            ldf = LogDensityFunction(f(); adtype)
+            logp, grad = LogDensityProblems.logdensity_and_gradient(ldf, x)
+            logp_view, grad_view = LogDensityProblems.logdensity_and_gradient(
+                ldf, (@view x[:])
+            )
+            @test logp == logp_view
+            @test grad == grad_view
+        end
+    end
+
     # Test that various different ways of specifying array types as arguments work with all
     # ADTypes.
     @testset "Array argument types" begin


### PR DESCRIPTION
I benchmarked locally and didn't find any performance regression on the normal Vector use case (since `convert` is just a no-op).