### PR TITLE
Pretty-print VNTs, accs, and VarInfo

### DIFF
--- a/src/accumulators.jl
+++ b/src/accumulators.jl
@@ -160,8 +160,33 @@ AccumulatorTuple(accs::Vararg{AbstractAccumulator}) = AccumulatorTuple(accs)
 AccumulatorTuple(nt::NamedTuple) = AccumulatorTuple(tuple(nt...))
 AccumulatorTuple(at::AccumulatorTuple) = at
 
-# When showing with text/plain, leave out information about the wrapper AccumulatorTuple.
-Base.show(io::IO, mime::MIME"text/plain", at::AccumulatorTuple) = show(io, mime, at.nt)
+function pretty_print(io::IO, at::AccumulatorTuple, prefix::String)
+    naccs = length(at)
+    if isempty(at.nt)
+        print(io, "AccumulatorTuple with 0 accumulators")
+        return nothing
+    end
+    println(
+        io, "AccumulatorTuple with ", naccs, naccs == 1 ? " accumulator:" : " accumulators"
+    )
+    for (i, (name, acc)) in enumerate(pairs(at.nt))
+        tree_symbol = i == naccs ? "└─ " : "├─ "
+        key_name = string(name)
+        print(io, prefix * tree_symbol)
+        printstyled(io, key_name; color=:cyan)
+        print(io, " => ")
+        show(io, acc)
+        if i < naccs
+            println(io)
+        end
+    end
+    return nothing
+end
+
+function Base.show(io::IO, ::MIME"text/plain", at::AccumulatorTuple)
+    pretty_print(io, at, "")
+    return nothing
+end
 Base.getindex(at::AccumulatorTuple, idx) = at.nt[idx]
 Base.length(::AccumulatorTuple{N}) where {N} = N
 Base.iterate(at::AccumulatorTuple, args...) = iterate(at.nt, args...)

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -133,6 +133,20 @@ function Base.values(vi::VarInfo)
     return mapreduce(p -> p.second.transform(p.second.val), push!, vi.values; init=Any[])
 end
 
+function Base.show(io::IO, ::MIME"text/plain", vi::VarInfo)
+    printstyled(io, "VarInfo\n"; bold=true)
+    print(io, " ├─ ")
+    printstyled("values"; bold=true)
+    print(io, "\n │  ")
+    DynamicPPL.VarNamedTuples.vnt_pretty_print(io, vi.values, " │  ", 0)
+    println(io)
+    print(io, " └─ ")
+    printstyled("accs"; bold=true)
+    print(io, "\n    ")
+    DynamicPPL.pretty_print(io, vi.accs, "    ")
+    return nothing
+end
+
 function Base.getindex(vi::VarInfo, vn::VarName)
     tv = getindex(vi.values, vn)
     return tv.transform(tv.val)

--- a/src/varnamedtuple.jl
+++ b/src/varnamedtuple.jl
@@ -62,6 +62,7 @@ include("varnamedtuple/partial_array.jl")
 include("varnamedtuple/vnt.jl")
 include("varnamedtuple/getset.jl")
 include("varnamedtuple/map.jl")
+include("varnamedtuple/show.jl")
 
 function AbstractPPL.hasvalue(vnt::VarNamedTuple, vn::VarName)
     return _haskey_optic(vnt, vn)

--- a/src/varnamedtuple/map.jl
+++ b/src/varnamedtuple/map.jl
@@ -60,10 +60,12 @@ julia> vnt = VarNamedTuple()
 VarNamedTuple()
 
 julia> vnt = setindex!!(vnt, [1, 2, 3], @varname(a))
-VarNamedTuple(a = [1, 2, 3],)
+VarNamedTuple
+└─ a => [1, 2, 3]
 
 julia> apply!!(x -> x .+ 1, vnt, @varname(a))
