### PR TITLE
VarNamedTuple: merge different-length vector-backed PartialArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DynamicPPL"
 uuid = "366bfd00-2699-11ea-058f-f148b4cae6d8"
-version = "0.42.7"
+version = "0.42.8"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/varnamedtuple/partial_array.jl
+++ b/src/varnamedtuple/partial_array.jl
@@ -647,6 +647,20 @@ function _subset_partialarray(pa::PartialArray, inds::Vararg{Any}; kw...)
 end
 
 Base.merge(x1::PartialArray, x2::PartialArray) = _merge(x1, x2, Val(true))
+function _grow_vector_to_length(pa::PartialArray{T,1,<:Vector}, new_length) where {T}
+    current_length = length(pa.data)
+    current_length == new_length && return pa
+    @assert current_length < new_length
+    new_data = similar(pa.data, new_length)
+    new_mask = fill!(similar(pa.mask, new_length), false)
+    for i in eachindex(pa.mask)
+        if pa.mask[i]
+            new_data[i] = pa.data[i]
+            new_mask[i] = true
+        end
+    end
+    return PartialArray(new_data, new_mask)
+end
 function _merge(pa1::PartialArray, pa2::PartialArray, recurse::Val)
     # If both `pa1` and `pa2` are GrowableArrays, we can grow them before merging
     if pa1.data isa GrowableArray && pa2.data isa GrowableArray && ndims(pa1) == ndims(pa2)
@@ -655,6 +669,11 @@ function _merge(pa1::PartialArray, pa2::PartialArray, recurse::Val)
         new_size = map(max, size1, size2)
         pa1 = grow_to_indices!!(pa1, new_size...)
         pa2 = grow_to_indices!!(pa2, new_size...)
+    elseif pa1.data isa Vector && pa2.data isa Vector
+        # Vector lengths may depend on earlier random variables, so merge over their union.
+        new_length = max(length(pa1.data), length(pa2.data))
+        pa1 = _grow_vector_to_length(pa1, new_length)
+        pa2 = _grow_vector_to_length(pa2, new_length)
     end
 
     # TODO(penelopeysm) In general, we should like to catch more cases (e.g. where the

--- a/src/varnamedtuple/partial_array.jl
+++ b/src/varnamedtuple/partial_array.jl
@@ -647,12 +647,13 @@ function _subset_partialarray(pa::PartialArray, inds::Vararg{Any}; kw...)
 end
 
 Base.merge(x1::PartialArray, x2::PartialArray) = _merge(x1, x2, Val(true))
-function _grow_vector_to_length(pa::PartialArray{T,1,<:Vector}, new_length) where {T}
+function _grow_vector_to_axes(pa::PartialArray{T,1,<:AbstractVector}, new_axes) where {T}
     current_length = length(pa.data)
-    current_length == new_length && return pa
+    axes(pa.data) == new_axes && return pa
+    new_length = length(only(new_axes))
     @assert current_length < new_length
-    new_data = similar(pa.data, new_length)
-    new_mask = fill!(similar(pa.mask, new_length), false)
+    new_data = similar(pa.data, new_axes)
+    new_mask = fill!(similar(pa.mask, new_axes), false)
     for i in eachindex(pa.mask)
         if pa.mask[i]
             new_data[i] = pa.data[i]
@@ -669,11 +670,16 @@ function _merge(pa1::PartialArray, pa2::PartialArray, recurse::Val)
         new_size = map(max, size1, size2)
         pa1 = grow_to_indices!!(pa1, new_size...)
         pa2 = grow_to_indices!!(pa2, new_size...)
-    elseif pa1.data isa Vector && pa2.data isa Vector
+    elseif pa1.data isa AbstractVector &&
+        pa2.data isa AbstractVector &&
+        length(pa1.data) != length(pa2.data) &&
+        !Base.has_offset_axes(pa1.data) &&
+        !Base.has_offset_axes(pa2.data) &&
+        typeof(axes(pa1.data, 1)) === typeof(axes(pa2.data, 1))
         # Vector lengths may depend on earlier random variables, so merge over their union.
