### PR TITLE
Let predict evaluate the chain across threads

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # 0.42.12
 
+`predict` now takes `multithreaded`, which spreads the samples of the chain over threads.
+Each sample is drawn with its own random number generator, seeded from `rng` before any thread starts, so a given `rng` gives the same predictions whatever the thread count.
+Those predictions differ from the single-threaded ones for that same `rng`, which draws every sample from one stream.
+See [#1170](https://github.com/TuringLang/DynamicPPL.jl/issues/1170).
+
 `check_model` now warns when a latent tilde statement overwrites a value computed from a model input.
 The check runs only when ForwardDiff is loaded and is best effort, so it can miss dependencies through untaken branches, conditions, and code it cannot differentiate.
 See [#1465](https://github.com/TuringLang/DynamicPPL.jl/pull/1465).

--- a/ext/DynamicPPLMCMCChainsExt.jl
+++ b/ext/DynamicPPLMCMCChainsExt.jl
@@ -208,12 +208,24 @@ function AbstractMCMC.bundle_samples(
 end
 
 """
+    chunk_ranges(n::Int, nchunks::Int)
+
+Split `1:n` into at most `nchunks` contiguous ranges of as equal length as possible.
+"""
+function chunk_ranges(n::Int, nchunks::Int)
+    nchunks = min(nchunks, n)
+    bounds = round.(Int, range(0, n; length=(nchunks + 1)))
+    return [(bounds[i] + 1):bounds[i + 1] for i in 1:nchunks]
+end
+
+"""
     reevaluate_with_chain(
         rng::AbstractRNG,
         model::Model,
         chain::MCMCChains.Chains
         accs::NTuple{N,AbstractAccumulator};
         fallback=nothing,
+        multithreaded=false,
     )
 
 Re-evaluate `model` for each sample in `chain` using the accumulators provided in `accs`,
@@ -224,37 +236,67 @@ initialisation strategy when re-evaluating the model. For many usecases the fall
 not be provided (as we expect the chain to contain all necessary variables); but for
 `predict` this has to be `InitFromPrior()` to allow sampling new variables (i.e. generating
 the posterior predictions).
+
+Set `multithreaded = true` to spread the samples over threads. Each sample is then evaluated
+with its own random number generator, seeded from `rng` before any thread starts, so the
+result is reproducible and does not depend on the number of threads. It does differ from the
+single-threaded result for the same `rng`, which draws every sample from one stream.
 """
 function reevaluate_with_chain(
     rng::Random.AbstractRNG,
     model::DynamicPPL.Model,
     chain::MCMCChains.Chains,
     accs::NTuple{N,DynamicPPL.AbstractAccumulator},
-    fallback::Union{DynamicPPL.AbstractInitStrategy,Nothing}=nothing,
+    fallback::Union{DynamicPPL.AbstractInitStrategy,Nothing}=nothing;
+    multithreaded::Bool=false,
 ) where {N}
     params_with_stats = AbstractMCMC.to_samples(DynamicPPL.ParamsWithStats, chain, model)
     vi = DynamicPPL.OnlyAccsVarInfo(DynamicPPL.AccumulatorTuple(accs))
-    return map(params_with_stats) do ps
-        DynamicPPL.init!!(
-            rng,
+    function evaluate(r, v, ps)
+        return DynamicPPL.init!!(
+            r,
             model,
-            vi,
+            v,
             DynamicPPL.InitFromParams(ps.params, fallback),
             DynamicPPL.UnlinkAll(),
         )
     end
+    if !multithreaded || isempty(params_with_stats)
+        return map(ps -> evaluate(rng, vi, ps), params_with_stats)
+    end
+    seeds = rand(rng, UInt, length(params_with_stats))
+    tasks = map(chunk_ranges(length(params_with_stats), Threads.nthreads())) do idxs
+        # An accumulator may hold mutable state, so no two tasks share a varinfo. `copy`
+        # rather than `deepcopy` for the rng: https://github.com/JuliaLang/julia/issues/42899
+        Threads.@spawn let task_rng = copy(rng), task_vi = copy(vi)
+            map(idxs) do i
+                Random.seed!(task_rng, seeds[i])
+                evaluate(task_rng, task_vi, params_with_stats[i])
+            end
+        end
+    end
+    return reshape(reduce(vcat, fetch.(tasks)), size(params_with_stats))
 end
 function reevaluate_with_chain(
     model::DynamicPPL.Model,
     chain::MCMCChains.Chains,
     accs::NTuple{N,DynamicPPL.AbstractAccumulator},
-    fallback::Union{DynamicPPL.AbstractInitStrategy,Nothing}=nothing,
+    fallback::Union{DynamicPPL.AbstractInitStrategy,Nothing}=nothing;
+    multithreaded::Bool=false,
 ) where {N}
-    return reevaluate_with_chain(Random.default_rng(), model, chain, accs, fallback)
+    return reevaluate_with_chain(
+        Random.default_rng(), model, chain, accs, fallback; multithreaded=multithreaded
+    )
 end
 
 """
-    predict([rng::AbstractRNG,] model::Model, chain::MCMCChains.Chains; include_all=false)
+    predict(
+        [rng::AbstractRNG,]
+        model::Model,
+        chain::MCMCChains.Chains;
+        include_all=false,
+        multithreaded=false,
+    )
 
 Sample from the posterior predictive distribution by executing `model` with parameters fixed to each sample
 in `chain`, and return the resulting `Chains`.
@@ -272,6 +314,14 @@ For each parameter configuration in `chain`:
 If `include_all` is `false`, the returned `Chains` will contain only those variables that were not fixed by
 the samples in `chain`. This is useful when you want to sample only new variables from the posterior
 predictive distribution.
+
+Set `multithreaded` to `true` to spread the samples of `chain` over threads. Each sample is
+then drawn with its own random number generator, seeded from `rng` before any thread starts,
+so a given `rng` gives the same predictions however many threads Julia was started with.
+Those predictions differ from the single-threaded ones for that same `rng`, which draws
+every sample from one stream. Threading only pays off when evaluating the model is itself
+expensive: it is a loss for a model that evaluates in microseconds, and for a model with
+many variables the time goes into building the `Chains` object rather than into evaluation.
 
 !!! warning "Variables are treated as they occur in the model"
     A variable drawn from a multivariate distribution in a single tilde-statement
@@ -329,6 +379,7 @@ function DynamicPPL.predict(
     model::DynamicPPL.Model,
     chain::MCMCChains.Chains;
     include_all=false,
+    multithreaded::Bool=false,
 )
     parameter_only_chain = MCMCChains.get_sections(chain, :parameters)
     accs = (
@@ -339,7 +390,12 @@ function DynamicPPL.predict(
     predictions = map(
         DynamicPPL.ParamsWithStats ∘ last,
         reevaluate_with_chain(
-            rng, model, parameter_only_chain, accs, DynamicPPL.InitFromPrior()
+            rng,
+            model,
+            parameter_only_chain,
+            accs,
+            DynamicPPL.InitFromPrior();
+            multithreaded=multithreaded,
         ),
     )
     chain_result = AbstractMCMC.from_samples(MCMCChains.Chains, predictions)
@@ -354,10 +410,17 @@ function DynamicPPL.predict(
     return chain_result[parameter_names]
 end
 function DynamicPPL.predict(
-    model::DynamicPPL.Model, chain::MCMCChains.Chains; include_all=false
+    model::DynamicPPL.Model,
+    chain::MCMCChains.Chains;
+    include_all=false,
+    multithreaded::Bool=false,
 )
     return DynamicPPL.predict(
-        DynamicPPL.Random.default_rng(), model, chain; include_all=include_all
+        DynamicPPL.Random.default_rng(),
+        model,
+        chain;
+        include_all=include_all,
+        multithreaded=multithreaded,
     )
 end
 

--- a/ext/DynamicPPLMCMCChainsExt.jl
+++ b/ext/DynamicPPLMCMCChainsExt.jl
@@ -266,12 +266,12 @@ function reevaluate_with_chain(
     end
     seeds = rand(rng, UInt, length(params_with_stats))
     tasks = map(chunk_ranges(length(params_with_stats), Threads.nthreads())) do idxs
-        # An accumulator may hold mutable state, so no two tasks share a varinfo. `copy`
-        # rather than `deepcopy` for the rng: https://github.com/JuliaLang/julia/issues/42899
-        Threads.@spawn let task_rng = copy(rng), task_vi = copy(vi)
+        # An accumulator may hold mutable state, so no two tasks share a varinfo. Each sample
+        # gets a fresh generator built from its own seed, so `rng` only has to produce the
+        # seeds: copying it would rule out generators such as `RandomDevice`.
+        Threads.@spawn let task_vi = copy(vi)
             map(idxs) do i
-                Random.seed!(task_rng, seeds[i])
-                evaluate(task_rng, task_vi, params_with_stats[i])
+                evaluate(Random.Xoshiro(seeds[i]), task_vi, params_with_stats[i])
             end
         end
     end

--- a/ext/DynamicPPLMCMCChainsExt.jl
+++ b/ext/DynamicPPLMCMCChainsExt.jl
@@ -282,10 +282,10 @@ function reevaluate_with_chain(
     chain::MCMCChains.Chains,
     accs::NTuple{N,DynamicPPL.AbstractAccumulator},
     fallback::Union{DynamicPPL.AbstractInitStrategy,Nothing}=nothing;
-    multithreaded::Bool=false,
+    kwargs...,
 ) where {N}
     return reevaluate_with_chain(
-        Random.default_rng(), model, chain, accs, fallback; multithreaded=multithreaded
+        Random.default_rng(), model, chain, accs, fallback; kwargs...
     )
 end
 
@@ -409,19 +409,8 @@ function DynamicPPL.predict(
     end
     return chain_result[parameter_names]
 end
-function DynamicPPL.predict(
-    model::DynamicPPL.Model,
-    chain::MCMCChains.Chains;
-    include_all=false,
-    multithreaded::Bool=false,
-)
-    return DynamicPPL.predict(
-        DynamicPPL.Random.default_rng(),
-        model,
-        chain;
-        include_all=include_all,
-        multithreaded=multithreaded,
-    )
+function DynamicPPL.predict(model::DynamicPPL.Model, chain::MCMCChains.Chains; kwargs...)
+    return DynamicPPL.predict(DynamicPPL.Random.default_rng(), model, chain; kwargs...)
 end
 
 """

--- a/test/model.jl
+++ b/test/model.jl
@@ -640,6 +640,12 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
                 )
                 @test size(mt3, 3) == size(multiple_β_chain, 3)
                 @test Set(keys(mt3)) == Set(keys(predictions))
+
+                # `RandomDevice` cannot be copied, and only has to supply the seeds.
+                mt4 = DynamicPPL.predict(
+                    Random.RandomDevice(), m_lin_reg_test, β_chain; multithreaded=true
+                )
+                @test Set(keys(mt4)) == Set(keys(predictions))
             end
 
             @testset "predictions with subsetted chain" begin

--- a/test/model.jl
+++ b/test/model.jl
@@ -585,13 +585,14 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
                 @test ys_pred_vec[2] ≈ ground_truth_β * xs_test[2] atol = 0.01
             end
 
+            # Normal linreg model
+            multiple_β_chain = MCMCChains.Chains(
+                reshape(rand(Normal(ground_truth_β, 0.002), 1000, 2), 1000, 1, 2),
+                [:β];
+                info=(; varname_to_symbol=Dict(@varname(β) => :β)),
+            )
+
             @testset "prediction from multiple chains" begin
-                # Normal linreg model
-                multiple_β_chain = MCMCChains.Chains(
-                    reshape(rand(Normal(ground_truth_β, 0.002), 1000, 2), 1000, 1, 2),
-                    [:β];
-                    info=(; varname_to_symbol=Dict(@varname(β) => :β)),
-                )
                 predictions = DynamicPPL.predict(m_lin_reg_test, multiple_β_chain)
                 @test size(multiple_β_chain, 3) == size(predictions, 3)
 
@@ -634,15 +635,10 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
                 @test ys_pred[1] ≈ ground_truth_β * xs_test[1] atol = 0.01
                 @test ys_pred[2] ≈ ground_truth_β * xs_test[2] atol = 0.01
 
-                two_chains = MCMCChains.Chains(
-                    reshape(rand(Normal(ground_truth_β, 0.002), 1000, 2), 1000, 1, 2),
-                    [:β];
-                    info=(; varname_to_symbol=Dict(@varname(β) => :β)),
-                )
                 mt3 = DynamicPPL.predict(
-                    Xoshiro(468), m_lin_reg_test, two_chains; multithreaded=true
+                    Xoshiro(468), m_lin_reg_test, multiple_β_chain; multithreaded=true
                 )
-                @test size(mt3, 3) == size(two_chains, 3)
+                @test size(mt3, 3) == size(multiple_β_chain, 3)
                 @test Set(keys(mt3)) == Set(keys(predictions))
             end
 

--- a/test/model.jl
+++ b/test/model.jl
@@ -621,6 +621,31 @@ const GDEMO_DEFAULT = DynamicPPL.TestUtils.demo_assume_observe_literal()
                 end
             end
 
+            @testset "multithreaded" begin
+                mt1 = DynamicPPL.predict(
+                    Xoshiro(468), m_lin_reg_test, β_chain; multithreaded=true
+                )
+                mt2 = DynamicPPL.predict(
+                    Xoshiro(468), m_lin_reg_test, β_chain; multithreaded=true
+                )
+                @test Array(mt1) == Array(mt2)
+                @test Set(keys(mt1)) == Set(keys(predictions))
+                ys_pred = vec(mean(Array(MCMCChains.group(mt1, :y)); dims=1))
+                @test ys_pred[1] ≈ ground_truth_β * xs_test[1] atol = 0.01
+                @test ys_pred[2] ≈ ground_truth_β * xs_test[2] atol = 0.01
+
+                two_chains = MCMCChains.Chains(
+                    reshape(rand(Normal(ground_truth_β, 0.002), 1000, 2), 1000, 1, 2),
+                    [:β];
+                    info=(; varname_to_symbol=Dict(@varname(β) => :β)),
+                )
+                mt3 = DynamicPPL.predict(
+                    Xoshiro(468), m_lin_reg_test, two_chains; multithreaded=true
+                )
+                @test size(mt3, 3) == size(two_chains, 3)
+                @test Set(keys(mt3)) == Set(keys(predictions))
+            end
+
             @testset "predictions with subsetted chain" begin
                 @model function f()
                     a ~ Normal()


### PR DESCRIPTION
Closes #1170.

`predict` is the only one of the six callers of `reevaluate_with_chain` that draws from the rng.
The other five pass `fallback=nothing`, and `init` then errors rather than drawing, so they never touch it.

Handing one rng to several tasks is a data race, and it would also break the two tests that assert a fixed seed reproduces, at [test/model.jl#L555-L562](https://github.com/TuringLang/DynamicPPL.jl/blob/3e56270e0bb4be1a3c4b0e51e0ba0f16d0e8b48d/test/model.jl#L555-L562) and [test/model.jl#L571-L576](https://github.com/TuringLang/DynamicPPL.jl/blob/3e56270e0bb4be1a3c4b0e51e0ba0f16d0e8b48d/test/model.jl#L571-L576).
The seeds are therefore drawn from `rng` before any thread starts, one per sample, the way AbstractMCMC seeds parallel chains.
Predictions are then reproducible and independent of the thread count.
They do differ from the single-threaded predictions for the same seed, because one stream cannot be replayed out of order, and that difference is why this is opt-in rather than the default.

Each task also gets its own varinfo.
Every accumulator used here is immutable, but a user-supplied accumulator holding mutable state would otherwise be shared across threads.

How much it buys depends on what dominates.
Over 4000 samples, 1000 iterations by 4 chains, on Julia 1.11 with 4 threads:

| model | predict | predict, threaded | map | map, threaded | from_samples |
|---|---|---|---|---|---|
| 2 variables, 5 predicted | 49.5 ms | 48.7 ms | 7.2 ms | 5.0 ms | 41.2 ms |
| 2 variables, 200 predicted | 1063 ms | 967 ms | 274 ms | 145 ms | 782 ms |
| expensive evaluation, 5 predicted | 514 ms | 247 ms | 476 ms | 173 ms | 34 ms |

The map itself gains 1.4x to 2.8x, but it is only 15% to 26% of `predict` unless evaluating the model is the expensive part, so end to end that is 1.02x, 1.1x and 2.1x.
Constructing the `Chains` object is 74% to 83% of the first two rows and looks like the better target for a follow-up.

The same keyword would suit `logjoint`, `logprior`, `loglikelihood`, `returned` and `pointwise_logdensities`, with no seeding needed.
Say if you would like them here.