-VarNamedTuple(a = [2, 3, 4],)
+VarNamedTuple
+└─ a => [2, 3, 4]
 ```
 """
 function apply!!(func, vnt::VarNamedTuple, name::VarName)

--- a/src/varnamedtuple/partial_array.jl
+++ b/src/varnamedtuple/partial_array.jl
@@ -65,19 +65,6 @@ end
 # ArrayLikeBlocks as scalars.
 Base.broadcastable(o::ArrayLikeBlock) = Ref(o)
 
-function Base.show(io::IO, alb::ArrayLikeBlock)
-    print(io, "ArrayLikeBlock(")
-    show(io, alb.block)
-    print(io, ", ")
-    show(io, alb.ix)
-    print(io, ", ")
-    show(io, alb.kw)
-    print(io, ", ")
-    show(io, alb.index_size)
-    print(io, ")")
-    return nothing
-end
-
 _blocktype(::Type{ArrayLikeBlock{T}}) where {T} = T
 
 """
@@ -262,30 +249,6 @@ end
 
 Base.ndims(::PartialArray{ElType,num_dims}) where {ElType,num_dims} = num_dims
 Base.eltype(::PartialArray{ElType}) where {ElType} = ElType
-
-function Base.show(io::IO, pa::PartialArray)
-    print(io, "PartialArray{", eltype(pa), ",", ndims(pa), "}(")
-    is_first = true
-    for inds in CartesianIndices(pa.mask)
-        if @inbounds(!pa.mask[inds])
-            continue
-        end
-        if !is_first
-            print(io, ", ")
-        else
-            is_first = false
-        end
-        val = @inbounds(pa.data[inds])
-        # Note the distinction: The raw strings that form part of the structure of the print
-        # out are `print`ed, whereas the keys and values are `show`n. The latter ensures
-        # that strings are quoted, Symbols are prefixed with :, etc.
-        show(io, Tuple(inds))
-        print(io, " => ")
-        show(io, val)
-    end
-    print(io, ")")
-    return nothing
-end
 
 Base.size(pa::PartialArray) = size(pa.data)
 Base.isassigned(pa::PartialArray, ix...; kw...) = isassigned(pa.data, ix...; kw...)

--- a/src/varnamedtuple/show.jl
+++ b/src/varnamedtuple/show.jl
@@ -1,0 +1,113 @@
+# Pretty-printing for VarNamedTuple and PartialArray.
+
+function Base.show(io::IO, vnt::VarNamedTuple)
+    if isempty(vnt.data)
+        return print(io, "VarNamedTuple()")
+    end
+    print(io, "VarNamedTuple")
+    show(io, vnt.data)
+    return nothing
+end
+
+const MAX_KEYS_OR_INDICES = 8
+
+function vnt_pretty_print(io::IO, pa::PartialArray, prefix::String, depth::Int)
+    # an incomplete PA is dimmed to indicate that it has missing entries.
+    size_style = if all(pa.mask)
+        (;)
+    else
+        (; color=:light_white)
+    end
+    print(io, "PartialArray ")
+    printstyled(io, "size=" * string(size(pa.data)); size_style...)
+    println(" data::" * string(typeof(pa.data)))
+    # can't use `keys(pa)` here as that recurses into each element.
+    nindices = count(pa.mask)
+    truncate = nindices > MAX_KEYS_OR_INDICES
+    active_indices = CartesianIndices(pa.data)[pa.mask]
+    for (i, idx) in enumerate(active_indices)
+        tree_symbol = i == nindices ? "└─ " : "├─ "
+        if truncate && i > 2 && i < nindices
+            if i == 3
+                print(io, prefix * "│  ")
+                printstyled(
+                    io,
+                    "⋮ (" * string(nindices - 3) * " more set indices) ";
+                    color=:light_white,
+                )
+                println(io)
+            end
+            continue
+        end
+        key_name = string(Tuple(idx))
+        print(io, prefix * tree_symbol)
+        printstyled(io, key_name; color=color_at_depth(depth))
+        print(io, " => ")
+        v = pa.data[idx]
+        if v isa VarNamedTuple || v isa PartialArray
+            nspaces_for_key = length(key_name) + 4
+            vnt_pretty_print(
+                io,
+                v,
+                prefix * (i == nindices ? "   " : "│  ") * (" "^nspaces_for_key),
+                depth + 1,
+            )
+        else
+            show(io, v)
+        end
+        if i < nindices
+            println(io)
+        end
+    end
+    return nothing
+end
+
+colors = [:red, :green, :blue, :yellow, :magenta, :cyan]
+color_at_depth(depth::Int) = colors[mod1(depth, length(colors))]
+
+function vnt_pretty_print(io::IO, vnt::VarNamedTuple, prefix::String, depth::Int)
+    println(io, "VarNamedTuple")
+    nkeys = length(keys(vnt.data))
+    # If there are loads of keys, show only the first two and the last
+    truncate = nkeys > MAX_KEYS_OR_INDICES
+    for (i, (k, v)) in enumerate(zip(keys(vnt.data), values(vnt.data)))
+        tree_symbol = i == nkeys ? "└─ " : "├─ "
+        if truncate && i > 2 && i < nkeys
+            if i == 3
+                print(io, prefix * "│  ")
+                printstyled(
+                    io, "⋮ (" * string(nkeys - 3) * " more keys) "; color=:light_white
+                )
+                println(io)
+            end
+            continue
+        end
+        key_name = string(k)
+        print(io, prefix * tree_symbol)
+        printstyled(io, key_name; color=color_at_depth(depth))
+        print(io, " => ")
+        if v isa VarNamedTuple || v isa PartialArray
+            nspaces_for_key = length(key_name) + 4
+            vnt_pretty_print(
+                io,
+                v,
+                prefix * (i == nkeys ? "   " : "│  ") * (" "^nspaces_for_key),
+                depth + 1,
+            )
+        else
+            show(io, v)
+        end
+        if i < nkeys
+            println(io)
+        end
+    end
+end
+
+function Base.show(io::IO, ::MIME"text/plain", vnt::VarNamedTuple)
+    if isempty(vnt.data)
+        print(io, "VarNamedTuple()")
+    else
+        vnt_pretty_print(io, vnt, "", 0)
+    end
+    return nothing
+end

--- a/src/varnamedtuple/vnt.jl
+++ b/src/varnamedtuple/vnt.jl
@@ -70,15 +70,6 @@ Base.:(==)(vnt1::VarNamedTuple, vnt2::VarNamedTuple) = vnt1.data == vnt2.data
 Base.isequal(vnt1::VarNamedTuple, vnt2::VarNamedTuple) = isequal(vnt1.data, vnt2.data)
 Base.hash(vnt::VarNamedTuple, h::UInt) = hash("vnt", hash(vnt.data, h))
 
-function Base.show(io::IO, vnt::VarNamedTuple)
-    if isempty(vnt.data)
-        return print(io, "VarNamedTuple()")
-    end
-    print(io, "VarNamedTuple")
-    show(io, vnt.data)
-    return nothing
-end
-
 function Base.copy(vnt::VarNamedTuple{names}) where {names}
     # Make a shallow copy of vnt, except for any VarNamedTuple or PartialArray elements,
     # which we recursively copy.

--- a/test/varnamedtuple.jl
+++ b/test/varnamedtuple.jl
@@ -1241,10 +1241,6 @@ Base.size(st::SizedThing) = st.size
         test_invariants(vnt)
     end
 
-    @testset "printing" begin
-        # TODO(penelopeysm) Rework printing tests
-    end
-
     @testset "block variables" begin
         # Tests for setting and getting block variables, i.e. variables that have a non-zero
         # size in a PartialArray, but are not Arrays themselves.


### PR DESCRIPTION
This chain of stuff

```julia
using DynamicPPL, BangBang
using DynamicPPL: templated_setindex!!, NoTemplate

