### PR TITLE
Fix stale check_model doctest broken by the #1438 fence fix

### DIFF
--- a/src/debug_utils.jl
+++ b/src/debug_utils.jl
@@ -186,7 +186,9 @@ julia> # Notice that VarInfo(model_incorrect) evaluates the model, but doesn't a
        model = demo_incorrect(); varinfo = VarInfo(model);
 
 julia> check_model(model; error_on_failure=true)
-ERROR: varname x used multiple times in model
+┌ Warning: Assigning to the variable x led to a previous value being overwritten. This indicates that a value is being set twice (e.g. if the same variable occurs in a model twice).
+└ @ DynamicPPL.DebugUtils DynamicPPL.jl/src/debug_utils.jl:237
+ERROR: Model check failed; please see the warnings above for details.
 ```
 """
 function check_model(


### PR DESCRIPTION
main's Doctests workflow is currently red: https://github.com/TuringLang/DynamicPPL.jl/actions/runs/29509495151/job/87658917625

#1438 fixed a real markdown bug (an unclosed \`\`\` fence in `check_model`'s docstring), which is good, but closing that fence changed where Documenter thinks the `jldoctest` block ends. That exposed a doctest that was already stale: the "Incorrect model" example expected

```
julia> check_model(model; error_on_failure=true)
ERROR: varname x used multiple times in model
```

but `check_model`'s actual behavior for repeated `VarName`s (since at least the `DebugAccumulator` rework) is to `@warn` per repeated variable and then raise the generic `error_on_failure` message at `src/debug_utils.jl:265-266`:

```
julia> check_model(model; error_on_failure=true)
┌ Warning: Assigning to the variable x led to a previous value being overwritten. This indicates that a value is being set twice (e.g. if the same variable occurs in a model twice).
└ @ DynamicPPL.DebugUtils DynamicPPL.jl/src/debug_utils.jl:237
ERROR: Model check failed; please see the warnings above for details.
```

Updated the docstring to match, mirroring the same warning-block style already used in the "Correct model" example just above it. Verified locally: `GROUP=Doctests julia --project=. -e 'using Pkg; Pkg.test()'` passes (1/1) on Julia 1.12, matching the CI job that was failing.