### PR TITLE
Attempt to make setindex!! on PA slices more understandable

### DIFF
--- a/src/varnamedtuple/getset.jl
+++ b/src/varnamedtuple/getset.jl
@@ -192,11 +192,9 @@ function _setindex_optic!!(
             NoTemplate()
         end
 
-        # TODO(penelopeysm): This check to haskey() will check *all* the indices, it only
-        # returns true if they are all filled. This is probably not really correct, and is
-        # why we need to have the hacky need_merge workaround just below this (because that
-        # catches the case where *some* of the indices are filled). We should rethink the
-        # logic in this section.
+        # haskey returns true only if *all* indices in the slice are filled. When only
+        # some are filled, we fall through to the else branch and use need_merge +
+        # _setindex_keep_existing!! to preserve the existing partial data.
         if Base.haskey(pa, coptic.ix...; coptic.kw...)
             # The PartialArray already contains an unmasked value at this index. We need to
             # set that value in place there.
@@ -213,24 +211,11 @@ function _setindex_optic!!(
             if permissions isa MustOverwrite
                 throw(MustOverwriteError(permissions))
             end
-            # Otherwise we can go ahead and make it
-            if any(view(pa.mask, coptic.ix...; coptic.kw...))
-                # NOTE: This is a VERY subtle case, which can happen when you are setting
-                # multiple indices at once, but some of them were masked. When they are
-                # masked, it will cause haskey to return false, so we can't go into the
-                # previous branch. However, if we naively call make_leaf to create the 
-                # sub-value and then setindex it inside the PartialArray, it will overwrite
-                # ALL the indices with the new leaf value, which will overwrite any
-                # previously active values! To avoid this, we will set a flag to indicate
-                # that we can create a new leaf, but at the end of the function we need to
-                # MERGE the new leaf into the existing PartialArray instead of overwriting
-                # it.
-                # This situation can happen e.g. with
-                #     using DynamicPPL
-                #     vnt = VarNamedTuple()
-                #     x = zeros(2)
-                #     vnt = DynamicPPL.templated_setindex!!(vnt, 1.0, @varname(x[1:2][1]), x)
-                #     vnt = DynamicPPL.templated_setindex!!(vnt, 2.0, @varname(x[1:2][2]), x)
+            # Otherwise we can go ahead and make it.
+            # Some indices in the slice may already have data (haskey returned false
+            # because not ALL are filled, but some are). We track this so we can use
+            # _setindex_keep_existing!! later, which preserves existing elements.
+            if is_multiindex && any(view(pa.mask, coptic.ix...; coptic.kw...))
                 need_merge = true
             end
             # No new data but we are allowed to create it.
@@ -251,16 +236,18 @@ function _setindex_optic!!(
     # In the merge path, some indices in the slice already have data but not all of them
     # (haskey returned false but any(mask) was true). If MustNotOverwrite is set, check
     # that the new sub-value doesn't overlap with existing data at the specific sub-indices.
-    if need_merge && permissions isa MustNotOverwrite && grown_sub_value isa PartialArray
+    if is_multiindex &&
+        permissions isa MustNotOverwrite &&
+        need_merge &&
+        grown_sub_value isa PartialArray
         existing_mask = view(pa.mask, coptic.ix...; coptic.kw...)
         if any(existing_mask .& grown_sub_value.mask)
             throw(MustNotOverwriteError(permissions))
         end
     end
 
-    return if need_merge
-        new_pa = BangBang.setindex!!(copy(pa), grown_sub_value, coptic.ix...; coptic.kw...)
-        _merge(pa, new_pa, Val(false))
+    return if is_multiindex && need_merge
+        _setindex_keep_existing!!(pa, grown_sub_value, coptic.ix...; coptic.kw...)
     else
         BangBang.setindex!!(pa, grown_sub_value, coptic.ix...; coptic.kw...)
     end

--- a/src/varnamedtuple/partial_array.jl
+++ b/src/varnamedtuple/partial_array.jl
@@ -636,6 +636,56 @@ function BangBang.setindex!!(pa::PartialArray, value, inds::Vararg{Any}; kw...)
     return _concretise_eltype!!(PartialArray(new_data, new_mask))
 end
 
+"""
+    _setindex_keep_existing!!(pa::PartialArray, value::PartialArray, inds...; kw...)
+
+Set elements from `value` into `pa` at positions `inds`, but only where `value.mask` is
+`true`. Existing elements in `pa` at positions where `value.mask` is `false` are preserved.
+
+This is used when setting sub-indices of a slice that already has partial data. For example,
+when setting `x[1:2][2]` after `x[1:2][1]` has already been set, we want to add the new
+value at index 2 without disturbing the existing value at index 1.
+
+This differs from `BangBang.setindex!!(pa, value::PartialArray, inds...)` in that the latter
+calls `_remove_partial_blocks!!`, which can destroy `ArrayLikeBlock`s that only partially
+overlap with `inds`. Here we handle ALBs more carefully: only the specific elements being
+overwritten (where `value.mask` is `true`) trigger ALB removal.
+"""
+function _setindex_keep_existing!!(
+    pa::PartialArray, value::PartialArray, inds::Vararg{Any}; kw...
+)
+    # Step 1: Remove any ArrayLikeBlocks that would be partially overwritten.
+    # An ALB spans multiple indices; if we overwrite only some of those indices, the
+    # remaining references become inconsistent. So we must remove the entire block.
+    et = eltype(pa.data)
+    if et <: ArrayLikeBlock || ArrayLikeBlock <: et
+        data_view = view(pa.data, inds...; kw...)
+        mask_view = view(pa.mask, inds...; kw...)
+        for i in eachindex(value.mask)
+            if value.mask[i] && mask_view[i] && data_view[i] isa ArrayLikeBlock
+                alb = data_view[i]
+                fill!(view(pa.mask, alb.ix...; alb.kw...), false)
+            end
+        end
+    end
+
+    # Step 2: Copy only the elements where value.mask is true.
+    # We mutate pa.data and pa.mask in place via views — this is safe because this
+    # function follows the `!!` convention (try to mutate, return the result).
+    # We do not do upfront type promotion here: the elements of `value` should have the
+    # same type as the elements of `pa`, since both originate from the same container.
+    data_view = view(pa.data, inds...; kw...)
+    mask_view = view(pa.mask, inds...; kw...)
+    for i in eachindex(value.mask)
+        if value.mask[i]
+            data_view[i] = value.data[i]
+            mask_view[i] = true
+        end
+    end
+
+    return pa
+end
+
 function _subset_partialarray(pa::PartialArray, inds::Vararg{Any}; kw...)
     if pa.data isa GrowableArray &&
         any(ind -> ind isa AbstractPPL.DynamicIndex || ind isa Colon, inds)


### PR DESCRIPTION
This is Claude's partial attempt to refactor my ugly VNT code into smaller bits. Unfortunately, while the code here gives all the right results, it leads to type instabilities for less pathological cases, specifically setting `x[1][1,2]` when there's already an element inside. Consequently, this cannot be merged right now. I don't yet know if this can be worked around.