v = VarNamedTuple()
v = templated_setindex!!(v, 2.0, @varname(b.c), NoTemplate())
v = templated_setindex!!(v, 1.0, @varname(a), NoTemplate())
v = templated_setindex!!(v, 1.0, @varname(b.a2), NoTemplate())
v = templated_setindex!!(v, 1.0, @varname(b.a3), NoTemplate())
v = templated_setindex!!(v, 1.0, @varname(b.a4), NoTemplate())
v = templated_setindex!!(v, 1.0, @varname(b.a5), NoTemplate())
v = templated_setindex!!(v, 1.0, @varname(b.a6), NoTemplate())
v = templated_setindex!!(v, 1.0, @varname(b.a7), NoTemplate())
v = templated_setindex!!(v, 1.0, @varname(b.a8), NoTemplate())
v = templated_setindex!!(v, 1.0, @varname(b.a9), NoTemplate())
v = templated_setindex!!(v, 1.0, @varname(b.a10), NoTemplate())
v = templated_setindex!!(v, 1.0, @varname(b.a11), NoTemplate())
v = templated_setindex!!(v, 1.0, @varname(b.d.a.g), NoTemplate())
for i in 1:10
    v = templated_setindex!!(v, 1.0, @varname(e.a[i]), (; a = randn(10)))
