### PR TITLE
Describe vi[:] as an alias, it is not being deprecated

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.42.5"
+version = "0.42.6"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/abstract_varinfo.jl
+++ b/src/abstract_varinfo.jl
@@ -404,8 +404,7 @@ Return the values stored internally in `vi` as a flattened `Vector`.
 For unlinked variables, these are vectorised model-space values. Linked variables are stored
 in transformed coordinates, which need not be in the support of their distributions.
 
-`vi[:]` is retained only for compatibility and will be deprecated once Turing stops using
-it. Use [`internal_values_as_vector`](@ref) instead. Both forms may promote mixed
+`vi[:]` is equivalent to [`internal_values_as_vector`](@ref). Both forms may promote mixed
 per-variable element types when constructing the output vector.
 
 # Examples


### PR DESCRIPTION
`vi[:]` is staying, per the decision on #1454, so the docstring should not promise a deprecation. It now describes `vi[:]` as an alias of `internal_values_as_vector`.

Bumps to 0.42.6 so the pending HISTORY section can be released.
