### PR TITLE
Remove `vnt_size` and size checks when setting in VNT

### DIFF
--- a/docs/src/accs/values.md
+++ b/docs/src/accs/values.md
@@ -46,7 +46,7 @@ vi = VarInfo(dirichlet_model)
 vi
 ```
 
-In `VarInfo`, it is mandatory to store `LinkedVectorValue`s or `VectorValue`s as `ArrayLikeBlock`s (see the [Array-like blocks](@ref) documentation for information on this).
+In `VarInfo`, it is mandatory to store `LinkedVectorValue`s or `VectorValue`s as `ArrayLikeBlock`s (see the [Array-like blocks](@ref array-like-blocks) documentation for information on this).
 The reason is because, if the value is linked, it may have a different size than the number of indices in the `VarName`.
 This means that when retrieving the keys, we obtain each block as a single key:
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -349,7 +349,6 @@ For more details on `VarNamedTuple`, see the Internals section of our documentat
 ```@docs
 DynamicPPL.VarNamedTuples.VarNamedTuple
 DynamicPPL.VarNamedTuples.@vnt
-DynamicPPL.VarNamedTuples.vnt_size
 DynamicPPL.VarNamedTuples.apply!!
 DynamicPPL.VarNamedTuples.densify!!
 DynamicPPL.VarNamedTuples.map_pairs!!

--- a/docs/src/vnt/arraylikeblocks.md
+++ b/docs/src/vnt/arraylikeblocks.md
@@ -1,4 +1,4 @@
-# Array-like blocks
+# [Array-like blocks](@id array-like-blocks)
 
 In a number of VNT use cases, it is necessary to associate multiple indices in a `VarNamedTuple` with an object that is not necessarily the same number of elements.
 
@@ -86,30 +86,6 @@ Furthermore, if you set a value into any of the indices covered by the block, th
 ```@example 1
 vnt = DynamicPPL.templated_setindex!!(vnt, Normal(), @varname(x[2]), x)
 ```
-
-## Size checks
-
-Currently, when setting any object `val` as an `ArrayLikeBlock`, there is a size check: we make sure that the range of indices being set to has the same size as `DynamicPPL.VarNamedTuples.vnt_size(val)`.
-By default, `vnt_size(x)` returns `Base.size(x)`.
-
-```@example 1
-DynamicPPL.VarNamedTuples.vnt_size(Dirichlet(ones(3)))
-```
-
-This is what allows us to set a `Dirichlet` distribution to three indices.
-However, trying to set the same distribution to two indices will fail:
-
-```@repl 1
-vnt = DynamicPPL.templated_setindex!!(
-    VarNamedTuple(), Dirichlet(ones(3)), @varname(x[1:2]), zeros(5)
-)
-```
-
-!!! note
-    
-    In principle, these checks can be removed since if `Dirichlet(ones(3))` is set as the prior of `x[1:2]`, then model evaluation will error anyway.
-    Furthermore, if at any point we need to know the size of the block, we can always retrieve it via `size(view(parent_array, alb.ix...; alb.kw...))`.
-    However, the checks are still here for now.
 
 ## Which parts of DynamicPPL use array-like blocks?
 

