### PR TITLE
Add more logging for `run_ad`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # DynamicPPL Changelog
 
+## 0.39.3
+
+`DynamicPPL.TestUtils.AD.run_ad` now generates much prettier output.
+In particular, when a test fails, it also tells you the tolerances needed to make it pass.
+
 ## 0.39.2
 
 `returned(model, parameters...)` now accepts any arguments that can be wrapped in `InitFromParams` (previously it would only accept `NamedTuple`, `AbstractDict{<:VarName}`, or a chain).

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.39.2"
+version = "0.39.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Closes #1166. Example code which you can run is here. On main, these will both print out gigantic ugly structs using their default display methods.

```julia
using DynamicPPL, Distributions, ADTypes, FiniteDifferences, ForwardDiff, Random
using DynamicPPL.TestUtils.AD: run_ad, ADResult, WithBackend

ref_adtype = AutoFiniteDifferences(fdm=central_fdm(5, 1))
adtype = AutoForwardDiff()

@model function f()
    a ~ Normal()
    2.0 ~ Normal(a)
end
model = f()

# This is an example of a successful test.
run_ad(model, adtype; rng=Xoshiro(468), test=WithBackend(ref_adtype), benchmark=true)

# This is an example of a "failed" test (rtol should never be set to be so small).
run_ad(model, adtype; rng=Xoshiro(468), test=WithBackend(ref_adtype), rtol=eps())
```

The successful test now outputs the following. The lines up until ADResult are logging generated during the call itself (which can be disabled with `verbose=true`), after that it's the display method of the `ADResult` struct.

```julia
julia> run_ad(model, adtype; rng=Xoshiro(468), test=WithBackend(ref_adtype), benchmark=true)
[ Info: Running AD on f with AutoForwardDiff()
       params : [0.07200886749732076]
       actual : (-3.699044608412951, [1.8559822650053586])
     expected : (-3.699044608412951, [1.8559822650053162])
   evaluation : 11.871 ns (1 allocs: 32 bytes)
     gradient : 48.126 ns (4 allocs: 144 bytes)
  grad / eval : 4.054
ADResult
  ├ model          : f
  ├ adtype         : AutoForwardDiff()
  ├ value_actual   : -3.699044608412951
  ├ value_expected : -3.699044608412951
  ├ grad_actual    : [1.8559822650053586]
  ├ grad_expected  : [1.8559822650053162]
  ├ grad_time      : 4.812606473594549e-8 s
  ├ primal_time    : 1.1870939420544339e-8 s
  └ params         : [0.07200886749732076]
```

This is the failing test, it now tells you how much of an atol/rtol you need to make it pass, which is really useful for figuring out whether you have a serious correctness issue, or whether finite differences are just a bit inaccurate (I've needed to do this for ADTests a few times).

```julia
julia> run_ad(model, adtype; rng=Xoshiro(468), test=WithBackend(ref_adtype), rtol=eps())
[ Info: Running AD on f with AutoForwardDiff()
       params : [0.07200886749732076]
       actual : (-3.699044608412951, [1.8559822650053586])
     expected : (-3.699044608412951, [1.8559822650053162])
ERROR: ADIncorrectException: The AD backend returned an incorrect gradient.
  Testing was carried out with
               atol : 2.220446049250313e-14
               rtol : 2.220446049250313e-16
  The gradient check failed because:
      expected grad : [1.8559822650053586]
        actual grad : [1.8559822650053162]
  The gradient correctness check would have passed if either:
               atol ≥ 4.241051954068098e-14, or
               rtol ≥ 2.2850713792008425e-14

Stacktrace:
 [1] (::DynamicPPL.TestUtils.AD.var"#exc#4"{Float64, Float64, Float64})()
   @ DynamicPPL.TestUtils.AD ~/ppl/dppl/src/test_utils/ad.jl:369
 [2] run_ad(model::Model{…}, adtype::AutoForwardDiff{…}; test::WithBackend{…}, benchmark::Bool, atol::Float64, rtol::Float64, getlogdensity::Function, rng::Xoshiro, varinfo::VarInfo{…}, params::Nothing, verbose::Bool)
   @ DynamicPPL.TestUtils.AD ~/ppl/dppl/src/test_utils/ad.jl:371
 [3] top-level scope
   @ REPL[8]:1
Some type information was truncated. Use `show(err)` to see complete types.
```