### PR TITLE
Fix ReverseDiff perf

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # DynamicPPL Changelog
 
+## 0.39.15
+
+Fix AD performance with ReverseDiff (v0.39.9 inadvertently introduced a bug that did not cause any correctness issues, but did cause severe slowdowns with ReverseDiff -- this patch reverts that).
+
 ## 0.39.14
 
 Optimise AD performance with ReverseDiff.

--- a/src/logdensityfunction.jl
+++ b/src/logdensityfunction.jl
@@ -446,7 +446,7 @@ _use_closure(::ADTypes.AutoMooncakeForward) = false
 # For ReverseDiff, with the compiled tape, you _must_ use a closure because otherwise with
 # DI.Constant arguments the tape will always be recompiled upon each call to
 # value_and_gradient. For non-compiled ReverseDiff, it is faster to not use a closure.
-_use_closure(::ADTypes.AutoReverseDiff{compile}) where {compile} = !compile
+_use_closure(::ADTypes.AutoReverseDiff{compile}) where {compile} = compile
 # For AutoEnzyme it allows us to avoid setting function_annotation
 _use_closure(::ADTypes.AutoEnzyme) = false
 # Since for most backends it's faster to not use a closure, we set that as the default


### PR DESCRIPTION
This code here, where `!closure` should have been `closure`, was missed by both PR submitter and PR reviewer:

https://github.com/TuringLang/DynamicPPL.jl/blob/32ad1709c839cc9d177562e52b5d97d813410692/src/logdensityfunction.jl#L467-L470

This PR fixes that. This should significantly improve ReverseDiff performance.