### PR TITLE
Improve ReverseDiff performance by avoiding views on TrackedArray

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # DynamicPPL Changelog
 
+## 0.39.14
+
+Optimise AD performance with ReverseDiff.
+
 ## 0.39.13
 
 Add compatibility with Mooncake.jl 0.5.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.39.13"
+version = "0.39.14"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -35,6 +35,7 @@ KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 MarginalLogDensities = "f0c3360a-fb8d-11e9-1194-5521fd7ee392"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 
 [extensions]
 DynamicPPLChainRulesCoreExt = ["ChainRulesCore"]
@@ -44,6 +45,7 @@ DynamicPPLJETExt = ["JET"]
 DynamicPPLMCMCChainsExt = ["MCMCChains"]
 DynamicPPLMarginalLogDensitiesExt = ["MarginalLogDensities"]
 DynamicPPLMooncakeExt = ["Mooncake"]
+DynamicPPLReverseDiffExt = ["ReverseDiff"]
 
 [compat]
 ADTypes = "1"
@@ -73,6 +75,7 @@ Mooncake = "0.4.147, 0.5"
 OrderedCollections = "1"
 Printf = "1.10"
 Random = "1.6"
+ReverseDiff = "1"
 Statistics = "1"
 Test = "1.6"
 julia = "1.10.8"

--- a/ext/DynamicPPLReverseDiffExt.jl
+++ b/ext/DynamicPPLReverseDiffExt.jl
@@ -1,0 +1,9 @@
+module DynamicPPLReverseDiffExt
+
+using DynamicPPL
+using ReverseDiff
+
+@inline DynamicPPL.maybe_view_ad(vect::ReverseDiff.TrackedArray, range) =
+    getindex(vect, range)
+
+end # module


### PR DESCRIPTION
For ReverseDiff it's somehow often faster to use getindex rather than view: https://github.com/JuliaDiff/ReverseDiff.jl/issues/281

This PR adds an overload to avoid using view on TrackedArrays. It should have no impact on primal performance or for any other AD backend.

## Example

```julia
using ReverseDiff, Chairmarks, Distributions, DynamicPPL, LinearAlgebra, LogDensityProblems, Random
import DifferentiationInterface as DI

@model function logreg(X, y)
    n, d = size(X)
    σ ~ InverseGamma(1.0, 1.0)
    β ~ MvNormal(zeros(d), σ * I)
    for i in 1:n
        logit = dot(X[i, :], β)
        y[i] ~ BernoulliLogit(logit)
    end
end

# data size = n
# number of variables = d + 1
n, d = 20, 20
X = rand(Xoshiro(468), Float64, n, d)
y = rand(Xoshiro(468), Bool, n)
model = logreg(X, y)
vi = DynamicPPL.link!!(VarInfo(Xoshiro(468), model), model)
xs = vi[:]

ldf = LogDensityFunction(model, getlogjoint_internal, vi; adtype=DI.AutoReverseDiff())
@be LogDensityProblems.logdensity_and_gradient(ldf, xs)
```

## main

```julia
julia> @be LogDensityProblems.logdensity_and_gradient(ldf, xs)
Benchmark: 323 samples with 1 evaluation
 min    290.917 μs (4858 allocs: 183.797 KiB)
 median 295.959 μs (4858 allocs: 183.797 KiB)
 mean   298.143 μs (4858 allocs: 183.797 KiB)
 max    385.125 μs (4858 allocs: 183.797 KiB)
```

## This PR
```julia
julia> @be LogDensityProblems.logdensity_and_gradient(ldf, xs)
Benchmark: 2179 samples with 1 evaluation
 min    32.375 μs (798 allocs: 42.125 KiB)
 median 33.583 μs (798 allocs: 42.125 KiB)
 mean   43.077 μs (798 allocs: 42.125 KiB, 0.18% gc time)
 max    10.240 ms (798 allocs: 42.125 KiB, 98.70% gc time)
```
