### PR TITLE
Fix inappropriate mutation of DebugAccumulator

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.40.2
+
+Fix a bug where `DebugAccumulator` was being improperly mutated during model checks.
+
 # 0.40.1
 
 Fix AD performance with ReverseDiff (v0.39.9 inadvertently introduced a bug that did not cause any correctness issues, but did cause severe slowdowns with ReverseDiff -- this patch reverts that).

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.40.1"
+version = "0.40.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/debug_utils.jl
+++ b/src/debug_utils.jl
@@ -81,6 +81,7 @@ end
 function DynamicPPL.accumulate_observe!!(
     acc::DebugAccumulator, right::Distribution, val, vn::Union{VarName,Nothing}, template
 )
+    failed = acc.failed
     if _has_partial_missings(val, right)
         msg = if vn === nothing
             "on the left-hand side of an observe statement"
@@ -94,7 +95,7 @@ function DynamicPPL.accumulate_observe!!(
             " It is not currently possible to set part but not all of a distribution" *
             " to be `missing`."
         @warn full_msg
-        acc.failed = true
+        failed = true
     end
     # Check for NaN's as well
     if _has_nans(val)
@@ -103,9 +104,9 @@ function DynamicPPL.accumulate_observe!!(
             " observe statement; this may indicate that your data" *
             " contain NaN values."
         @warn msg
-        acc.failed = true
+        failed = true
     end
-    return acc
+    return DebugAccumulator(failed)
 end
 
 """

--- a/test/debug_utils.jl
+++ b/test/debug_utils.jl
@@ -8,6 +8,18 @@ using DynamicPPL, Distributions, Test
 using LinearAlgebra: I
 using Random: Xoshiro
 
+function test_model_fails_check(model)
+    issuccess = check_model(model)
+    @test !issuccess
+    @test_throws ErrorException check_model(model; error_on_failure=true)
+end
+function test_model_can_run_but_fails_check(model)
+    # Check that it can actually run
+    @test VarInfo(model) isa VarInfo
+    # but if you call check_model it should fail
+    return test_model_fails_check(model)
+end
+
 @testset "check_model" begin
     @testset "$(model.f)" for model in DynamicPPL.TestUtils.DEMO_MODELS
         @test check_model(model)
@@ -15,15 +27,6 @@ using Random: Xoshiro
     end
 
     @testset "multiple usage of same variable" begin
-        function test_model_can_run_but_fails_check(model)
-            # Check that it can actually run
-            @test VarInfo(model) isa VarInfo
-            # but if you call check_model it should fail
-            issuccess = check_model(model)
-            @test !issuccess
-            @test_throws ErrorException check_model(model; error_on_failure=true)
-        end
-
         @testset "simple" begin
             @model function buggy_demo_model()
                 x ~ Normal()
@@ -86,7 +89,7 @@ using Random: Xoshiro
                 return x ~ MvNormal(zeros(length(x)), I)
             end
             model = demo_missing_in_multivariate([1.0, missing])
-            @test_throws ErrorException check_model(model; error_on_failure=true)
+            test_model_fails_check(model)
         end
 
         @testset "condition both in args and context" begin


### PR DESCRIPTION
This was a bug that wasn't caught because we did a lot of `@test_throws ErrorException`. The problem is that even though it was indeed supposed to throw an error, it threw a _different_ ErrorException due to the bug, and the test masked that.