### PR TITLE
restrict eltype of stats when making chain

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # DynamicPPL Changelog
 
+## 0.39.12
+
+When constructing an `MCMCChains.Chains`, sampler statistics that are not `Union{Real,Missing}` are dropped from the chain (previously this would cause chain construction to fail).
+Note that MCMCChains in general cannot contain non-numeric statistics, so this is the only reasonable behaviour.
+
 ## 0.39.11
 
 Allow passing `accs::Union{NTuple{N,AbstractAccumulator},AccumulatorTuple}` into the `LogDensityFunction` constructor to specify custom accumulators to use when evaluating the model.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.39.11"
+version = "0.39.12"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
When constructing an (MCMCChains) chain, if a sampler had statistics that were non-numeric, the current code would attempt to shove it inside the chain anyway. This fails because MCMCChains doesn't like anything that's non-numeric. This PR changes it to drop the offending value instead of throwing an error.