### PR TITLE
Refactor: unify logjoint/logprior/loglikelihood/returned via internal helper (#1332)

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -1030,16 +1030,12 @@ julia> # Truth.
 -9902.33787706641
 ```
 """
-function _evaluate_and_extract(model, params, vi, extract_fn)
-    init_strategy = InitFromParams(params..., nothing)
-    return extract_fn(init!!(model, vi, init_strategy, UnlinkAll()))
-end
-
 function logjoint(model::Model, params)
     vi = OnlyAccsVarInfo(
         AccumulatorTuple(LogPriorAccumulator(), LogLikelihoodAccumulator())
     )
-    return _evaluate_and_extract(model, (params,), vi, x -> getlogjoint(last(x)))
+    init_strategy = InitFromParams(params, nothing)
+    return getlogjoint(last(init!!(model, vi, init_strategy, UnlinkAll())))
 end
 function logjoint(model::Model, varinfo::AbstractVarInfo)
     return logjoint(model, get_values(varinfo))
@@ -1082,7 +1078,8 @@ julia> # Truth.
 """
 function logprior(model::Model, params)
     vi = OnlyAccsVarInfo(AccumulatorTuple(LogPriorAccumulator()))
-    return _evaluate_and_extract(model, (params,), vi, x -> getlogprior(last(x)))
+    init_strategy = InitFromParams(params, nothing)
+    return getlogprior(last(init!!(model, vi, init_strategy, UnlinkAll())))
 end
 function logprior(model::Model, varinfo::AbstractVarInfo)
     return logprior(model, get_values(varinfo))
@@ -1121,7 +1118,8 @@ julia> # Truth.
 """
 function Distributions.loglikelihood(model::Model, params)
     vi = OnlyAccsVarInfo(AccumulatorTuple(LogLikelihoodAccumulator()))
-    return _evaluate_and_extract(model, (params,), vi, x -> getloglikelihood(last(x)))
+    init_strategy = InitFromParams(params, nothing)
+    return getloglikelihood(last(init!!(model, vi, init_strategy, UnlinkAll())))
 end
 function Distributions.loglikelihood(model::Model, varinfo::AbstractVarInfo)
     return loglikelihood(model, get_values(varinfo))
@@ -1165,5 +1163,6 @@ function returned(model::Model, parameters...)
     # Note: we can't use `fix(model, parameters)` because
     # https://github.com/TuringLang/DynamicPPL.jl/issues/1097
     vi = DynamicPPL.OnlyAccsVarInfo(DynamicPPL.AccumulatorTuple())
-    return _evaluate_and_extract(model, parameters, vi, first)
+    init_strategy = InitFromParams(parameters..., nothing)
+    return first(init!!(model, vi, init_strategy, UnlinkAll()))
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -1030,12 +1030,16 @@ julia> # Truth.
 -9902.33787706641
 ```
 """
+function _evaluate_and_extract(model, params, vi, extract_fn)
+    init_strategy = InitFromParams(params..., nothing)
+    return extract_fn(init!!(model, vi, init_strategy, UnlinkAll()))
+end
+
 function logjoint(model::Model, params)
     vi = OnlyAccsVarInfo(
         AccumulatorTuple(LogPriorAccumulator(), LogLikelihoodAccumulator())
     )
-    init_strategy = InitFromParams(params, nothing)
-    return getlogjoint(last(init!!(model, vi, init_strategy, UnlinkAll())))
+    return _evaluate_and_extract(model, (params,), vi, x -> getlogjoint(last(x)))
 end
 function logjoint(model::Model, varinfo::AbstractVarInfo)
     return logjoint(model, get_values(varinfo))
@@ -1078,8 +1082,7 @@ julia> # Truth.
 """
 function logprior(model::Model, params)
     vi = OnlyAccsVarInfo(AccumulatorTuple(LogPriorAccumulator()))
-    init_strategy = InitFromParams(params, nothing)
-    return getlogprior(last(init!!(model, vi, init_strategy, UnlinkAll())))
+    return _evaluate_and_extract(model, (params,), vi, x -> getlogprior(last(x)))
 end
 function logprior(model::Model, varinfo::AbstractVarInfo)
     return logprior(model, get_values(varinfo))
@@ -1118,8 +1121,7 @@ julia> # Truth.
 """
 function Distributions.loglikelihood(model::Model, params)
     vi = OnlyAccsVarInfo(AccumulatorTuple(LogLikelihoodAccumulator()))
-    init_strategy = InitFromParams(params, nothing)
-    return getloglikelihood(last(init!!(model, vi, init_strategy, UnlinkAll())))
+    return _evaluate_and_extract(model, (params,), vi, x -> getloglikelihood(last(x)))
 end
 function Distributions.loglikelihood(model::Model, varinfo::AbstractVarInfo)
     return loglikelihood(model, get_values(varinfo))
@@ -1162,14 +1164,6 @@ julia> returned(model, Dict{VarName,Float64}(@varname(m) => 2.0))
 function returned(model::Model, parameters...)
     # Note: we can't use `fix(model, parameters)` because
     # https://github.com/TuringLang/DynamicPPL.jl/issues/1097
-    return first(
-        init!!(
-            model,
-            DynamicPPL.OnlyAccsVarInfo(DynamicPPL.AccumulatorTuple()),
-            # Use `nothing` as the fallback to ensure that any missing parameters cause an
-            # error
-            InitFromParams(parameters..., nothing),
-            UnlinkAll(),
-        ),
-    )
+    vi = DynamicPPL.OnlyAccsVarInfo(DynamicPPL.AccumulatorTuple())
+    return _evaluate_and_extract(model, parameters, vi, first)
 end


### PR DESCRIPTION
### What was the problem?

The problem was that in the code, the functions logjoint, logprior, loglikelihood, and the returned values all followed the same internal pattern. They were each

1) Creating an OnlyAccsVarInfo object with some accumulators.
2) Calling init!! with InitFromParams(..., nothing).
3) Extracting a result from the output.

This pattern was repeated across all four functions resulting in duplicated code. There was no shared way to handle this which made the code harder to maintain and less efficient.

### How did you fix it?

To solve this I introduced a single internal helper function called _evaluate_and_extract. This function handles the common steps of

1) Initializing the strategy with InitFromParams using the given parameters.
2) Calling init!! with the model variable information and initialization strategy.
3) Extracting the result using a provided function.

### Here’s the implementation
**function _evaluate_and_extract(model, params, vi, extract_fn)
    init_strategy = InitFromParams(params..., nothing)
    return extract_fn(init!!(model, vi, init_strategy, UnlinkAll()))
end**

Now each of the original functions (logjoint, logprior, loglikelihood) delegates the work to this helper function. They simply pass their own vi (with the appropriate accumulators) and an extraction function (extract_fn). This reduces code duplication and makes the structure clearer and more reusable.

### Note

The function pointwise_logdensities had already been fixed in version v0.41 as mentioned in the issue.

### Tests

I ran all 62,988 existing tests locally and everything passed successfully.

This change makes the code more maintainable and easier to understand by reducing redundancy.