### PR TITLE
Construct the default marginalizer with an explicit LBFGS

### DIFF
--- a/ext/DynamicPPLMarginalLogDensitiesExt.jl
+++ b/ext/DynamicPPLMarginalLogDensitiesExt.jl
@@ -34,7 +34,9 @@ end
         marginalized_varnames::AbstractVector{<:VarName};
         transform_strategy::DynamicPPL.AbstractTransformStrategy=DynamicPPL.LinkAll(),
         getlogprob=DynamicPPL.getlogjoint,
-        method::MarginalLogDensities.AbstractMarginalizer=MarginalLogDensities.LaplaceApprox();
+        method::MarginalLogDensities.AbstractMarginalizer=MarginalLogDensities.LaplaceApprox(
+            MarginalLogDensities.Optim.LBFGS()
+        );
         kwargs...,
     )
 
@@ -114,7 +116,9 @@ function DynamicPPL.marginalize(
     marginalized_varnames::AbstractVector{<:VarName};
     transform_strategy::DynamicPPL.AbstractTransformStrategy=DynamicPPL.LinkAll(),
     getlogprob::Function=DynamicPPL.getlogjoint,
-    method::MarginalLogDensities.AbstractMarginalizer=MarginalLogDensities.LaplaceApprox(),
+    method::MarginalLogDensities.AbstractMarginalizer=MarginalLogDensities.LaplaceApprox(
+        MarginalLogDensities.Optim.LBFGS()
+    ),
     kwargs...,
 )
     # Construct the marginal log-density model.


### PR DESCRIPTION
Fixes #1447.

`marginalize` defaulted to `MarginalLogDensities.LaplaceApprox()`, whose own default solver is a bare `LBFGS` that OptimizationOptimJL stopped re-exporting in 0.4.19. The default now passes `MarginalLogDensities.Optim.LBFGS()` explicitly.

`Optim` is reachable from the `MarginalLogDensities` namespace on both 0.4.18 and 0.4.19, so this needs no pin and no new dependency. The integration tests pass against 0.4.19 unpinned.
