### PR TITLE
Add `get_priors(::AbstractVarInfo)`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.40.3
+
+Added a convenience function, `get_priors(::AbstractVarInfo)`, which extracts the `VarNamedTuple` of prior distributions from a VarInfo that contains a `PriorDistributionAccumulator`.
+
 # 0.40.2
 
 Fix a bug where `DebugAccumulator` was being improperly mutated during model checks.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.40.2"
+version = "0.40.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/accs/existing.md
+++ b/docs/src/accs/existing.md
@@ -41,6 +41,5 @@ get_vector_params
 
 ```@docs
 PriorDistributionAccumulator
+get_priors
 ```
-
-(No convenience function for this one yet.)

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -100,6 +100,7 @@ export AbstractVarInfo,
     get_vector_params,
     # Accumulators - miscellany
     PriorDistributionAccumulator,
+    get_priors,
     BijectorAccumulator,
     # Working with internal values as vectors
     unflatten!!,

--- a/src/accumulators/priors.jl
+++ b/src/accumulators/priors.jl
@@ -9,6 +9,16 @@ An accumulator that stores the prior distributions of every variable seen in a m
 PriorDistributionAccumulator() = VNTAccumulator{PRIOR_ACCNAME}(_get_dist)
 
 """
+    get_priors(vi::DynamicPPL.AbstractVarInfo)
+
+Extract the priors stored in the `PriorDistributionAccumulator` of an AbstractVarInfo.
+Errors if the AbstractVarInfo does not have a `PriorDistributionAccumulator`.
+"""
+function get_priors(vi::DynamicPPL.AbstractVarInfo)
+    return DynamicPPL.getacc(vi, Val(PRIOR_ACCNAME)).values
+end
+
+"""
     extract_priors([rng::Random.AbstractRNG, ]model::Model)
 
 Extract the priors from a model. This is done by sampling from the model and recording the

--- a/test/accumulators.jl
+++ b/test/accumulators.jl
@@ -19,7 +19,10 @@ using DynamicPPL:
     map_accumulator,
     reset,
     setacc!!,
-    split
+    split,
+    PriorDistributionAccumulator,
+    get_priors,
+    @varname
 
 @testset "accumulators" begin
     @testset "individual accumulator types" begin
@@ -165,6 +168,21 @@ using DynamicPPL:
                 acc -> promote_for_threadsafe_eval(acc, Float64), accs, Val(:LogLikelihood)
             ) == AccumulatorTuple(lp_f32, LogLikelihoodAccumulator(1.0))
         end
+    end
+
+    @testset "PriorDistributionAccumulator" begin
+        accs = DynamicPPL.OnlyAccsVarInfo(
+            PriorDistributionAccumulator(), RawValueAccumulator(false)
+        )
+        @model function f()
+            x ~ Normal()
+            return y ~ Normal(x)
+        end
+        _, accs = DynamicPPL.init!!(f(), accs, InitFromPrior(), UnlinkAll())
+        vals = get_raw_values(accs)
+        priors = get_priors(accs)
+        @test priors[@varname(x)] == Normal()
+        @test priors[@varname(y)] == Normal(vals[@varname(x)])
     end
 end
 


### PR DESCRIPTION
It gets pretty tiring using `getacc(vi, Val(:Prior...))` in Turing.

Also adds a basic test for the `PriorDistributionAccumulator`, which previously was not tested at all (probably my fault).