### PR TITLE
VarNamedTuple: merge growable and templated arrays

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # 0.42.11
 
-Partial-array merges now expand growable storage when the other array has a template, including for matrices and higher-dimensional arrays.
+Partial-array merges now expand growable storage when the other array has a template, including for matrices and higher-dimensional arrays. See [#1482](https://github.com/TuringLang/DynamicPPL.jl/pull/1482).
 
 Stan programs can now be embedded as distributions in DynamicPPL models when BridgeStan is loaded, with ForwardDiff and Mooncake support. See [#1478](https://github.com/TuringLang/DynamicPPL.jl/pull/1478).
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # 0.42.11
 
+Partial-array merges now expand growable storage when the other array has a template, including for matrices and higher-dimensional arrays.
+
 Stan programs can now be embedded as distributions in DynamicPPL models when BridgeStan is loaded, with ForwardDiff and Mooncake support. See [#1478](https://github.com/TuringLang/DynamicPPL.jl/pull/1478).
 
 # 0.42.10

--- a/src/varnamedtuple/partial_array.jl
+++ b/src/varnamedtuple/partial_array.jl
@@ -675,14 +675,16 @@ function _has_compatible_vector_axes(v1::AbstractVector, v2::AbstractVector)
     )
 end
 function _merge(pa1::PartialArray, pa2::PartialArray, recurse::Val)
-    # If both `pa1` and `pa2` are GrowableArrays, we can grow them before merging
-    if pa1.data isa GrowableArray && pa2.data isa GrowableArray && ndims(pa1) == ndims(pa2)
+    # Growable storage records a minimum extent, even when the other array has a template.
+    if (pa1.data isa GrowableArray || pa2.data isa GrowableArray) &&
+        ndims(pa1) == ndims(pa2)
         size1 = size(pa1.data)
         size2 = size(pa2.data)
         new_size = map(max, size1, size2)
         pa1 = grow_to_indices!!(pa1, new_size...)
         pa2 = grow_to_indices!!(pa2, new_size...)
-    elseif pa1.data isa AbstractVector &&
+    end
+    if pa1.data isa AbstractVector &&
         pa2.data isa AbstractVector &&
         length(pa1.data) != length(pa2.data) &&
         !Base.has_offset_axes(pa1.data) &&

--- a/test/conditionfix.jl
+++ b/test/conditionfix.jl
@@ -412,7 +412,7 @@ DynamicPPL.setchildcontext(::MyParentContext, child) = MyParentContext(child)
         end
     end
 
-    @testset "merging growable and templated conditions" begin
+    @testset "merging growable and templated conditions (#1481)" begin
         @model function partial_array_model()
             x = zeros(2, 2)
             x[1, 1] ~ Normal()
@@ -427,11 +427,13 @@ DynamicPPL.setchildcontext(::MyParentContext, child) = MyParentContext(child)
             x[2, 1] := 2.5
         end
         for op in (condition, fix)
-            model = op(partial_array_model(), Dict(@varname(x[1, 1]) => 1.5))
-            nested = partial_array_parent(model)
-            for updated in
-                (op(model, next_values), op(nested, VarNamedTuple(; child=next_values)))
-                @test returned(updated, VarNamedTuple()) == [1.5 0.0; 2.5 0.0]
+            model = partial_array_model()
+            nested = op(partial_array_parent(model), Dict(@varname(child.x[1, 1]) => 1.5))
+            model = op(model, Dict(@varname(x[1, 1]) => 1.5))
+            for (partial_model, values) in
+                ((model, next_values), (nested, VarNamedTuple(; child=next_values)))
+                @test returned(op(partial_model, values), VarNamedTuple()) ==
+                    [1.5 0.0; 2.5 0.0]
             end
         end
     end

--- a/test/conditionfix.jl
+++ b/test/conditionfix.jl
@@ -411,6 +411,30 @@ DynamicPPL.setchildcontext(::MyParentContext, child) = MyParentContext(child)
             end
         end
     end
+
+    @testset "merging growable and templated conditions" begin
+        @model function partial_array_model()
+            x = zeros(2, 2)
+            x[1, 1] ~ Normal()
+            x[2, 1] ~ Normal()
+            return x
+        end
+        @model function partial_array_parent(child_model)
+            return child ~ to_submodel(child_model)
+        end
+        next_values = @vnt begin
+            @template x = zeros(2, 2)
+            x[2, 1] := 2.5
+        end
+        for op in (condition, fix)
+            model = op(partial_array_model(), Dict(@varname(x[1, 1]) => 1.5))
+            nested = partial_array_parent(model)
+            for updated in
+                (op(model, next_values), op(nested, VarNamedTuple(; child=next_values)))
+                @test returned(updated, VarNamedTuple()) == [1.5 0.0; 2.5 0.0]
+            end
+        end
+    end
 end
 
 @testset "PrefixContext + CondFixContext interactions" begin

--- a/test/varnamedtuple.jl
+++ b/test/varnamedtuple.jl
@@ -1201,7 +1201,7 @@ end
     end
 
     @testset "merging PartialArrays with different axes" begin
-        @testset "mixed growable and templated storage" begin
+        @testset "mixed growable and templated storage (#1481)" begin
             growable = setindex!!(VarNamedTuple(), "left", @varname(x[1, 2]))
             templated = templated_setindex!!(
                 VarNamedTuple(), "right", @varname(x[2, 1]), Matrix{String}(undef, 2, 2)

--- a/test/varnamedtuple.jl
+++ b/test/varnamedtuple.jl
@@ -1201,6 +1201,38 @@ end
     end
 
     @testset "merging PartialArrays with different axes" begin
+        @testset "mixed growable and templated storage" begin
+            growable = setindex!!(VarNamedTuple(), "left", @varname(x[1, 2]))
+            templated = templated_setindex!!(
+                VarNamedTuple(), "right", @varname(x[2, 1]), Matrix{String}(undef, 2, 2)
+            )
+            original_growable, original_templated = copy(growable), copy(templated)
+            expected = setindex!!(copy(templated), "left", @varname(x[1, 2]))
+            @test @inferred(merge(growable, templated)) == expected
+            @test @inferred(merge(templated, growable)) == expected
+            @test isequal(growable, original_growable)
+            @test isequal(templated, original_templated)
+
+            templated = setindex!!(templated, "overlap", @varname(x[1, 2]))
+            @test merge(growable, templated)[@varname(x[1, 2])] == "overlap"
+            @test merge(templated, growable)[@varname(x[1, 2])] == "left"
+
+            growable = setindex!!(VarNamedTuple(), 1.0, @varname(x[3]))
+            templated = templated_setindex!!(VarNamedTuple(), 2.0, @varname(x[1]), zeros(2))
+            expected = setindex!!(copy(growable), 2.0, @varname(x[1]))
+            @test @inferred(merge(growable, templated)) == expected
+            @test @inferred(merge(templated, growable)) == expected
+
+            for template in (zeros(2), zeros(1, 1), OA.OffsetArray(zeros(2, 2), 0:1, 0:1))
+                growable = setindex!!(VarNamedTuple(), 1.0, @varname(x[2, 2]))
+                templated = templated_setindex!!(
+                    VarNamedTuple(), 2.0, @varname(x[1]), template
+                )
+                @test_throws ArgumentError merge(growable, templated)
+                @test_throws ArgumentError merge(templated, growable)
+            end
+        end
+
         @testset "different vector lengths" begin
             vnt1 = templated_setindex!!(VarNamedTuple(), 1.0, @varname(x[1]), zeros(1))
             vnt2 = templated_setindex!!(VarNamedTuple(), 2.0, @varname(x[1]), zeros(2))


### PR DESCRIPTION
Growable storage records a minimum extent, not the full array shape. Expand it before merging with templated arrays, preserving bindings and overwrite precedence.

```julia
using DynamicPPL

a = @vnt begin
    x[1, 1] := 1.5
end
b = @vnt begin
    @template x = zeros(2, 2)
    x[2, 1] := 2.5
end
```

Before, `merge(a, b)` throws:

```text
ERROR: ArgumentError: Cannot merge PartialArrays with different axes
```

After:

```julia
merged = merge(a, b)
merged[@varname(x[1, 1])]  # 1.5
merged[@varname(x[2, 1])]  # 2.5
```

Tests cover both merge orders, masked entries, and nested conditioning/fixing.

Fix #1481.
