### PR TITLE
`FixedTransform` extensions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -67,6 +67,7 @@ There is [a migration guide available on the DynamicPPL documentation](https://t
 ## Miscellaneous breaking changes
 
   - Removed the `varinfo` keyword argument from `DynamicPPL.TestUtils.AD.run_ad`, and replaced the `varinfo` field in the returned `ADResult` with `ldf::LogDensityFunction`.
+  - Removed the method `Bijectors.bijector(::DynamicPPL.Model)`; equivalent information can be obtained with `get_fixed_transforms` (although it returns a `VarNamedTuple` of transforms rather than a single stacked transform).
 
 ## Internal changes
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,12 +14,15 @@ Concretely,
   - `LinkedVectorValue(vec, tfm)` is now `TransformedValue(vec, DynamicLink())`
 
 **Note that this means for `VectorValue` and `LinkedVectorValue`, the transform is no longer stored on the value itself.**
-This means that given one of these values, you *cannot* access the raw value without running the model.
+This means that given one of these values, you *cannot* access the raw value without knowing the distribution from which it was sampled.
 
 The reason why this is done is that the transform may in principle change between model executions.
 This can happen if the prior distribution of a variable depends on the value of another variable.
 Previously, in DynamicPPL, we *always* made sure to recompute the transform during model evaluation; however, this was not enforced by the data structure.
 The current implementation makes it impossible to accidentally use an outdated transform, and is therefore more robust.
+
+The function `DynamicPPL.get_raw_value(::TransformedValue[, ::Distribution])` has been added to simplify the extraction of the raw value from a `TransformedValue`.
+The distribution argument is only needed if the transform is `DynamicLink` or `Unlink`.
 
 ### Addition of `FixedTransform`
 
@@ -32,15 +35,12 @@ For many simple distributions, this in fact saves absolutely no time, because de
 However, there are some edge cases for which this is not the case: for example, `product_distribution([Beta(2, 2), Normal()])` is quite slow (~ 3 µs).
 In such cases, using `FixedTransform` can lead to substantial performance improvements.
 
-To use `FixedTransform` with `LogDensityFunction`, you need to:
+To see how to use `FixedTransform`, please see the documentation at https://turinglang.org/DynamicPPL.jl/stable/fixed_transforms.
+The following entry points are provided:
 
- 1. Create a `VarNamedTuple` mapping `VarName`s to `FixedTransform`s for the variables in your model.
-    This can be done using `DynamicPPL.FixedTransformAccumulator` (see the DynamicPPL docs for more info), but is most easily done by calling `get_fixed_transforms(model, transform_strategy)`, where `transform_strategy` says whether you want linked or unlinked transforms.
-
- 2. Wrap the `VarNamedTuple` inside `WithTransforms(vnt, UnlinkAll())`.
-    `WithTransforms` is a subtype of `AbstractTransformStrategy`, much like `LinkAll()`.
-    However, `WithTransforms` specifies that *these exact transforms are to be used*, whereas `LinkAll` says 'derive the transforms again at model runtime'.
- 3. Construct a `LogDensityFunction(model, getlogjoint_internal, WithTransforms(...)); adtype=adtype`.
+  - `DynamicPPL.get_fixed_transforms(::Model, ::AbstractTransformStrategy)`
+  - The `fix_transforms` keyword argument to `LogDensityFunction`
+  - `FixedTransformAccumulator` for specialised use cases
 
 ### Removal of `getindex(vi::VarInfo, vn::VarName)`
 
@@ -52,19 +52,17 @@ That means that if we update the vectorised value without changing the transform
 In particular, this is *exactly* what the function `unflatten!!` does: it updates the vectorised values but does not touch the transform.
 
 In the current version, we have removed this method to prevent the possibility of obtaining incorrect results.
-(Our hands are also forced by the fact that the new `TransformedValue`s do not store the actual transform with them.)
 
-*In place of using `VarInfo`, we strongly recommend that you migrate to using `OnlyAccsVarInfo`.*
+**How do I get around this?**
+
+There are two ways of working around this.
+The first is to access the transformed value in the VarInfo, and then get the raw value from that: `DynamicPPL.get_raw_value(DynamicPPL.get_transformed_value(vi, vn)[, dist])`.
+Note that the `dist` argument corresponds to the distribution for `vn` (see above for more information).
+
+The recommended way of avoiding this, however, is to migrate to using `OnlyAccsVarInfo`.*
 In particular, to access raw (untransformed) values, you should use an `OnlyAccsVarInfo` with a `RawValueAccumulator`.
+These are guaranteed to be always up-to-date and you do not have to mess around with transforms.
 There is [a migration guide available on the DynamicPPL documentation](https://turinglang.org/DynamicPPL.jl/stable/migration/) and we are very happy to add more examples to this if you run into something that is not covered.
-
-### FixedTransformAccumulator
-
-TODO, this part is still being worked on.
-
-  - `BijectorAccumulator` → `FixedTransformAccumulator`
-  - `get_fixed_transforms(::VarInfo)`
-  - `get_fixed_transforms(::Model)`
 
 ## Miscellaneous breaking changes
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -568,6 +568,7 @@ The interface for working with transformed values consists of:
 ```@docs
 DynamicPPL.get_transform
 DynamicPPL.get_internal_value
+DynamicPPL.get_raw_value
 DynamicPPL.set_internal_value
 ```
 

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -157,6 +157,7 @@ export AbstractVarInfo,
     TransformedValue,
     get_transform,
     get_internal_value,
+    get_raw_value,
     set_internal_value,
     # Transform strategies
     update_transform_status!!,

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -172,7 +172,10 @@ function pws_with_eval(
     return ParamsWithStats(params, stats)
 end
 
-# Specialisation for when the LDF is known to have all fixed transforms
+# Specialisation for when the LDF is known to have all fixed transforms. In this case, we
+# can avoid reevaluating the model because the transformed values + their transforms are
+# all known (unless we need log probs, or `:=` results, in which case we will just have
+# to reevaluate anyway).
 function ParamsWithStats(
     param_vector::AbstractVector,
     ldf::LogDensityFunction{M,A,L,F,V,D,X,C,true},
@@ -180,20 +183,19 @@ function ParamsWithStats(
     include_colon_eq::Bool=true,
     include_log_probs::Bool=true,
 ) where {M,A,L,F,V,D,X,C}
-    if include_log_probs || include_colon_eq
-        return pws_with_eval(param_vector, ldf, stats; include_colon_eq, include_log_probs)
+    return if include_log_probs || include_colon_eq
+        pws_with_eval(param_vector, ldf, stats; include_colon_eq, include_log_probs)
+    else
+        params = VarNamedTuple()
+        for (vn, rat) in pairs(ldf._varname_ranges)
+            top_sym = AbstractPPL.getsym(vn)
+            template = get(ldf._varname_ranges.data, top_sym, DynamicPPL.NoTemplate())
+            raw_val = rat.transform.transform(param_vector[rat.range])
+            params = DynamicPPL.templated_setindex!!(params, raw_val, vn, template)
+        end
+        params = densify!!(params)
+        ParamsWithStats(params, stats)
     end
-    # Fast path: extract raw values directly from the parameter vector using the fixed
-    # transforms, without re-evaluating the model.
-    params = VarNamedTuple()
-    for (vn, rat) in pairs(ldf._varname_ranges)
-        top_sym = AbstractPPL.getsym(vn)
-        template = get(ldf._varname_ranges.data, top_sym, DynamicPPL.NoTemplate())
-        raw_val = rat.transform.transform(param_vector[rat.range])
-        params = DynamicPPL.templated_setindex!!(params, raw_val, vn, template)
-    end
-    params = densify!!(params)
-    return ParamsWithStats(params, stats)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", pws::ParamsWithStats)

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -120,8 +120,22 @@ via `unflatten!!` plus re-evaluation. It is faster for two reasons:
    otherwise re-evaluation would mutate the VarInfo, rendering it unusable for subsequent
    MCMC iterations).
 2. The re-evaluation is faster as it uses `OnlyAccsVarInfo`.
+
+Furthermore, if the `LogDensityFunction` has all fixed transforms (i.e., was constructed
+with `fix_transforms=true`), and neither `include_log_probs` nor `include_colon_eq` is
+set, then model re-evaluation is skipped entirely and the raw parameter values are
+extracted directly from the parameter vector using the cached transforms.
 """
 function ParamsWithStats(
+    param_vector::AbstractVector,
+    ldf::DynamicPPL.LogDensityFunction,
+    stats::NamedTuple=NamedTuple();
+    include_colon_eq::Bool=true,
+    include_log_probs::Bool=true,
+)
+    return pws_with_eval(param_vector, ldf, stats; include_colon_eq, include_log_probs)
+end
+function pws_with_eval(
     param_vector::AbstractVector,
     ldf::DynamicPPL.LogDensityFunction,
     stats::NamedTuple=NamedTuple();
@@ -155,6 +169,30 @@ function ParamsWithStats(
             ),
         )
     end
+    return ParamsWithStats(params, stats)
+end
+
+# Specialisation for when the LDF is known to have all fixed transforms
+function ParamsWithStats(
+    param_vector::AbstractVector,
+    ldf::LogDensityFunction{M,A,L,F,V,D,X,C,true},
+    stats::NamedTuple=NamedTuple();
+    include_colon_eq::Bool=true,
+    include_log_probs::Bool=true,
+) where {M,A,L,F,V,D,X,C}
+    if include_log_probs || include_colon_eq
+        return pws_with_eval(param_vector, ldf, stats; include_colon_eq, include_log_probs)
+    end
+    # Fast path: extract raw values directly from the parameter vector using the fixed
+    # transforms, without re-evaluating the model.
+    params = VarNamedTuple()
+    for (vn, rat) in pairs(ldf._varname_ranges)
+        top_sym = AbstractPPL.getsym(vn)
+        template = get(ldf._varname_ranges.data, top_sym, DynamicPPL.NoTemplate())
+        raw_val = rat.transform.transform(param_vector[rat.range])
+        params = DynamicPPL.templated_setindex!!(params, raw_val, vn, template)
+    end
+    params = densify!!(params)
     return ParamsWithStats(params, stats)
 end
 

--- a/src/contexts/init.jl
+++ b/src/contexts/init.jl
@@ -14,7 +14,7 @@ abstract type AbstractInitStrategy end
 
 Generate a new value for a random variable with the given distribution.
 
-This function must return an `TransformedValue`.
+This function must return a `TransformedValue`.
 
 If `strategy` provides values that are already untransformed (e.g., a Float64 within (0, 1)
 for `dist::Beta`, then you should return a `TransformedValue` with a `NoTransform()`.

--- a/src/logdensityfunction.jl
+++ b/src/logdensityfunction.jl
@@ -212,7 +212,7 @@ struct LogDensityFunction{
         # Determine LDF transform strategy.
         dynamic_transform_strategy = infer_transform_strategy_from_values(vnt)
         # `dynamic_transform_strategy` might be LinkAll() or UnlinkAll(), for example. We
-        # might need to convert this to a set of fixed transforrms.
+        # might need to convert this to a set of fixed transforms.
         transform_strategy = if fix_transforms
             # Reevaluate model again to determine the fixed transforms. This is kind of
             # wasteful: for example, we could tie this model evaluation to one of the

--- a/src/logdensityfunction.jl
+++ b/src/logdensityfunction.jl
@@ -189,6 +189,8 @@ struct LogDensityFunction{
     # type of the vector passed to logdensity functions
     X<:AbstractVector,
     AC<:AccumulatorTuple,
+    # whether all transforms are FixedTransforms, enabling fast parameter extraction
+    AllFixed,
 }
     model::M
     adtype::AD
@@ -231,6 +233,12 @@ struct LogDensityFunction{
         end
         ranges_and_transforms = get_rangeandtransforms(vnt)
 
+        # Determine whether all transforms are fixed. This enables fast parameter
+        # extraction in ParamsWithStats without model re-evaluation.
+        all_fixed = all(
+            rat -> rat.transform isa FixedTransform, values(ranges_and_transforms)
+        )
+
         # Get vectorised parameters. Note that `internal_values_as_vector` just concatenates
         # all the vectors inside in iteration order of the VNT's keys. *In principle*, the
         # result of that should always be consistent with the ranges extracted above via
@@ -268,6 +276,7 @@ struct LogDensityFunction{
             typeof(prep),
             typeof(x),
             typeof(accs),
+            all_fixed,
         }(
             model,
             adtype,

--- a/src/transformed_values.jl
+++ b/src/transformed_values.jl
@@ -78,27 +78,63 @@ function Base.isequal(tv1::TransformedValue, tv2::TransformedValue)
 end
 
 """
-    get_transform(tv::TransformedValue)
+    DynamicPPL.get_transform(tv::TransformedValue)
 
-Get the function that converts the transformed value back to the raw value.
+Get the subtype of `AbstractTransform` that is stored inside `tv`. Note that this is not
+always a function that can be used to obtain the raw, untransformed value. If you need the
+    raw value, please use [`DynamicPPL.get_raw_value`](@ref).
 """
 get_transform(tv::TransformedValue) = tv.transform
 
 """
-    get_internal_value(tv::TransformedValue)
+    DynamicPPL.get_internal_value(tv::TransformedValue)
 
 Get the internal value stored in `tv`.
 """
 get_internal_value(tv::TransformedValue) = tv.value
 
 """
-    set_internal_value(tv::TransformedValue, new_val)
+    DynamicPPL.set_internal_value(tv::TransformedValue, new_val)
 
 Create a new `TransformedValue` with the same transformation as `tv`, but with
 internal value `new_val`.
 """
 set_internal_value(tv::TransformedValue, new_val) =
     TransformedValue(new_val, get_transform(tv))
+
+"""
+    DynamicPPL.get_raw_value(tv::TransformedValue)
+    DynamicPPL.get_raw_value(tv::TransformedValue, dist::Distribution)
+
+Get the raw (untransformed) value from a `TransformedValue`.
+
+The two-argument version, with a `dist::Distribution` argument, is required when the
+`TransformedValue` holds a *dynamic* transform (i.e., `tv.transform` is either
+[`DynamicLink`](@ref) or [`Unlink`](@ref).
+
+For [`FixedTransform`](@ref) or [`NoTransform`](@ref), the `dist` argument is not needed
+(and if supplied, will be ignored).
+"""
+get_raw_value(tv::TransformedValue{<:Any,NoTransform}) = get_internal_value(tv)
+get_raw_value(tv::TransformedValue{<:Any,NoTransform}, ::Distribution) = get_raw_value(tv)
+function get_raw_value(tv::TransformedValue{<:Any,<:FixedTransform})
+    return tv.transform.transform(get_internal_value(tv))
+end
+function get_raw_value(tv::TransformedValue{<:Any,<:FixedTransform}, ::Distribution)
+    return get_raw_value(tv)
+end
+function get_raw_value(
+    tv::TransformedValue{<:AbstractVector{<:Real},DynamicLink}, dist::Distribution
+)
+    finvlink = Bijectors.VectorBijectors.from_linked_vec(dist)
+    return finvlink(get_internal_value(tv))
+end
+function get_raw_value(
+    tv::TransformedValue{<:AbstractVector{<:Real},Unlink}, dist::Distribution
+)
+    invlink = Bijectors.VectorBijectors.from_vec(dist)
+    return invlink(get_internal_value(tv))
+end
 
 """
     abstract type AbstractTransformStrategy end

--- a/src/transformed_values.jl
+++ b/src/transformed_values.jl
@@ -123,6 +123,16 @@ end
 function get_raw_value(tv::TransformedValue{<:Any,<:FixedTransform}, ::Distribution)
     return get_raw_value(tv)
 end
+function get_raw_value(::TransformedValue{<:Any,<:Union{DynamicLink,Unlink}})
+    return throw(
+        ArgumentError(
+            "dynamic transforms including `DynamicLink` and `Unlink` must be calculated" *
+            " from the distribution of the variable: please use `get_raw_value(tv, dist)`" *
+            " instead, or alternatively fix the transforms if you know that they are" *
+            " constant.",
+        ),
+    )
+end
 function get_raw_value(
     tv::TransformedValue{<:AbstractVector{<:Real},DynamicLink}, dist::Distribution
 )

--- a/src/transformed_values.jl
+++ b/src/transformed_values.jl
@@ -82,7 +82,7 @@ end
 
 Get the subtype of `AbstractTransform` that is stored inside `tv`. Note that this is not
 always a function that can be used to obtain the raw, untransformed value. If you need the
-    raw value, please use [`DynamicPPL.get_raw_value`](@ref).
+raw value, please use [`DynamicPPL.get_raw_value`](@ref).
 """
 get_transform(tv::TransformedValue) = tv.transform
 
@@ -199,9 +199,8 @@ target_transform(::UnlinkAll, ::VarName) = Unlink()
     WithTransforms(transforms::VarNamedTuple, fallback) <: AbstractTransformStrategy
 
 Indicate that the variables in `transforms` should be transformed according to their
-corresponding values in `transforms`, which should be subtypes of `AbstractTransform`.
-specified in `transforms`. The link statuses of other variables are determined by the
-`fallback` strategy.
+corresponding values in `transforms`, which should be subtypes of `AbstractTransform`. The
+link statuses of other variables are determined by the `fallback` strategy.
 """
 struct WithTransforms{V<:VarNamedTuple,L<:AbstractTransformStrategy} <:
        AbstractTransformStrategy

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -28,7 +28,7 @@ On top of that, `VarInfo` also stores a transform strategy, which reflects the l
 of variables inside the `VarInfo`. For example, a `VarInfo{LinkAll}` should contain only
 `TransformedValue{T,DynamicLink}`s in its `values` field. This unfortunately leads to
 redundancy of information, but is necessary for type stability, since that allows us to have
-    compile-time knowledge of what transformations are applied.
+compile-time knowledge of what transformations are applied.
 
 Because the job of `VarInfo` is to store transformed values, there is no generic
 `setindex!!` implementation on `VarInfo` itself. Instead, all storage must go via

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -26,9 +26,9 @@ in a `VarInfo`.
 
 On top of that, `VarInfo` also stores a transform strategy, which reflects the linked status
 of variables inside the `VarInfo`. For example, a `VarInfo{LinkAll}` should contain only
-`TransformedValue{T,LinkAll}`s in its `values` field. This unfortunately leads to redundancy
-of information, but is necessary for type stability, since that allows us to have
-compile-time knowledge of what transformations are applied.
+`TransformedValue{T,DynamicLink}`s in its `values` field. This unfortunately leads to
+redundancy of information, but is necessary for type stability, since that allows us to have
+    compile-time knowledge of what transformations are applied.
 
 Because the job of `VarInfo` is to store transformed values, there is no generic
 `setindex!!` implementation on `VarInfo` itself. Instead, all storage must go via

--- a/test/chains.jl
+++ b/test/chains.jl
@@ -73,7 +73,7 @@ end
     @testset "$(m.f)" for m in DynamicPPL.TestUtils.ALL_MODELS
         @testset "$transform_strategy" for transform_strategy in (UnlinkAll(), LinkAll())
             # Get the ParamsWithStats using LogDensityFunction
-            ldf = DynamicPPL.LogDensityFunction(m, getlogjoint, transform_strategy)
+            ldf = LogDensityFunction(m, getlogjoint, transform_strategy)
             param_vector = rand(ldf)
             # This will give us a VNT of values.params`.
             actual_vnt = ParamsWithStats(param_vector, ldf).params
@@ -89,6 +89,54 @@ end
             for vn in keys(actual_vnt)
                 @test actual_vnt[vn] == expected_vnt[vn]
             end
+        end
+    end
+end
+
+@testset "ParamsWithStats from LogDensityFunction with fixed transforms" begin
+    # Note: can't use ALL_MODELS here because that contains a model with dynamic transforms,
+    # which would yield incorrect results with fix_transforms.
+    @testset "$(m.f)" for m in DynamicPPL.TestUtils.DEMO_MODELS
+        @testset "$transform_strategy" for transform_strategy in (UnlinkAll(), LinkAll())
+            ldf_fixed = LogDensityFunction(
+                m, getlogjoint_internal, transform_strategy; fix_transforms=true
+            )
+            ldf_dynamic = LogDensityFunction(m, getlogjoint_internal, transform_strategy)
+            param_vector = rand(ldf_fixed)
+
+            # Fast path (no log probs, no colon eq): should match the model-evaluation path
+            fast = ParamsWithStats(
+                param_vector, ldf_fixed; include_log_probs=false, include_colon_eq=false
+            )
+            slow = ParamsWithStats(
+                param_vector, ldf_dynamic; include_log_probs=false, include_colon_eq=false
+            )
+            @test fast == slow
+        end
+    end
+
+    @testset "check that model is actually not evaluated" begin
+        should_error = false
+        @model function prickly()
+            x ~ Normal()
+            return should_error && error("nope")
+        end
+        # need to construct LDF without erroring
+        ldf = LogDensityFunction(
+            prickly(), getlogjoint_internal, LinkAll(); fix_transforms=true
+        )
+        # now make the model error
+        should_error = true
+        @test_throws ErrorException prickly()()
+        # check that ParamsWithStats doesn't error
+        @test ParamsWithStats(
+            [0.5], ldf; include_log_probs=false, include_colon_eq=false
+        ) isa Any
+        # but it does if you set either of them to true
+        for (ilp, ice) in ((true, false), (false, true), (true, true))
+            @test_throws ErrorException ParamsWithStats(
+                [0.5], ldf; include_log_probs=ilp, include_colon_eq=ice
+            )
         end
     end
 end

--- a/test/logdensityfunction.jl
+++ b/test/logdensityfunction.jl
@@ -549,12 +549,21 @@ end
 end
 
 @testset "LogDensityFunction: fix_transforms correctness" begin
+    # Helper function to check whether the AllFixed type parameter on LogDensityFunction is
+    # set correctly.
+    function has_all_fixed_transforms(
+        ::LogDensityFunction{M,A,L,F,V,D,X,C,AF}
+    ) where {M,A,L,F,V,D,X,C,AF}
+        return AF
+    end
+
     @testset "$(m.f)" for m in DynamicPPL.TestUtils.DEMO_MODELS
         @testset "$strategy" for strategy in (UnlinkAll(), LinkAll())
             ldf_dynamic = LogDensityFunction(m, getlogjoint_internal, strategy)
             ldf_fixed = LogDensityFunction(
                 m, getlogjoint_internal, strategy; fix_transforms=true
             )
+            @test has_all_fixed_transforms(ldf_fixed)
             # Check that the transform strategy does contain fixed transforms
             tfm_strategy = ldf_fixed.transform_strategy
             @test tfm_strategy isa WithTransforms

--- a/test/transformed_values.jl
+++ b/test/transformed_values.jl
@@ -11,6 +11,75 @@ using Distributions
 using Random: Xoshiro
 using Test
 
+@testset "TransformedValue API" begin
+    @testset "get_transform, get_internal_value, set_internal_value" begin
+        ft = FixedTransform(nothing)
+        transforms = [DynamicLink(), Unlink(), NoTransform(), ft]
+        @testset "$tfm" for tfm in transforms
+            tv = TransformedValue([1.0, 2.0], tfm)
+            @test get_transform(tv) == tfm
+            @test get_internal_value(tv) == [1.0, 2.0]
+
+            tv2 = set_internal_value(tv, [3.0, 4.0])
+            @test get_internal_value(tv2) == [3.0, 4.0]
+            @test get_transform(tv2) == tfm
+        end
+    end
+
+    @testset "==" begin
+        tv1 = TransformedValue([1.0], NoTransform())
+        tv2 = TransformedValue([1.0], NoTransform())
+        tv3 = TransformedValue([2.0], NoTransform())
+        tv4 = TransformedValue([1.0], DynamicLink())
+        @test tv1 == tv2
+        @test tv1 != tv3
+        @test tv1 != tv4
+    end
+
+    @testset "get_raw_value" begin
+        struct DummyDist <: Distributions.ContinuousMultivariateDistribution end
+
+        @testset "NoTransform" begin
+            raw = randn(3)
+            tv = TransformedValue(raw, NoTransform())
+            @test get_raw_value(tv) == raw
+            @test get_raw_value(tv, DummyDist()) == raw
+        end
+
+        @testset "FixedTransform" begin
+            dist = Beta(2, 5)
+            ft = FixedTransform(Bijectors.VectorBijectors.from_linked_vec(dist))
+            flink = Bijectors.VectorBijectors.to_linked_vec(dist)
+            raw_val = rand(dist)
+            linked_val = flink(raw_val)
+            tv = TransformedValue(linked_val, ft)
+            @test get_raw_value(tv) ≈ raw_val
+            @test get_raw_value(tv, dist) ≈ raw_val
+        end
+
+        @testset "DynamicLink" begin
+            dist = Beta(2, 5)
+            flink = Bijectors.VectorBijectors.to_linked_vec(dist)
+            raw_val = rand(Xoshiro(468), dist)
+            linked_val = flink(raw_val)
+            tv = TransformedValue(linked_val, DynamicLink())
+            @test_throws ArgumentError get_raw_value(tv)
+            @test get_raw_value(tv, dist) ≈ raw_val
+        end
+
+        @testset "Unlink" begin
+            dist = Dirichlet([1.0, 2.0, 3.0])
+            fvec = Bijectors.VectorBijectors.to_vec(dist)
+            raw_val = rand(Xoshiro(468), dist)
+            vec_val = fvec(raw_val)
+            tv = TransformedValue(vec_val, Unlink())
+            @test_throws ArgumentError get_raw_value(tv)
+            @test_throws "dynamic transforms" get_raw_value(tv)
+            @test get_raw_value(tv, dist) ≈ raw_val
+        end
+    end
+end
+
 @testset "get_fixed_transforms" begin
     # Check that `get_fixed_transforms` does indeed return a VNT of the correct transforms.
     xdist = Beta(2, 5)

--- a/test/transformed_values.jl
+++ b/test/transformed_values.jl
@@ -8,7 +8,6 @@ using AbstractPPL: AbstractPPL
 using Bijectors: Bijectors
 using DynamicPPL
 using Distributions
-using Random: Xoshiro
 using Test
 
 @testset "TransformedValue API" begin
@@ -60,7 +59,7 @@ using Test
         @testset "DynamicLink" begin
             dist = Beta(2, 5)
             flink = Bijectors.VectorBijectors.to_linked_vec(dist)
-            raw_val = rand(Xoshiro(468), dist)
+            raw_val = rand(dist)
             linked_val = flink(raw_val)
             tv = TransformedValue(linked_val, DynamicLink())
             @test_throws ArgumentError get_raw_value(tv)
@@ -70,7 +69,7 @@ using Test
         @testset "Unlink" begin
             dist = Dirichlet([1.0, 2.0, 3.0])
             fvec = Bijectors.VectorBijectors.to_vec(dist)
-            raw_val = rand(Xoshiro(468), dist)
+            raw_val = rand(dist)
             vec_val = fvec(raw_val)
             tv = TransformedValue(vec_val, Unlink())
             @test_throws ArgumentError get_raw_value(tv)
@@ -236,7 +235,7 @@ end
 
         # Create a TransformedValue with ft
         flink = Bijectors.VectorBijectors.to_linked_vec(dist)
-        raw_val = rand(Xoshiro(468), dist)
+        raw_val = rand(dist)
         linked_val, logjac = Bijectors.with_logabsdet_jacobian(flink, raw_val)
         tv = TransformedValue(linked_val, ft)
 


### PR DESCRIPTION
This extracts the raw value from a `TransformedValue`. In the cases where the transform is dynamic, it also demands that the distribution be supplied.

It also adds an overload for `ParamsWithStats(vector, ldf)`, which avoids re-evaluating the model when it's not needed (i.e., in the special case where the LDF is constructed with fixed transforms for all variables).

 - ~~I found that not having this was actually a blocker for the VI stuff upstream because in the docs there's an example of `rand(vi_result, 100000)` (https://turinglang.org/docs/tutorials/variational-inference/#obtaining-summary-statistics). Previously, this would just return each sample as a raw vector, which I don't like (https://github.com/TuringLang/Turing.jl/issues/2783): I would much prefer it return a `VarNamedTuple`, and so I changed it to do so. However, in the process, it ends up evaluating the model 100000 times and (for some unknown reason) crashes Julia on my laptop. This is a quick workaround to avoid having to evaluate the model, although in general I'd probably still like to know why it crashes (it can't be that handling 100000 VNTs is problematic, otherwise we would already have tons of issues with MCMC).~~ The crash (which I think is an OOM) is fixed by https://github.com/TuringLang/DynamicPPL.jl/pull/1350

The code is mostly Claude, but I gave it a lot of steering, and did a few changes by hand. I will self-review this tomorrow.

Closes #1347 (partly ... for now)