### PR TITLE
fix: correct getindex(vi, ::Colon) docstring (#854)

### DIFF
--- a/src/abstract_varinfo.jl
+++ b/src/abstract_varinfo.jl
@@ -399,8 +399,11 @@ Return an iterator over all `vns` in `vi`.
 """
     getindex(vi::AbstractVarInfo, ::Colon)
 
-Return the current value(s) of `vn` (`vns`) in `vi` in the support of its (their)
-distribution(s) as a flattened `Vector`.
+Return the internal value(s) stored in `vi` as a flattened `Vector`. Note that
+these values may be in transformed (linked) space if `vi` has been linked.
+
+For untransformed values, use [`getindex_internal`](@ref) after calling
+[`invlink`](@ref) on `vi`.
 
 The default implementation is to call [`internal_values_as_vector`](@ref).
 """


### PR DESCRIPTION
Closes #854

## What was the problem?
The docstring for `getindex(vi::AbstractVarInfo, ::Colon)` incorrectly 
stated that it returns values "in the support of its distribution(s)". 
This is wrong - `vi[:]` actually returns the internally stored values, 
which may be in transformed (linked) space if `vi` has been linked.

## What did I fix?
Updated the docstring to correctly state that:
- `vi[:]` returns internal values which may be transformed
- For untransformed values use `getindex_internal` after calling `invlink`