### PR TITLE
Enable the option to switch between differentiating a closure, and a function with constant arguments

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # DynamicPPL Changelog
 
+## 0.39.9
+
+The internals of `LogDensityFunction` have been changed slightly so that you do not need to specify `function_annotation` when performing AD with Enzyme.jl.
+There are also some small performance improvements with other AD backends.
+
 ## 0.39.8
 
 Allow the `getlogdensity` argument of `LogDensityFunction` to accept callable structs as well as functions.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -34,6 +34,8 @@ In particular, when a test fails, it also tells you the tolerances needed to mak
 
 `returned(model, parameters...)` now accepts any arguments that can be wrapped in `InitFromParams` (previously it would only accept `NamedTuple`, `AbstractDict{<:VarName}`, or a chain).
 
+There should also be some minor performance improvements (maybe 10%) on AD with ForwardDiff / Mooncake.
+
 ## 0.39.1
 
 `LogDensityFunction` now allows you to call `logdensity_and_gradient(ldf, x)` with `AbstractVector`s `x` that are not plain Vectors (they will be converted internally before calculating the gradient).

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.39.8"
+version = "0.39.9"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/logdensityfunction.jl
+++ b/src/logdensityfunction.jl
@@ -388,30 +388,27 @@ tweak_adtype(adtype::ADTypes.AbstractADType, ::Model, ::AbstractVarInfo) = adtyp
 """
     _use_closure(adtype::ADTypes.AbstractADType)
 
-In LogDensityProblems, we want to calculate the derivative of logdensity(f, x)
-with respect to x, where f is the model (in our case LogDensityFunction) and is
-a constant. However, DifferentiationInterface generally expects a
-single-argument function g(x) to differentiate.
+In LogDensityProblems, we want to calculate the derivative of `logdensity(f, x)` with
+respect to x, where f is the model (in our case LogDensityFunction or its arguments ) and is
+a constant. However, DifferentiationInterface generally expects a single-argument function
+g(x) to differentiate.
 
 There are two ways of dealing with this:
 
 1. Construct a closure over the model, i.e. let g = Base.Fix1(logdensity, f)
 
-2. Use a constant DI.Context. This lets us pass a two-argument function to DI,
-   as long as we also give it the 'inactive argument' (i.e. the model) wrapped
-   in `DI.Constant`.
+2. Use a constant DI.Context. This lets us pass a two-argument function to DI, as long as we
+   also give it the 'inactive argument' (i.e. the model) wrapped in `DI.Constant`.
 
-The relative performance of the two approaches, however, depends on the AD
-backend used. Some benchmarks are provided here:
-https://github.com/TuringLang/DynamicPPL.jl/issues/946#issuecomment-2931604829
+The relative performance of the two approaches, however, depends on the AD backend used.
+Some benchmarks are provided here: https://github.com/TuringLang/DynamicPPL.jl/pull/1172
 
-This function is used to determine whether a given AD backend should use a
-closure or a constant. If `use_closure(adtype)` returns `true`, then the
-closure approach will be used. By default, this function returns `false`, i.e.
-the constant approach will be used.
+This function is used to determine whether a given AD backend should use a closure or a
+constant. If `use_closure(adtype)` returns `true`, then the closure approach will be used.
+By default, this function returns `false`, i.e. the constant approach will be used.
 """
 # For these AD backends both closure and no closure work, but it is just faster to not use a
-# closure 
+# closure (see link in the docstring).
 _use_closure(::ADTypes.AutoForwardDiff) = false
 _use_closure(::ADTypes.AutoMooncake) = false
 _use_closure(::ADTypes.AutoMooncakeForward) = false

--- a/test/integration/enzyme/main.jl
+++ b/test/integration/enzyme/main.jl
@@ -6,14 +6,8 @@ import Enzyme: set_runtime_activity, Forward, Reverse, Const
 using ForwardDiff: ForwardDiff  # run_ad uses FD for correctness test
 
 ADTYPES = (
-    (
-        "EnzymeForward",
-        AutoEnzyme(; mode=set_runtime_activity(Forward), function_annotation=Const),
-    ),
-    (
-        "EnzymeReverse",
-        AutoEnzyme(; mode=set_runtime_activity(Reverse), function_annotation=Const),
-    ),
+    ("EnzymeForward", AutoEnzyme(; mode=set_runtime_activity(Forward))),
+    ("EnzymeReverse", AutoEnzyme(; mode=set_runtime_activity(Reverse))),
 )
 
 @testset "$ad_key" for (ad_key, ad_type) in ADTYPES


