### PR TITLE
Fix ReverseDiff perf

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,8 @@
-# v0.40
+# 0.40.1
+
+Fix AD performance with ReverseDiff (v0.39.9 inadvertently introduced a bug that did not cause any correctness issues, but did cause severe slowdowns with ReverseDiff -- this patch reverts that).
+
+# 0.40
 
 v0.40 of DynamicPPL brings with it a complete rewrite of DynamicPPL's core data structure, `VarInfo`.
 
@@ -292,6 +296,12 @@ In this release, to reduce code duplication, they have been merged into a single
   - `Bijectors.bijector(::Model)`, which creates a bijector from the vectorised variable space of the model to the linked variable space of the model, now has slightly different optional arguments. See the docstring for details.
   - `NamedDist` no longer allows variable names with `Colon`s in them, such as `x[:]`.
   - `value_iterator_from_chain` is removed; please use `AbstractMCMC.to_samples(DynamicPPL.ParamsWithStats, chain, model)` instead.
+
+# 0.39.15
+
+Fix AD performance with ReverseDiff (v0.39.9 inadvertently introduced a bug that did not cause any correctness issues, but did cause severe slowdowns with ReverseDiff -- this patch reverts that).
+
+This is a backport of the same patch in v0.40.1.
 
 # 0.39.14
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.40"
+version = "0.40.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/logdensityfunction.jl
+++ b/src/logdensityfunction.jl
@@ -467,7 +467,7 @@ _use_closure(::ADTypes.AutoMooncakeForward) = false
 # For ReverseDiff, with the compiled tape, you _must_ use a closure because otherwise with
 # DI.Constant arguments the tape will always be recompiled upon each call to
 # value_and_gradient. For non-compiled ReverseDiff, it is faster to not use a closure.
-_use_closure(::ADTypes.AutoReverseDiff{compile}) where {compile} = !compile
+_use_closure(::ADTypes.AutoReverseDiff{compile}) where {compile} = compile
 # For AutoEnzyme it allows us to avoid setting function_annotation
 _use_closure(::ADTypes.AutoEnzyme) = false
 # Since for most backends it's faster to not use a closure, we set that as the default


### PR DESCRIPTION
This code here, where `!compile` should have been `compile`, was missed by both PR submitter and PR reviewer:

https://github.com/TuringLang/DynamicPPL.jl/blob/32ad1709c839cc9d177562e52b5d97d813410692/src/logdensityfunction.jl#L467-L470

This PR fixes that. This should significantly improve compiled ReverseDiff performance.

I manually backported this to v0.39 (see [the `backport-0.39` branch](https://github.com/TuringLang/DynamicPPL.jl/tree/backport-0.39)) since this felt both important and also quite small.