### PR TITLE
accumulators: Isolate debug raw-value splits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ vi = accumulate_assume!!(vi, x, tval, logjac, vn, dist, template)
   - Use `VarNamedTuple` as the canonical internal representation for named parameter collections in new code. Convert user-facing `NamedTuple` and `Dict{VarName}` inputs at boundaries.
   - Preserve templates, shapes, and index structure when round-tripping between named values and flat vectors.
   - Ensure `copy(acc)` does not share mutable internal state; aliased accumulator containers corrupt results when copied for `ThreadSafeVarInfo`.
+  - Ensure `split(acc)` does not share mutable accumulation state; `combine` must merge that state even when it is stored outside the main value container.
   - Use `@varname(x)`, not `:x` or `VarName(:x)`. Use subsumption for containment checks, e.g. `subsumes(@varname(x), @varname(x[1]))`. Conditioning on `@varname(x)` covers subindices; conditioning on `@varname(x[1])` only matches that index.
 
 ## `@model` Compiler

--- a/src/accumulators/raw_values.jl
+++ b/src/accumulators/raw_values.jl
@@ -61,6 +61,18 @@ function DebugRawValueAccumulator()
     return VNTAccumulator{RAW_VALUE_ACCNAME}(DebugGetRawValues(Set{VarName}()))
 end
 
+# Split accumulators need independent sets because repeated names are mutable state.
+function _zero(
+    acc::Union{
+        VNTAccumulator{RAW_VALUE_ACCNAME,DebugGetRawValues},
+        TSVNTAccumulator{RAW_VALUE_ACCNAME,DebugGetRawValues},
+    },
+)
+    new_acc = copy(acc)
+    empty!(new_acc.f.repeated_vns)
+    return update_values(new_acc, empty(new_acc.values))
+end
+
 # Unfortunately we have to overload accumulate_assume!! since we need to use the
 # templated_setindex_no_overwrite!! function
 function accumulate_assume!!(
@@ -120,9 +132,7 @@ function DynamicPPL.combine(
         TSVNTAccumulator{RAW_VALUE_ACCNAME,DebugGetRawValues},
     },
 )
-    if acc1.f !== acc2.f
-        throw(ArgumentError("Cannot combine accumulators with different functions"))
-    end
+    union!(acc1.f.repeated_vns, acc2.f.repeated_vns)
 
     new_values = acc1.values
     for (vn, val) in pairs(acc2.values)

--- a/test/accumulators.jl
+++ b/test/accumulators.jl
@@ -99,6 +99,12 @@ TEST_ACCUMULATORS = (
             ]
                 @test combine(acc, split(acc)) == acc
             end
+
+            acc = DynamicPPL.DebugRawValueAccumulator()
+            split_acc, other_split_acc = split(acc), split(acc)
+            @test split_acc.f.repeated_vns !== other_split_acc.f.repeated_vns
+            push!(split_acc.f.repeated_vns, @varname(x))
+            @test combine(acc, split_acc).f.repeated_vns == Set((@varname(x),))
         end
 
         @testset "conversions" begin


### PR DESCRIPTION
Give each split accumulator independent repeated-variable state and merge it during combination.

Fixes #1444.