### PR TITLE
Fix UnlinkSome bug

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.40.23
+
+Fix incorrect behaviour when generating a new VarInfo with an `UnlinkSome` transform strategy (all variables would be instantiated as unlinked regardless of the fallback transform strategy).
+
 # 0.40.22
 
 Add a method for `AbstractMCMC.from_samples` to convert from a matrix of `VarNamedTuple`s to `MCMCChains.Chains`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.40.22"
+version = "0.40.23"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/varinfo.jl
+++ b/src/varinfo.jl
@@ -109,10 +109,7 @@ sections of Turing.jl. If linking performance is critical, it is recommended to 
 both methods for the specific model in question.
 """
 function DynamicPPL.VarInfo(
-    rng::Random.AbstractRNG,
-    model::Model,
-    init_strategy::AbstractInitStrategy,
-    ::Union{UnlinkAll,UnlinkSome},
+    rng::Random.AbstractRNG, model::Model, init_strategy::AbstractInitStrategy, ::UnlinkAll
 )
     # In this case, no variables are to be linked. We can optimise performance by directly
     # calling init!! and not faffing about with accumulators. (This does lead to significant

--- a/test/varinfo.jl
+++ b/test/varinfo.jl
@@ -386,10 +386,14 @@ end
             )
             test_transform_strategy(UnlinkAll(), model, Set{VarName}())
             test_transform_strategy(
-                UnlinkSome(Set([@varname(x)]), LinkAll()), model, Set{VarName}()
+                UnlinkSome(Set([@varname(x)]), LinkAll()),
+                model,
+                Set{VarName}([@varname(y)]),
             )
             test_transform_strategy(
-                UnlinkSome(Set([@varname(y)]), LinkAll()), model, Set{VarName}()
+                UnlinkSome(Set([@varname(y)]), LinkAll()),
+                model,
+                Set{VarName}([@varname(x)]),
             )
             test_transform_strategy(
                 UnlinkSome(Set([@varname(x), @varname(y)]), LinkAll()),


### PR DESCRIPTION
Generating a VarInfo with `UnlinkSome(vns, LinkAll())` should link any VarNames not in `vns`, but right now it doesn't. This patch fixes it.