### PR TITLE
Add extra accs argument for LogDensityFunction

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # DynamicPPL Changelog
 
+## 0.39.11
+
+Allow passing `accs::Union{NTuple{N,AbstractAccumulator},AccumulatorTuple}` into the `LogDensityFunction` constructor to specify custom accumulators to use when evaluating the model.
+Previously, this was hard-coded.
+
 ## 0.39.10
 
 Rename the internal functions `matchingvalue` and `get_matching_type` to `convert_model_argument` and `promote_model_type_argument` respectively.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.39.10"
+version = "0.39.11"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/accumulators.jl
+++ b/src/accumulators.jl
@@ -157,6 +157,7 @@ end
 
 AccumulatorTuple(accs::Vararg{AbstractAccumulator}) = AccumulatorTuple(accs)
 AccumulatorTuple(nt::NamedTuple) = AccumulatorTuple(tuple(nt...))
+AccumulatorTuple(at::AccumulatorTuple) = at
 
 # When showing with text/plain, leave out information about the wrapper AccumulatorTuple.
 Base.show(io::IO, mime::MIME"text/plain", at::AccumulatorTuple) = show(io, mime, at.nt)


### PR DESCRIPTION
This PR fixes another feature regression in FastLDF, which is that the accumulators used for actual evaluation of the log-density are hardcoded. (Technically not hardcoded, but you have to overload some internal function, which is not good.)

In SlowLDF the accs were taken from the VarInfo passed in:

https://github.com/TuringLang/DynamicPPL.jl/blob/6c615ad41946ffa11698408948f85cd4606262ff/src/logdensityfunction.jl#L135-L140

I found that I needed this functionality in the optimisation code so that I can pass in the accumulator that checks at runtime whether constraints are satisfied.

I **think** this isn't breaking, since it's the final positional argument and it is optional.