### PR TITLE
test: Add indexed-container demos and skip fork benchmarks

### DIFF
--- a/.github/workflows/Benchmarking.yml
+++ b/.github/workflows/Benchmarking.yml
@@ -14,7 +14,10 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
+  # Fork PRs cannot use the write token needed to post results. Using
+  # `pull_request_target` here would execute untrusted PR code with that token.
   benchmark-pr:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     # OS pinned (rather than `ubuntu-latest`) so that successive runs land on
     # the same VM family — GitHub silently rotates `latest` and the noise
     # floor changes between runs. Julia version pinned for the same reason:
@@ -46,6 +49,7 @@ jobs:
             benchmarks/version_info.txt
 
   benchmark-main:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     # Tracks main's moving HEAD — the displayed main SHA may shift between
     # successive re-runs of the same PR if main advances in the interim.
     runs-on: ubuntu-22.04

--- a/src/test_utils/models.jl
+++ b/src/test_utils/models.jl
@@ -511,6 +511,93 @@ function varnames(model::Model{typeof(demo_dot_assume_observe_matrix_index)})
     return [@varname(s[1]), @varname(s[2]), @varname(m)]
 end
 
+@model function demo_assume_matrix_index_observe_matrix_index(
+    x=transpose([1.5 2.0;]), ::Type{TV}=Matrix{Float64}
+) where {TV}
+    s = TV(undef, size(x))
+    for j in axes(s, 2), i in axes(s, 1)
+        s[i, j] ~ InverseGamma(2, 3)
+    end
+    m = TV(undef, size(x))
+    for j in axes(m, 2), i in axes(m, 1)
+        m[i, j] ~ Normal(0, sqrt(s[i, j]))
+    end
+    for j in axes(x, 2), i in axes(x, 1)
+        x[i, j] ~ Normal(m[i, j], sqrt(s[i, j]))
+    end
+
+    return (; s=s, m=m, x=x)
+end
+function logprior_true(
+    model::Model{typeof(demo_assume_matrix_index_observe_matrix_index)}, s, m
+)
+    return loglikelihood(InverseGamma(2, 3), s) + sum(logpdf.(Normal.(0, sqrt.(s)), m))
+end
+function loglikelihood_true(
+    model::Model{typeof(demo_assume_matrix_index_observe_matrix_index)}, s, m
+)
+    return sum(logpdf.(Normal.(m, sqrt.(s)), model.args.x))
+end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_assume_matrix_index_observe_matrix_index)}, s, m
+)
+    return _demo_logprior_true_with_logabsdet_jacobian(model, s, m)
+end
+function varnames(model::Model{typeof(demo_assume_matrix_index_observe_matrix_index)})
+    x = model.args.x
+    s_vns = vec([@varname(s[i, j]) for i in axes(x, 1), j in axes(x, 2)])
+    m_vns = vec([@varname(m[i, j]) for i in axes(x, 1), j in axes(x, 2)])
+    return [s_vns; m_vns]
+end
+
+@model function demo_assume_nested_index_observe_nested_index(
+    x=[[1.5], [2.0]], ::Type{TV}=Vector{Float64}
+) where {TV}
+    s = [TV(undef, length(xi)) for xi in x]
+    for i in eachindex(s), j in eachindex(s[i])
+        s[i][j] ~ InverseGamma(2, 3)
+    end
+    m = [TV(undef, length(xi)) for xi in x]
+    for i in eachindex(m), j in eachindex(m[i])
+        m[i][j] ~ Normal(0, sqrt(s[i][j]))
+    end
+    for i in eachindex(x), j in eachindex(x[i])
+        x[i][j] ~ Normal(m[i][j], sqrt(s[i][j]))
+    end
+
+    return (; s=s, m=m, x=x)
+end
+function logprior_true(
+    model::Model{typeof(demo_assume_nested_index_observe_nested_index)}, s, m
+)
+    s_vec = [value for values in s for value in values]
+    m_vec = [value for values in m for value in values]
+    return loglikelihood(InverseGamma(2, 3), s_vec) +
+           sum(logpdf.(Normal.(0, sqrt.(s_vec)), m_vec))
+end
+function loglikelihood_true(
+    model::Model{typeof(demo_assume_nested_index_observe_nested_index)}, s, m
+)
+    return sum(
+        logpdf(Normal(m[i][j], sqrt(s[i][j])), model.args.x[i][j]) for
+        i in eachindex(model.args.x) for j in eachindex(model.args.x[i])
+    )
+end
+function logprior_true_with_logabsdet_jacobian(
+    model::Model{typeof(demo_assume_nested_index_observe_nested_index)}, s, m
+)
+    b = Bijectors.bijector(InverseGamma(2, 3))
+    s_unconstrained = [b.(values) for values in s]
+    Δlogp = sum(Bijectors.logabsdetjac(b, value) for values in s for value in values)
+    return (s=s_unconstrained, m=m), logprior_true(model, s, m) - Δlogp
+end
+function varnames(model::Model{typeof(demo_assume_nested_index_observe_nested_index)})
+    x = model.args.x
+    s_vns = [@varname(s[i][j]) for i in eachindex(x) for j in eachindex(x[i])]
+    m_vns = [@varname(m[i][j]) for i in eachindex(x) for j in eachindex(x[i])]
+    return [s_vns; m_vns]
+end
+
 @model function demo_assume_matrix_observe_matrix_index(
     x=transpose([1.5 2.0;]), ::Type{TV}=Array{Float64}
 ) where {TV}
