### PR TITLE
fix docs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.41.4
+
+Improve docs (in particular, make sure that outer constructors of structs also appear in the built docs).
+
 # 0.41.3
 
 Add a lower-level constructor for `LogDensityFunction` which directly takes a VNT of `RangeAndTransform`s plus a sample vectorised input.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.41.3"
+version = "0.41.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -63,6 +63,7 @@ logjoint
 The [LogDensityProblems.jl](https://github.com/tpapp/LogDensityProblems.jl) interface is also supported by wrapping a [`Model`](@ref) in a `DynamicPPL.LogDensityFunction`.
 
 ```@docs
+LogDensityFunction(::Model, ::Any, ::VarNamedTuple)
 LogDensityFunction
 RangeAndTransform
 get_range_and_transform
@@ -580,7 +581,10 @@ It is a fairly common operation to want to convert a collection of `VarInfo` obj
 This can be accomplished by first converting each `VarInfo` into a `ParamsWithStats` object:
 
 ```@docs
-DynamicPPL.ParamsWithStats
+ParamsWithStats
+ParamsWithStats(::AbstractInitStrategy, ::Model)
+ParamsWithStats(::AbstractVarInfo)
+ParamsWithStats(::AbstractVector, ::LogDensityFunction)
 ```
 
 Once you have a **matrix** of these, you can convert them into a chains object using:


### PR DESCRIPTION
I realised that the actually-useful constructors of `LogDensityFunction` and `ParamsWithStats` were not being documented (because Documenter.jl doesn't document constructors by default, just the struct type itself). This PR adds them to the docs.