-        new_length = max(length(pa1.data), length(pa2.data))
-        pa1 = _grow_vector_to_length(pa1, new_length)
-        pa2 = _grow_vector_to_length(pa2, new_length)
+        new_axes = length(pa1.data) < length(pa2.data) ? axes(pa2.data) : axes(pa1.data)
+        pa1 = _grow_vector_to_axes(pa1, new_axes)
+        pa2 = _grow_vector_to_axes(pa2, new_axes)
     end
 
     # TODO(penelopeysm) In general, we should like to catch more cases (e.g. where the

--- a/src/varnamedtuple/partial_array.jl
+++ b/src/varnamedtuple/partial_array.jl
@@ -663,6 +663,7 @@ function _grow_vector_to_axes(pa::PartialArray{T,1,<:AbstractVector}, new_axes) 
     return PartialArray(new_data, new_mask)
 end
 function _has_compatible_vector_axes(v1::AbstractVector, v2::AbstractVector)
+    typeof(only(axes(v1))) === typeof(only(axes(v2))) || return false
     shorter, longer = length(v1) < length(v2) ? (v1, v2) : (v2, v1)
     shorter_axis = only(axes(shorter))
     prefix_axis = only(axes(view(longer, Base.OneTo(length(shorter)))))

--- a/src/varnamedtuple/partial_array.jl
+++ b/src/varnamedtuple/partial_array.jl
@@ -664,7 +664,14 @@ function _grow_vector_to_axes(pa::PartialArray{T,1,<:AbstractVector}, new_axes) 
 end
 function _has_compatible_vector_axes(v1::AbstractVector, v2::AbstractVector)
     shorter, longer = length(v1) < length(v2) ? (v1, v2) : (v2, v1)
-    return axes(shorter) === axes(view(longer, Base.OneTo(length(shorter))))
+    shorter_axis = only(axes(shorter))
+    prefix_axis = only(axes(view(longer, Base.OneTo(length(shorter)))))
+    # Axis equality can ignore coordinate metadata carried by custom axes.
+    properties = propertynames(shorter_axis, true)
+    return properties == propertynames(prefix_axis, true) && all(
+        name -> isequal(getproperty(shorter_axis, name), getproperty(prefix_axis, name)),
+        properties,
+    )
 end
 function _merge(pa1::PartialArray, pa2::PartialArray, recurse::Val)
     # If both `pa1` and `pa2` are GrowableArrays, we can grow them before merging

--- a/src/varnamedtuple/partial_array.jl
+++ b/src/varnamedtuple/partial_array.jl
@@ -662,6 +662,10 @@ function _grow_vector_to_axes(pa::PartialArray{T,1,<:AbstractVector}, new_axes) 
     end
     return PartialArray(new_data, new_mask)
 end
+function _has_compatible_vector_axes(v1::AbstractVector, v2::AbstractVector)
+    shorter, longer = length(v1) < length(v2) ? (v1, v2) : (v2, v1)
+    return axes(shorter) === axes(view(longer, Base.OneTo(length(shorter))))
+end
 function _merge(pa1::PartialArray, pa2::PartialArray, recurse::Val)
     # If both `pa1` and `pa2` are GrowableArrays, we can grow them before merging
     if pa1.data isa GrowableArray && pa2.data isa GrowableArray && ndims(pa1) == ndims(pa2)
@@ -675,7 +679,7 @@ function _merge(pa1::PartialArray, pa2::PartialArray, recurse::Val)
         length(pa1.data) != length(pa2.data) &&
         !Base.has_offset_axes(pa1.data) &&
         !Base.has_offset_axes(pa2.data) &&
-        typeof(axes(pa1.data, 1)) === typeof(axes(pa2.data, 1))
+        _has_compatible_vector_axes(pa1.data, pa2.data)
         # Vector lengths may depend on earlier random variables, so merge over their union.
         new_axes = length(pa1.data) < length(pa2.data) ? axes(pa2.data) : axes(pa1.data)
         pa1 = _grow_vector_to_axes(pa1, new_axes)

--- a/test/varnamedtuple.jl
+++ b/test/varnamedtuple.jl
@@ -1205,6 +1205,20 @@ Base.size(st::SizedThing) = st.size
             @test merged_dims[@varname(x[1])] == 1.0
             @test merged_dims[@varname(x[2])] == 3.0
             @test typeof(merged_dims.data.x.data) === typeof(dims2.data.x.data)
