### PR TITLE
Improve NamedDist docstring with fields documentation

### DIFF
--- a/src/distribution_wrappers.jl
+++ b/src/distribution_wrappers.jl
@@ -10,18 +10,19 @@ using Distributions:
 using FillArrays: Fill
 
 """
-    NamedDist{variate, support, Td, Tv}
+    NamedDist(dist::Distribution, name::Symbol)
 
 A named distribution that carries the name of the random variable with it.
 
 # Fields
 
-- `dist::Td`: The underlying distribution.
-- `name::Tv`: The name of the random variable as a `VarName`.
+$(TYPEDFIELDS)
 """
 struct NamedDist{variate,support,Td<:Distribution{variate,support},Tv<:VarName} <:
        Distribution{variate,support}
+    "the underlying distribution"
     dist::Td
+    "the name of the random variable"
     name::Tv
 end
 

--- a/src/distribution_wrappers.jl
+++ b/src/distribution_wrappers.jl
@@ -10,7 +10,14 @@ using Distributions:
 using FillArrays: Fill
 
 """
+    NamedDist{variate, support, Td, Tv}
+
 A named distribution that carries the name of the random variable with it.
+
+# Fields
+
+- `dist::Td`: The underlying distribution.
+- `name::Tv`: The name of the random variable as a `VarName`.
 """
 struct NamedDist{variate,support,Td<:Distribution{variate,support},Tv<:VarName} <:
        Distribution{variate,support}


### PR DESCRIPTION
### What does this PR do?

The NamedDist struct previously had a very brief one line description which lacked detailed documentation.

### Changes made

1) Added a full struct signature to the docstring header.

2) Included a # Fields section to explain the dist and name fields.

3) Updated the documentation style to match the standard Julia documentation format used across the rest of the codebase.

### Why?

Providing proper documentation for the fields helps both users and developers understand the purpose of the struct without needing to dive into the source code itself.