### PR TITLE
Implement `DynamicPPL.rand_with_logdensity` on `LogDensityFunction`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # DynamicPPL Changelog
 
+## 0.39.6
+
+Introduces a new function, `DynamicPPL.rand_with_logpdf([rng,] ldf[, strategy])`, which allows generating new trial parameter values from a `LogDensityFunction`.
+Previously this would have been accomplished using the `ldf.varinfo` object, but since v0.39 there is no longer a `VarInfo` inside a `LogDensityFunction`, so this function is a direct replacement for that pattern.
+
 ## 0.39.5
 
 Fixed a bug which prevented passing immutable data (such as NamedTuples or ordinary structs) as arguments to DynamicPPL models, or fixing the model on such data.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.39.5"
+version = "0.39.6"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -80,6 +80,13 @@ Internally, this is accomplished using [`init!!`](@ref) on:
 OnlyAccsVarInfo
 ```
 
+When given a `LogDensityFunction` (and only a `LogDensityFunction`!) it is often useful to be able to sample new parameters from the prior of the model, for example, when searching for initial points for MCMC sampling.
+This can be done with:
+
+```@docs
+rand_with_logdensity
+```
+
 ## Condition and decondition
 
 A [`Model`](@ref) can be conditioned on a set of observations with [`AbstractPPL.condition`](@ref) or its alias [`|`](@ref).

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -100,6 +100,7 @@ export AbstractVarInfo,
     # LogDensityFunction
     LogDensityFunction,
     OnlyAccsVarInfo,
+    rand_with_logdensity,
     # Leaf contexts
     AbstractContext,
     contextualize,


### PR DESCRIPTION
Previously, if you were performing MCMC sampling with a LogDensityFunction `ldf` and you wanted to figure out a set of reasonable initial parameters you could do:

```julia
_, vi = DynamicPPL.init!!(rng, ldf.model, ldf.varinfo, strategy)
logp = ldf.getlogjoint(vi)
params = vi[:]
```

You could then check, for example, whether logp was finite, etc. etc -- see e.g. [SliceSampling.jl](https://github.com/TuringLang/SliceSampling.jl/blob/2dd671699f9357033928bc4864e549187a344fa1/ext/SliceSamplingTuringExt.jl#L38-L66) or [Turing's HMC implementation](https://github.com/TuringLang/Turing.jl/blob/4dc7ad096f92fd571de312e7751986484ac6cb50/src/mcmc/hmc.jl#L152-L178).

Now that LogDensityFunction no longer stores a varinfo, this becomes impossible. Turing can currently handle it because _it_ is responsible for generating the VarInfo and creating the LDF. However, external samplers _cannot_, because the external sampler is just given the LDF and that's it -- there's no way for it to regenerate the VarInfo.

This unfortunately blocks a lot of things. For example, in MH if you want to generate a new proposal from the prior, you can't do it with just a LogDensityFunction. That's partly why in Turing we are still stuck with carrying an old model + varinfo wrapper struct around. See https://github.com/TuringLang/Turing.jl/blob/4dc7ad096f92fd571de312e7751986484ac6cb50/src/mcmc/mh.jl#L181-L199

---------

There is a cheap way to fix it, which is to just lump a varinfo into LogDensityFunction. I think that is a band-aid, and I don't like that. It also makes my life harder later on, as I REALLY want us to minimise usage of any varinfo that is not OnlyAccsVarInfo.

So, this PR introduces a new function that will do that correctly for LogDensityFunction using a custom accumulator. It's kind of like ValuesAsInModel, but it is a bit more 'batteries included' since it also calculates logjac.

While this does get things across the line in a way I'm generally happy with (see the docstring for a very nice invariant, which is also checked in the test suite), it is my belief that this `rand_with_logdensity` function will need to eventually live inside AbstractMCMC. I think it should be a method on AbstractMCMC.LogDensityModel, which would delegate to the inner `model.logdensity` object.

The problem with that is, unfortunately, the strategy argument is currently very much DynamicPPL exclusive. So the `InitFrom...` strategies also need to be upstreamed, which I feel less happy about doing. So I think this PR is a good middle ground for now.