+
+            coordinates1 = templated_setindex!!(
+                VarNamedTuple(),
+                1.0,
+                @varname(x[1]),
+                DD.DimArray(zeros(1), (DD.X(10:10:10),)),
+            )
+            coordinates2 = templated_setindex!!(
+                VarNamedTuple(),
+                2.0,
+                @varname(x[1]),
+                DD.DimArray(zeros(2), (DD.X(20:10:30),)),
+            )
+            @test_throws ArgumentError merge(coordinates2, coordinates1)
         end
 
         @testset "different dimensions" begin

--- a/test/varnamedtuple.jl
+++ b/test/varnamedtuple.jl
@@ -1178,18 +1178,25 @@ Base.size(st::SizedThing) = st.size
         =#
     end
 
-    @testset "merging PartialArrays errors with different axes" begin
-        @testset "different sizes" begin
+    @testset "merging PartialArrays with different axes" begin
+        @testset "different vector lengths" begin
             vnt1 = templated_setindex!!(VarNamedTuple(), 1.0, @varname(x[1]), zeros(1))
             vnt2 = templated_setindex!!(VarNamedTuple(), 2.0, @varname(x[1]), zeros(2))
-            @test_throws ArgumentError merge(vnt1, vnt2)
+            vnt2 = setindex!!(vnt2, 3.0, @varname(x[2]))
+            @test @inferred(merge(vnt1, vnt2)) == vnt2
 
+            expected = templated_setindex!!(VarNamedTuple(), 1.0, @varname(x[1]), zeros(2))
+            expected = setindex!!(expected, 3.0, @varname(x[2]))
+            @test @inferred(merge(vnt2, vnt1)) == expected
+        end
+
+        @testset "different dimensions" begin
             vnt1 = templated_setindex!!(VarNamedTuple(), 1.0, @varname(x[1]), zeros(1))
             vnt2 = templated_setindex!!(VarNamedTuple(), 2.0, @varname(x[1]), zeros(1, 1))
             @test_throws ArgumentError merge(vnt1, vnt2)
         end
 
-        @testset "different types" begin
+        @testset "different axis origins" begin
             vnt1 = templated_setindex!!(VarNamedTuple(), 1.0, @varname(x[1]), zeros(1))
             vnt2 = templated_setindex!!(
                 VarNamedTuple(), 2.0, @varname(x[0]), OA.OffsetArray(zeros(1), 0:0)

--- a/test/varnamedtuple.jl
+++ b/test/varnamedtuple.jl
@@ -1188,6 +1188,23 @@ Base.size(st::SizedThing) = st.size
             expected = templated_setindex!!(VarNamedTuple(), 1.0, @varname(x[1]), zeros(2))
             expected = setindex!!(expected, 3.0, @varname(x[2]))
             @test @inferred(merge(vnt2, vnt1)) == expected
+
+            bits1 = templated_setindex!!(VarNamedTuple(), false, @varname(x[1]), falses(1))
+            bits2 = templated_setindex!!(VarNamedTuple(), true, @varname(x[1]), falses(2))
+            bits2 = setindex!!(bits2, true, @varname(x[2]))
+            @test @inferred(merge(bits1, bits2)) == bits2
+
+            dims1 = templated_setindex!!(
+                VarNamedTuple(), 1.0, @varname(x[1]), DD.DimArray(zeros(1), (DD.X,))
+            )
+            dims2 = templated_setindex!!(
+                VarNamedTuple(), 2.0, @varname(x[1]), DD.DimArray(zeros(2), (DD.X,))
+            )
+            dims2 = setindex!!(dims2, 3.0, @varname(x[2]))
+            merged_dims = @inferred merge(dims2, dims1)
+            @test merged_dims[@varname(x[1])] == 1.0
+            @test merged_dims[@varname(x[2])] == 3.0
+            @test typeof(merged_dims.data.x.data) === typeof(dims2.data.x.data)
         end
 
         @testset "different dimensions" begin

--- a/test/varnamedtuple.jl
+++ b/test/varnamedtuple.jl
@@ -157,6 +157,28 @@ struct SizedThing{T<:Tuple}
 end
 Base.size(st::SizedThing) = st.size
 
+struct TaggedAxis{Tag} <: AbstractUnitRange{Int}
+    stop::Int
+end
+Base.first(::TaggedAxis) = 1
+Base.last(axis::TaggedAxis) = axis.stop
+Base.length(axis::TaggedAxis) = axis.stop
+Base.getindex(axis::TaggedAxis, i::Int) = getindex(Base.OneTo(axis.stop), i)
+
+struct TaggedVector{Tag,T} <: AbstractVector{T}
+    data::Vector{T}
+end
+TaggedVector{Tag}(data::Vector{T}) where {Tag,T} = TaggedVector{Tag,T}(data)
+Base.size(vector::TaggedVector) = size(vector.data)
+Base.axes(vector::TaggedVector{Tag}) where {Tag} = (TaggedAxis{Tag}(length(vector.data)),)
+Base.getindex(vector::TaggedVector, i::Int) = vector.data[i]
+Base.setindex!(vector::TaggedVector, value, i::Int) = setindex!(vector.data, value, i)
+function Base.similar(
+    vector::TaggedVector, ::Type{T}, axes::Tuple{TaggedAxis{Tag}}
+) where {T,Tag}
+    return TaggedVector{Tag}(similar(vector.data, T, length(only(axes))))
+end
+
 @testset "VarNamedTuple" begin
     @testset "Construction" begin
         vnt1 = VarNamedTuple()
@@ -1231,6 +1253,14 @@ Base.size(st::SizedThing) = st.size
                 DD.DimArray(zeros(2), (DD.X([20, 30]),)),
             )
             @test_throws ArgumentError merge(coordinates2, incompatible_coordinates)