### PR DESCRIPTION
Prior to 'fast' LDF (i.e. in DynamicPPL < 0.38) there were two different functions that were differentiated through when performing `LogDensityFunctions.logdensity_and_gradient`: one was a multi-argument function `f(x, c1, c2, c3, ...)` where `x` is the active argument, and one was a callable struct `F(x)` where `F` closed over the inactive arguments `c1, c2, c3`. See https://github.com/TuringLang/DynamicPPL.jl/pull/806 and https://github.com/TuringLang/DynamicPPL.jl/pull/922 for previous history, and [the old version of `src/logdensityfunction.jl` here](https://github.com/TuringLang/DynamicPPL.jl/blob/6c615ad41946ffa11698408948f85cd4606262ff/src/logdensityfunction.jl#L225-L264).

This feature was not ported over to FastLDF in #1139, which is probably an example of laziness on my part. The benefits of doing this is mainly improved performance, but for Enzyme it also allows us to avoid setting `function_annotation` (see also https://github.com/TuringLang/DynamicPPL.jl/pull/1048).

Here are some benchmarks: `clos` means use the closure, `func` means the original function. As one can see most of the AD backends are faster with the function rather than the closure, hence `_use_closure` is mostly set to `false`. Part of me wonders if sticking an `@inline` on the callable struct might remove this difference, but my industriousness _does_ have a limit.

```julia
# Run this once with `_use_closure` set to true and once with it set to false.

using DynamicPPL, Distributions, ForwardDiff, ReverseDiff, Mooncake, Enzyme, ADTypes, DataFrames
using DynamicPPL.TestUtils.AD: run_ad, ADResult

ADTYPES = Dict(
    "ForwardDiff" => AutoForwardDiff(),
    "ReverseDiff" => AutoReverseDiff(; compile=false),
    "ReverseDiffCompiled" => AutoReverseDiff(; compile=true),
    "MooncakeFwd" => AutoMooncakeForward(),
    "MooncakeRvs" => AutoMooncake(),
)
MODELS = DynamicPPL.TestUtils.DEMO_MODELS

RESULTS = []
for model in MODELS
    for (adtype_name, adtype) in ADTYPES
        result = run_ad(model, adtype; benchmark=true)
        push!(RESULTS, (model="$(model.f)", adtype=adtype_name, time=(result.grad_time / result.primal_time)))
    end
end
RESULT_DF = DataFrame(RESULTS)

using CSV
CSV.write("results.csv", RESULT_DF)
```

Here `time` refers to the time for gradient divided by time for primal.