@@ -637,6 +724,7 @@ const MultivariateAssumeDemoModels = Union{
     Model{typeof(demo_assume_submodel_observe_index_literal)},
     Model{typeof(demo_dot_assume_observe_submodel)},
     Model{typeof(demo_dot_assume_observe_matrix_index)},
+    Model{typeof(demo_assume_matrix_index_observe_matrix_index)},
 }
 function posterior_mean(model::MultivariateAssumeDemoModels)
     # Get some containers to fill.
@@ -683,6 +771,56 @@ function rand_prior_true(rng::Random.AbstractRNG, model::MultivariateAssumeDemoM
     for i in LinearIndices(vals.s)
         vals.s[i] = rand(rng, InverseGamma(2, 3))
         vals.m[i] = rand(rng, Normal(0, sqrt(vals.s[i])))
+    end
+
+    return vals
+end
+
+function posterior_mean(model::Model{typeof(demo_assume_nested_index_observe_nested_index)})
+    vals = rand_prior_true(model)
+
+    vals.s[1][1] = 19 / 8
+    vals.m[1][1] = 3 / 4
+
+    vals.s[2][1] = 8 / 3
+    vals.m[2][1] = 1
+
+    return vals
+end
+function likelihood_optima(
+    model::Model{typeof(demo_assume_nested_index_observe_nested_index)}
+)
+    vals = rand_prior_true(model)
+
+    vals.s[1][1] = floatmin()
+    vals.s[2][1] = floatmin()
+
+    vals.m[1][1] = 1.5
+    vals.m[2][1] = 2.0
+
+    return vals
+end
+function posterior_optima(
+    model::Model{typeof(demo_assume_nested_index_observe_nested_index)}
+)
+    vals = rand_prior_true(model)
+
+    vals.s[1][1] = 0.890625
+    vals.s[2][1] = 1
+    vals.m[1][1] = 3 / 4
+    vals.m[2][1] = 1
+
+    return vals
+end
+function rand_prior_true(
+    rng::Random.AbstractRNG,
+    model::Model{typeof(demo_assume_nested_index_observe_nested_index)},
+)
+    retval = model(rng)
+    vals = (s=retval.s, m=retval.m)
+    for i in eachindex(vals.s), j in eachindex(vals.s[i])
+        vals.s[i][j] = rand(rng, InverseGamma(2, 3))
+        vals.m[i][j] = rand(rng, Normal(0, sqrt(vals.s[i][j])))
     end
 
     return vals
@@ -833,6 +971,8 @@ const DEMO_MODELS = (
     demo_assume_submodel_observe_index_literal(),
     demo_dot_assume_observe_submodel(),
     demo_dot_assume_observe_matrix_index(),
+    demo_assume_matrix_index_observe_matrix_index(),
+    demo_assume_nested_index_observe_nested_index(),
     demo_assume_matrix_observe_matrix_index(),
     demo_nested_colons(),
 )


### PR DESCRIPTION
Add demo models for matrix and nested indexing. Skip benchmark jobs for fork PRs, which lack write permission.

Fixes #748; fixes #1044.