### PR TITLE
Add pretty-printing for `DynamicPPL.ParamsWithStats`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.40.10
+
+Added pretty-printing for `DynamicPPL.ParamsWithStats`.
+
 # 0.40.9
 
 Added more docs on special VNT operations, namely `densify!!` and `skeleton`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.40.9"
+version = "0.40.10"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -157,3 +157,35 @@ function ParamsWithStats(
     end
     return ParamsWithStats(params, stats)
 end
+
+function Base.show(io::IO, ::MIME"text/plain", pws::ParamsWithStats)
+    printstyled(io, "ParamsWithStats"; bold=true)
+    print(io, "\n ├─ ")
+    if isempty(pws.params)
+        printstyled(io, "params"; bold=true)
+        println(io, " (empty)")
+    else
+        printstyled(io, "params"; bold=true)
+        print(io, "\n │  ")
+        DynamicPPL.VarNamedTuples.vnt_pretty_print(io, pws.params, " │  ", 0)
+        println(io)
+    end
+    print(io, " └─ ")
+    printstyled(io, "stats"; bold=true)
+    if isempty(pws.stats)
+        println(io, " (empty)")
+    else
+        n = length(pws.stats)
+        for (i, (k, v)) in enumerate(pairs(pws.stats))
+            if i == n
+                print(io, "\n    └─ ")
+            else
+                print(io, "\n    ├─ ")
+            end
+            printstyled(io, k; color=:blue)
+            print(io, " = ")
+            show(io, v)
+        end
+    end
+    return nothing
+end


### PR DESCRIPTION
e.g.

```julia
ParamsWithStats
 ├─ params
 │  VarNamedTuple
 │  └─ x => 0.9360638178036182
 └─ stats
    ├─ n_steps = 3
    ├─ is_accept = true
    ├─ acceptance_rate = 0.8410611104801813
    ├─ log_density = -1.3570462687052154
    ├─ hamiltonian_energy = 1.7672188630819894
    ├─ hamiltonian_energy_error = 0.07697947434403862
    ├─ max_hamiltonian_energy_error = 0.2663841937562428
    ├─ tree_depth = 2
    ├─ numerical_error = false
    ├─ step_size = 1.3590337181507763
    ├─ nom_step_size = 1.3590337181507763
    ├─ logprior = -1.3570462687052154
    ├─ loglikelihood = 0.0
    └─ logjoint = -1.3570462687052154
```