```
model                                       adtype               time(clos)   time(func)   clos/func    mean(clos/func)  std(clos/func)
demo_dot_assume_observe                     ForwardDiff          1.525467599  1.274712187  1.196715317  1.194930597      0.142726317
demo_assume_index_observe                   ForwardDiff          1.44429541   1.367799257  1.055926448                   
demo_assume_multivariate_observe            ForwardDiff          1.679705404  1.458947368  1.151313228                   
demo_dot_assume_observe_index               ForwardDiff          2.003910968  1.5681335    1.277895644                   
demo_assume_dot_observe                     ForwardDiff          3.160890644  2.269975335  1.392477969                   
demo_assume_multivariate_observe_literal    ForwardDiff          1.526315789  1.463927463  1.042617089                   
demo_dot_assume_observe_index_literal       ForwardDiff          1.490406868  1.100337767  1.354499421                   
demo_assume_dot_observe_literal             ForwardDiff          2.172935945  2.269538142  0.957435306                   
demo_assume_observe_literal                 ForwardDiff          1.739594118  1.306940931  1.331042648                   
demo_assume_submodel_observe_index_literal  ForwardDiff          1.597721311  1.290655327  1.237914785                   
demo_dot_assume_observe_submodel            ForwardDiff          1.497499745  1.131985731  1.322896308                   
demo_dot_assume_observe_matrix_index        ForwardDiff          1.375612421  1.140178153  1.206489019                   
demo_assume_matrix_observe_matrix_index     ForwardDiff          1.403399928  1.393818007  1.006874585                   
demo_dot_assume_observe                     MooncakeFwd          13.71284271  12.28016878  1.116665655  1.117348426      0.138978196
demo_assume_index_observe                   MooncakeFwd          9.806866033  10.16455696  0.964809983                   
demo_assume_multivariate_observe            MooncakeFwd          14.32729477  13.44351464  1.065740258                   
demo_dot_assume_observe_index               MooncakeFwd          12.99918633  10.98645643  1.183201009                   
demo_assume_dot_observe                     MooncakeFwd          8.9453125    6.336938553  1.411614209                   
demo_assume_multivariate_observe_literal    MooncakeFwd          14.36744828  13.78410311  1.042320139                   
demo_dot_assume_observe_index_literal       MooncakeFwd          12.39047587  11.19519899  1.106766917                   
demo_assume_dot_observe_literal             MooncakeFwd          7.90678468   8.648456658  0.914242274                   
demo_assume_observe_literal                 MooncakeFwd          8.14370993   6.063852475  1.342992753                   
demo_assume_submodel_observe_index_literal  MooncakeFwd          12.37424316  11.59245604  1.0674393                     
demo_dot_assume_observe_submodel            MooncakeFwd          13.58812441  11.94641598  1.137422674                   
demo_dot_assume_observe_matrix_index        MooncakeFwd          14.33099908  12.31012     1.164164044                   
demo_assume_matrix_observe_matrix_index     MooncakeFwd          14.38441882  14.26812892  1.008150326                   
demo_dot_assume_observe                     MooncakeRvs          4.975314511  3.923043303  1.268228293  1.161985086      0.1449571
demo_assume_index_observe                   MooncakeRvs          3.276771572  3.252789532  1.007372761                   
demo_assume_multivariate_observe            MooncakeRvs          5.260503186  4.572033898  1.150582717                   
demo_dot_assume_observe_index               MooncakeRvs          4.566469869  3.630591631  1.257775683                   
demo_assume_dot_observe                     MooncakeRvs          5.616897585  4.911655364  1.143585445                   
demo_assume_multivariate_observe_literal    MooncakeRvs          4.942171437  4.519455416  1.093532513                   
demo_dot_assume_observe_index_literal       MooncakeRvs          4.740758124  3.331779452  1.422890738                   
demo_assume_dot_observe_literal             MooncakeRvs          4.985933104  5.047140831  0.987872792                   
demo_assume_observe_literal                 MooncakeRvs          4.938183576  4.422866152  1.1165121                     
demo_assume_submodel_observe_index_literal  MooncakeRvs          4.572583408  3.873515664  1.18047371                    
demo_dot_assume_observe_submodel            MooncakeRvs          4.389248431  3.8731542    1.133249079                   
demo_dot_assume_observe_matrix_index        MooncakeRvs          5.60766652   4.015870574  1.396376307                   
demo_assume_matrix_observe_matrix_index     MooncakeRvs          4.727606079  4.990326923  0.947353981                   
demo_dot_assume_observe                     ReverseDiff          67.84729114  52.74588235  1.28630498   1.178560687      0.130455839
demo_assume_index_observe                   ReverseDiff          58.17253605  54.37883925  1.069764211                   
demo_assume_multivariate_observe            ReverseDiff          66.15684785  59.30163603  1.115599034                   
demo_dot_assume_observe_index               ReverseDiff          71.56960413  63.23089475  1.131877137                   
demo_assume_dot_observe                     ReverseDiff          157.984494   110.0992542  1.434927922                   
demo_assume_multivariate_observe_literal    ReverseDiff          55.93370698  52.77155172  1.059921589                   
demo_dot_assume_observe_index_literal       ReverseDiff          72.94905858  55.06082648  1.324881286                   
demo_assume_dot_observe_literal             ReverseDiff          103.8512397  96.80268542  1.072813623                   
demo_assume_observe_literal                 ReverseDiff          125.2098441  104.3174019  1.200277632                   
demo_assume_submodel_observe_index_literal  ReverseDiff          67.71928065  57.96516872  1.1682754                     
demo_dot_assume_observe_submodel            ReverseDiff          61.50066487  52.23269152  1.177436258                   
demo_dot_assume_observe_matrix_index        ReverseDiff          60.39138037  46.0713928   1.310821677                   
demo_assume_matrix_observe_matrix_index     ReverseDiff          45.24193548  46.71880176  0.968388182                   
demo_dot_assume_observe                     ReverseDiffCompiled  20.90625     51.28954839  0.407612285  0.367591864      0.052660854
demo_assume_index_observe                   ReverseDiffCompiled  19.2457378   53.7984      0.357738107                   
demo_assume_multivariate_observe            ReverseDiffCompiled  18.49863146  58.35986883  0.316975206                   
demo_dot_assume_observe_index               ReverseDiffCompiled  22.21232631  59.22746781  0.375034205                   
demo_assume_dot_observe                     ReverseDiffCompiled  48.54647089  105.2648943  0.461183866                   
demo_assume_multivariate_observe_literal    ReverseDiffCompiled  15.95453127  53.94781274  0.295740095                   
demo_dot_assume_observe_index_literal       ReverseDiffCompiled  22.12678788  56.35138968  0.39265736                    
demo_assume_dot_observe_literal             ReverseDiffCompiled  36.52301255  96.41645676  0.378804758                   
demo_assume_observe_literal                 ReverseDiffCompiled  42.81327191  95.05131878  0.450422703                   
demo_assume_submodel_observe_index_literal  ReverseDiffCompiled  20.31091181  59.84733874  0.339378696                   
demo_dot_assume_observe_submodel            ReverseDiffCompiled  17.81327801  53.81377064  0.331017095                   
demo_dot_assume_observe_matrix_index        ReverseDiffCompiled  17.93991416  47.62331839  0.376704412                   
demo_assume_matrix_observe_matrix_index     ReverseDiffCompiled  13.98849123  47.35032558  0.29542545                    
```