--- a/src/accumulators/pointwise_logdensities.jl
+++ b/src/accumulators/pointwise_logdensities.jl
@@ -22,7 +22,7 @@ function (plp::PointwiseLogProb{Prior,Likelihood})(
         return DoNotAccumulate()
     end
 end
-const POINTWISE_ACCNAME = :PointwiseLogProbAccumulator
+const POINTWISE_ACCNAME = :PointwiseLogProb
 
 # Not exported
 function get_pointwise_logprobs(varinfo::AbstractVarInfo)

--- a/src/contexts.jl
+++ b/src/contexts.jl
@@ -168,6 +168,7 @@ function tilde_observe!!(
     ::Distribution,
     ::Any,
     ::Union{VarName,Nothing},
+    ::Any,
     ::AbstractVarInfo,
 )
     return error("tilde_observe!! not implemented for context of type $(typeof(context))")

--- a/src/logdensityfunction.jl
+++ b/src/logdensityfunction.jl
@@ -497,7 +497,7 @@ function get_ranges_and_linked(vnt::VarNamedTuple)
             val = tv.val
             range = offset:(offset + length(val) - 1)
             offset += length(val)
-            ral = RangeAndLinked(range, tv isa LinkedVectorValue, tv.size)
+            ral = RangeAndLinked(range, tv isa LinkedVectorValue)
             template = vnt.data[AbstractPPL.getsym(vn)]
             ranges_vnt = templated_setindex!!(ranges_vnt, ral, vn, template)
             return ranges_vnt, offset

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -314,8 +314,7 @@ function setindex_with_dist!!(
     vi::VarInfo, tval::UntransformedValue, dist::Distribution, vn::VarName, template
 )
     raw_value = DynamicPPL.get_internal_value(tval)
-    sz = hasmethod(size, (typeof(raw_value),)) ? size(raw_value) : ()
-    tval = VectorValue(to_vec_transform(dist)(raw_value), from_vec_transform(dist), sz)
+    tval = VectorValue(to_vec_transform(dist)(raw_value), from_vec_transform(dist))
     return setindex_with_dist!!(vi, tval, dist, vn, template)
 end
 
@@ -330,9 +329,9 @@ transformation of the variable!
 function set_transformed!!(vi::VarInfo, linked::Bool, vn::VarName)
     old_tv = getindex(vi.values, vn)
     new_tv = if linked
-        LinkedVectorValue(old_tv.val, old_tv.transform, old_tv.size)
+        LinkedVectorValue(old_tv.val, old_tv.transform)
     else
-        VectorValue(old_tv.val, old_tv.transform, old_tv.size)
+        VectorValue(old_tv.val, old_tv.transform)
     end
     new_values = setindex!!(vi.values, new_tv, vn)
     new_transform_strategy = update_transform_strategy(
@@ -358,7 +357,7 @@ set_transformed!!(vi::VarInfo, ::NoTransformation) = set_transformed!!(vi, false
 function set_transformed!!(vi::VarInfo, linked::Bool)
     ctor = linked ? LinkedVectorValue : VectorValue
     new_values = map_values!!(vi.values) do tv
-        ctor(tv.val, tv.transform, tv.size)
+        ctor(tv.val, tv.transform)
     end
     new_transform_strategy = linked ? LinkAll() : UnlinkAll()
     return VarInfo(new_transform_strategy, new_values, vi.accs)
@@ -528,7 +527,7 @@ for T in (:VectorValue, :LinkedVectorValue)
             len = length(old_val)
             new_val = @view vci.vec[(vci.index):(vci.index + len - 1)]
             vci.index += len
-            return $T(new_val, tv.transform, tv.size)
+            return $T(new_val, tv.transform)
         end
     end
 end

--- a/src/varnamedtuple.jl
+++ b/src/varnamedtuple.jl
@@ -8,7 +8,6 @@ using BangBang
 using DynamicPPL: DynamicPPL
 
 export VarNamedTuple,
-    vnt_size,
     map_pairs!!,
     map_values!!,
     apply!!,

--- a/src/varnamedtuple/map.jl
+++ b/src/varnamedtuple/map.jl
@@ -263,27 +263,12 @@ function _map_values_recursive_pa_noalb!!(func, pa::PartialArray)
     end
 end
 
-function _check_size(new_block, old_block)
-    sz_new = vnt_size(new_block)
-    sz_old = vnt_size(old_block)
-    if sz_new != sz_old
-        throw(
-            DimensionMismatch(
-                "map_pairs!! can't change the size of a block. Tried to change " *
-                "from $(sz_old) to $(sz_new).",
-            ),
-        )
-    end
-end
 function _map_pairs_recursive!!(pairfunc, alb::ArrayLikeBlock, vn)
-    # new_block = _map_pairs_recursive!!(pairfunc, alb.block, vn)
     new_block = pairfunc(vn => alb.block)
-    _check_size(new_block, alb.block)
     return ArrayLikeBlock(new_block, alb.ix, alb.kw, alb.index_size)
 end
 function _map_values_recursive!!(func, alb::ArrayLikeBlock)
     new_block = _map_values_recursive!!(func, alb.block)
-    _check_size(new_block, alb.block)
     return ArrayLikeBlock(new_block, alb.ix, alb.kw, alb.index_size)
 end
 


### PR DESCRIPTION
This PR removes size checks when setting a value inside a VNT. That means, for example, you can assign `Dirichlet(ones(2))` (which has size `(2,)`) to `x[1:5]` even though the indices are not the same size:

```julia
julia> using DynamicPPL, Distributions

julia> vnt = @vnt begin
           @template x = zeros(5)
           x[1:5] := Dirichlet(ones(2))
       end
VarNamedTuple
└─ x => PartialArray size=(5,) data::Vector{DynamicPPL.VarNamedTuples.ArrayLikeBlock{Dirichlet{Float64, Vector{Float64}, Float64}, Tuple{UnitRange{Int64}}, @NamedTuple{}, Tuple{Int64}}}
        ├─ (1,) => DynamicPPL.VarNamedTuples.ArrayLikeBlock{Dirichlet{Float64, Vector{Float64}, Float64}, Tuple{UnitRange{Int64}}, @NamedTuple{}, Tuple{Int64}}(Dirichlet{Float64, Vector{Float64}, Float64}(alpha=[1.0, 1.0]), (1:5,), NamedTuple(), (5,))
        ├─ (2,) => DynamicPPL.VarNamedTuples.ArrayLikeBlock{Dirichlet{Float64, Vector{Float64}, Float64}, Tuple{UnitRange{Int64}}, @NamedTuple{}, Tuple{Int64}}(Dirichlet{Float64, Vector{Float64}, Float64}(alpha=[1.0, 1.0]), (1:5,), NamedTuple(), (5,))
        ├─ (3,) => DynamicPPL.VarNamedTuples.ArrayLikeBlock{Dirichlet{Float64, Vector{Float64}, Float64}, Tuple{UnitRange{Int64}}, @NamedTuple{}, Tuple{Int64}}(Dirichlet{Float64, Vector{Float64}, Float64}(alpha=[1.0, 1.0]), (1:5,), NamedTuple(), (5,))
        ├─ (4,) => DynamicPPL.VarNamedTuples.ArrayLikeBlock{Dirichlet{Float64, Vector{Float64}, Float64}, Tuple{UnitRange{Int64}}, @NamedTuple{}, Tuple{Int64}}(Dirichlet{Float64, Vector{Float64}, Float64}(alpha=[1.0, 1.0]), (1:5,), NamedTuple(), (5,))
        └─ (5,) => DynamicPPL.VarNamedTuples.ArrayLikeBlock{Dirichlet{Float64, Vector{Float64}, Float64}, Tuple{UnitRange{Int64}}, @NamedTuple{}, Tuple{Int64}}(Dirichlet{Float64, Vector{Float64}, Float64}(alpha=[1.0, 1.0]), (1:5,), NamedTuple(), (5,))
```

The reason for this is twofold.

## Pointwise log-probabilities

One is to do with #1279. The issue there is that when accumulating pointwise log-densities in VNT, you can have a model that looks like

```julia
@model function ...
   x[1:2] ~ Dirichlet(ones(2))
end
```

It's only possible to associate a single float probability with the VarName `x[1:2]`. If there were size checks, it would be impossible to associate a true float with `x[1:2]`, because the size of a float is `()` which doesn't line up with the expected size `(2,)`. You would have to wrap a float in a struct like

```julia
struct SizedLogProb{T}
    lp::Float64
    sz::T
end
vnt_size(s::SizedLogProb) = s.sz
```

before storing it in a VNT. The problem with this is that when the user expects to get a log-probability, they'll now get this ugly `SizedLogProb` thing, which forces them to carry the burden of internal VNT details.

## Sizes are checked at model runtime anyway

The main reason why we want to avoid storing something of the wrong size is because we want to avoid the possibility of constructing "inconsistent VNTs". Here I use "inconsistent" to mean VNTs precisely like the one above:

```julia
julia> vnt = @vnt begin
           @template x = zeros(5)
           x[1:5] := Dirichlet(ones(2))
       end
```

In this example, which could arise when e.g. storing the prior distributions of variables, we don't ever want to have a scenario where we collect a prior `Dirichlet(ones(2))` that *cannot* be associated with a value `x[1:5]`.

The thing is, though, that can never happen anyway. If you were to write `x[1:5] ~ Dirichlet(ones(2))`, when you evaluate the model, this will fail anyway because `rand(Dirichlet(...))` will return a length-2 vector, which cannot then be set into `x[1:5]`. (This is completely independent of any VNTs and will fail even with an empty OnlyAccsVarInfo that has no accumulators.)

In my opinion, then, the size check when setting items in VNTs is superfluous because it is impossible to construct a model that will both run correctly and lead to inconsistent VNTs. Inconsistent VNTs only arise from models that cannot be run.

## Conclusion

If not for the issue with pointwise logprobs, I would have probably just let it slide and kept the size check in even though IMO it doesn't accomplish much. However, given that there is actually a motivation to remove it, I decided that it's better to remove it.

Because of this, several structs in DynamicPPL that used to store size information now no longer need to. These include `RangeAndLinked`, `VectorValue`, and `LinkedVectorValue`. I have therefore also removed those fields.

I'm currently somewhere around 95% sure that this is the right thing to do. However, I've decided to separate this into another PR just to cover for that 5% chance, in case I need to revert it in the future.

## Previous discussion about the need for size checks

See https://github.com/TuringLang/DynamicPPL.jl/pull/1180#discussion_r2633079830.

Given that this was a point of disagreement before, I feel obliged to offer a bit more explanation.

Philosophically I still agree that for a completely generic data structure / container, it makes sense that you cannot assign a value to `x[1:5]` unless the value *does* indeed have size `(5,)`. However, I think in this PR I am rejecting the premise of that argument. Specifically, the use of VNT is so closely tied to a DPPL model (and especially more so since templates / shadow arrays were implemented), that I don't think that VNT is truly a generic data structure, and I think it's okay to rely on point (2) above, and to sacrifice some purity for pragmatism.