end
v
```

Printing this in the REPL gives

```julia
julia> v
VarNamedTuple
├─ b => VarNamedTuple
│       ├─ c => 2.0
│       ├─ a2 => 1.0
│       │  ⋮ (9 more keys)
│       └─ d => VarNamedTuple
│               └─ a => VarNamedTuple
│                       └─ g => 1.0
├─ a => 1.0
└─ e => VarNamedTuple
        └─ a => PartialArray size=(10,) data::Vector{Float64}
                ├─ (1,) => 1.0
                ├─ (2,) => 1.0
                │  ⋮ (7 more set indices)
                └─ (10,) => 1.0
```

It actually has colour too:

<img width="567" height="311" alt="Screenshot 2026-01-24 at 00 20 10" src="https://github.com/user-attachments/assets/15c72c09-d4e1-4e25-866a-9a9ab2ce3404" />

The method I overloaded is `show(io, MIME("text/plain"), vnt)`, which is meant for pretty-printing (see https://docs.julialang.org/en/v1/base/io-network/#Base.show-Tuple%7BIO,%20Any,%20Any%7D). Also, there is no longer any pretension that the two-argument show method `show(io, vnt)` should return something that is parseable by `repr`. So we don't even try, and we just defer to Julia's default implementation of `show`. Given that our PartialArrays can now contain arbitrary arrays, I don't see the point of trying so hard to make it roundtrip with repr.

```julia
julia> show(v)
VarNamedTuple(b = VarNamedTuple(c = 2.0, a2 = 1.0, a3 = 1.0, a4 = 1.0, a5 = 1.0, a6 = 1.0, a7 = 1.0, a8 = 1.0, a9 = 1.0, a10 = 1.0, a11 = 1.0, d = VarNamedTuple(a = VarNamedTuple(g = 1.0,),)), a = 1.0, e = VarNamedTuple(a = DynamicPPL.VarNamedTuples.PartialArray{Float64, 1, Vector{Float64}, Vector{Bool}}([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0], Bool[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),))
```

Finally, I just went ahead and did the same thing for AccumulatorTuple and VarInfo, meaning that now instead of a horrendous wall of text, you can do this:

```julia
julia> using DynamicPPL, Distributions

julia> @model f() = x ~ Normal()
f (generic function with 2 methods)

julia> vi = VarInfo(f())
VarInfo
 ├─ values
 │  VarNamedTuple
 │  └─ x => DynamicPPL.TransformedValue{false, Vector{Float64}, DynamicPPL.UnwrapSingletonTransform{Tuple{Int64}}, Tuple{}}([-0.5363082349124643], DynamicPPL.UnwrapSingletonTransform{Tuple{Int64}}((1,)), ())
 └─ accs
    AccumulatorTuple with 3 accumulators
    ├─ LogPrior => LogPriorAccumulator(-1.0627517946221343)
    ├─ LogJacobian => LogJacobianAccumulator(0.0)
    └─ LogLikelihood => LogLikelihoodAccumulator(0.0)
```