### PR TITLE
Store a full transform strategy in VarInfo rather than just `true`/`false`/`nothing`

### DIFF
--- a/docs/src/accs/values.md
+++ b/docs/src/accs/values.md
@@ -22,14 +22,15 @@ Unfortunately, not everything in DynamicPPL follows this clean structure yet.
 In particular, there is a struct, called `VarInfo`:
 
 ```julia
-struct VarInfo{linked,V<:VarNamedTuple,A<:AccumulatorTuple}
+struct VarInfo{Tfm<:AbstractTransformStrategy,V<:VarNamedTuple,A<:AccumulatorTuple}
+    transform_strategy::Tfm
     values::V
     accs::A
 end
 ```
 
 The `values` field stores either [`LinkedVectorValue`](@ref)s or [`VectorValue`](@ref)s.
-The `link` type parameter can either be `true` or `false`, which indicates that _all values stored_ are linked or unlinked, respectively; or it can be `nothing`, which indicates that it is not known whether the values are linked or unlinked, and must be checked on a case-by-case basis.
+The `transform_strategy` field stores an `AbstractTransformStrategy` which is (as far as possible) consistent with the type of values stored in `values`.
 
 Here is an example:
 

--- a/test/contexts/init.jl
+++ b/test/contexts/init.jl
@@ -98,10 +98,10 @@ using Test
             @testset "$transform_strategy" for transform_strategy in (
                 LinkAll(),
                 UnlinkAll(),
-                LinkSome((@varname(a),), UnlinkAll()),
-                LinkSome((@varname(b),), UnlinkAll()),
-                UnlinkSome((@varname(a),), LinkAll()),
-                UnlinkSome((@varname(b),), LinkAll()),
+                LinkSome(Set([@varname(a)]), UnlinkAll()),
+                LinkSome(Set([@varname(b)]), UnlinkAll()),
+                UnlinkSome(Set([@varname(a)]), LinkAll()),
+                UnlinkSome(Set([@varname(b)]), LinkAll()),
             )
                 # Generate a VarInfo with that strategy
                 vi = last(

--- a/test/logdensityfunction.jl
+++ b/test/logdensityfunction.jl
@@ -180,8 +180,8 @@ end
     @testset "$transform_strategy" for transform_strategy in (
         UnlinkAll(),
         LinkAll(),
-        LinkSome((@varname(x),), UnlinkAll()),
-        UnlinkSome((@varname(x),), LinkAll()),
+        LinkSome(Set([@varname(x)]), UnlinkAll()),
+        UnlinkSome(Set([@varname(x)]), LinkAll()),
     )
         accs = OnlyAccsVarInfo(VectorValueAccumulator())
         _, accs = init!!(model, accs, InitFromPrior(), transform_strategy)

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -376,25 +376,27 @@ end
         @testset "$(model.f)" for model in (x_before_y(), y_before_x())
             test_transform_strategy(LinkAll(), model, Set([@varname(x), @varname(y)]))
             test_transform_strategy(
-                LinkSome((@varname(x),), UnlinkAll()), model, Set([@varname(x)])
+                LinkSome(Set([@varname(x)]), UnlinkAll()), model, Set([@varname(x)])
             )
             test_transform_strategy(
-                LinkSome((@varname(y),), UnlinkAll()), model, Set([@varname(y)])
+                LinkSome(Set([@varname(y)]), UnlinkAll()), model, Set([@varname(y)])
             )
             test_transform_strategy(
-                LinkSome((@varname(x), @varname(y)), UnlinkAll()),
+                LinkSome(Set([@varname(x), @varname(y)]), UnlinkAll()),
                 model,
                 Set([@varname(x), @varname(y)]),
             )
             test_transform_strategy(UnlinkAll(), model, Set{VarName}())
             test_transform_strategy(
-                UnlinkSome((@varname(x),), LinkAll()), model, Set{VarName}()
+                UnlinkSome(Set([@varname(x)]), LinkAll()), model, Set{VarName}()
             )
             test_transform_strategy(
-                UnlinkSome((@varname(y),), LinkAll()), model, Set{VarName}()
+                UnlinkSome(Set([@varname(y)]), LinkAll()), model, Set{VarName}()
             )
             test_transform_strategy(
-                UnlinkSome((@varname(x), @varname(y)), LinkAll()), model, Set{VarName}()
+                UnlinkSome(Set([@varname(x), @varname(y)]), LinkAll()),
+                model,
+                Set{VarName}(),
             )
         end
     end
@@ -488,8 +490,8 @@ end
         @testset for transform_strategy in [
             UnlinkAll(),
             LinkAll(),
-            LinkSome((@varname(y),), UnlinkAll()),
-            LinkSome((@varname(x), @varname(z)), UnlinkAll()),
+            LinkSome(Set([@varname(y)]), UnlinkAll()),
+            LinkSome(Set([@varname(x), @varname(z)]), UnlinkAll()),
         ]
             vi = VarInfo(model, InitFromParams(unlinked_values), transform_strategy)
 


### PR DESCRIPTION
Closes https://github.com/TuringLang/DynamicPPL.jl/issues/1255.

I thought this would have no impact on performance, but weirdly it makes `subset` about 3x faster on some models. I have no idea why. I'll take it, though.