+
+            meters = PartialArray(
+                TaggedVector{:meters}([1.0]), TaggedVector{:meters}([true])
+            )
+            seconds = PartialArray(
+                TaggedVector{:seconds}([2.0, 3.0]), TaggedVector{:seconds}([true, true])
+            )
+            @test_throws ArgumentError merge(seconds, meters)
         end
 
         @testset "different dimensions" begin

--- a/test/varnamedtuple.jl
+++ b/test/varnamedtuple.jl
@@ -1210,15 +1210,27 @@ Base.size(st::SizedThing) = st.size
                 VarNamedTuple(),
                 1.0,
                 @varname(x[1]),
-                DD.DimArray(zeros(1), (DD.X(10:10:10),)),
+                DD.DimArray(zeros(2), (DD.X([10, 20]),)),
             )
             coordinates2 = templated_setindex!!(
                 VarNamedTuple(),
                 2.0,
                 @varname(x[1]),
-                DD.DimArray(zeros(2), (DD.X(20:10:30),)),
+                DD.DimArray(zeros(3), (DD.X([10, 20, 30]),)),
             )
-            @test_throws ArgumentError merge(coordinates2, coordinates1)
+            coordinates2 = setindex!!(coordinates2, 3.0, @varname(x[3]))
+            merged_coordinates = @inferred merge(coordinates2, coordinates1)
+            @test merged_coordinates[@varname(x[1])] == 1.0
+            @test merged_coordinates[@varname(x[3])] == 3.0
+            @test DD.dims(merged_coordinates.data.x.data) == (DD.X([10, 20, 30]),)
+
+            incompatible_coordinates = templated_setindex!!(
+                VarNamedTuple(),
+                1.0,
+                @varname(x[1]),
+                DD.DimArray(zeros(2), (DD.X([20, 30]),)),
+            )
+            @test_throws ArgumentError merge(coordinates2, incompatible_coordinates)
         end
 
         @testset "different dimensions" begin


### PR DESCRIPTION
Element-wise random arrays whose length depends on an earlier random variable produce `PartialArray`s backed by ordinary vectors of the current length. Merging snapshots from different executions therefore failed the unequal-axes check. The existing union-of-indices path handled this case only for `GrowableArray` backings.

Extend that normalization to ordinary vectors. Before merging, widen the shorter backing to the common length and copy only entries marked valid by its mask. Existing merge semantics then preserve left-only tail entries while giving the right operand precedence on overlaps.

The change remains limited to ordinary vectors. Arrays with different dimensions, offset axes, or other layouts still throw because their widening semantics are not generally defined.

Regression tests cover growth, shrinkage, retained tail entries, right-hand precedence, inference, and the remaining incompatible-axis cases. The complete `VarNamedTuple` test suite passes.

Fixes #1470.
