### PR TITLE
Add accessor functions for necessary types

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.41.2
+
+Export the accessor functions `get_values(::VarInfo)` and `get_logdensity_callable(::LogDensityFunction)`, so that users do not need to access internal fields of these types directly.
+
 # 0.41.1
 
 Fix a missing interpolation in the DynamicPPL compiler which would cause errors if DynamicPPL was not loaded explicitly by the user.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.41.1"
+version = "0.41.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -67,6 +67,7 @@ LogDensityFunction
 get_input_vector_type
 RangeAndTransform
 get_range_and_transform
+get_logdensity_callable
 ```
 
 Internally, this is accomplished using [`init!!`](@ref) on:
@@ -326,6 +327,7 @@ AbstractVarInfo
 
 ```@docs
 VarInfo
+DynamicPPL.get_values
 DynamicPPL.setindex_with_dist!!
 ```
 

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -46,6 +46,7 @@ import Base:
 # VarInfo
 export AbstractVarInfo,
     VarInfo,
+    get_values,
     VarNamedTuple,
     @vnt,
     map_pairs!!,
@@ -131,6 +132,7 @@ export AbstractVarInfo,
     get_input_vector_type,
     RangeAndTransform,
     get_range_and_transform,
+    get_logdensity_callable,
     # Leaf contexts
     AbstractContext,
     contextualize,

--- a/src/abstract_varinfo.jl
+++ b/src/abstract_varinfo.jl
@@ -54,7 +54,7 @@ end
 """
     get_values(vi::AbstractVarInfo)
 
-Return the `VarNamedTuple` in `vi` that stores the variables' values.
+Return the `VarNamedTuple` in `vi` that stores the variables' transformed values.
 
 This should be implemented by each subtype of `AbstractVarInfo`.
 """

--- a/src/logdensityfunction.jl
+++ b/src/logdensityfunction.jl
@@ -366,6 +366,19 @@ function get_range_and_transform(ldf::LogDensityFunction, vn::VarName)
     return ldf._varname_ranges[vn]
 end
 
+"""
+    DynamicPPL.get_logdensity_callable(ldf::LogDensityFunction)
+
+A `LogDensityFunction` stores a callable that, given an `OnlyAccsVarInfo`, can be used to
+calculate the log density of the model at a given set of parameters. For example, most
+usecases in DynamicPPL use [`DynamicPPL.getlogjoint_internal`](@ref) for this purpose.
+
+This function retrieves that callable.
+"""
+function get_logdensity_callable(l::LogDensityFunction)
+    return l._getlogdensity
+end
+
 ###################################
 # LogDensityProblems.jl interface #
 ###################################

--- a/test/logdensityfunction.jl
+++ b/test/logdensityfunction.jl
@@ -83,6 +83,16 @@ using Mooncake: Mooncake
     end
 end
 
+@testset "LogDensityFunction: accessor functions" begin
+    @model f() = x ~ Normal()
+    ldf = LogDensityFunction(f(), getlogprior, UnlinkAll())
+    @test DynamicPPL.get_logdensity_callable(ldf) == getlogprior
+    @test DynamicPPL.get_input_vector_type(ldf) == Vector{Float64}
+    rat = DynamicPPL.get_range_and_transform(ldf, @varname(x))
+    @test rat.range == 1:1
+    @test rat.transform isa Unlink
+end
+
 @testset "LogDensityFunction: correctness with multiple threads" begin
     @testset "Threaded assume" begin
         @model function threaded_assume()


### PR DESCRIPTION
Turing accesses some of DPPL's types' fields, which is bad style and means that nonbreaking changes can potentially break upstream users. These accessor functions are more explicit about the API.