### PR TITLE
varnamedtuple: resolve dynamic indices in membership checks

### DIFF
--- a/src/subsample.jl
+++ b/src/subsample.jl
@@ -746,7 +746,7 @@ Base.length(::SubsamplingShape) = _throw_full_data_access()
 function VarNamedTuples._haskey_optic(
     data::SubsamplingShape, optic::VarNamedTuples.IndexWithoutChild
 )
-    return checkbounds(Bool, data.data, optic.ix...; optic.kw...)
+    return VarNamedTuples._haskey_optic(data.data, optic)
 end
 function Base.getindex(data::SubsamplingShape, indices...)
     return SubsamplingShape(view(data.data, indices...), data.root)

--- a/src/varnamedtuple/getset.jl
+++ b/src/varnamedtuple/getset.jl
@@ -91,15 +91,16 @@ function _haskey_optic(pa::PartialArray, ::AbstractPPL.Iden)
     end
 end
 function _haskey_optic(pa::PartialArray, optic::AbstractPPL.Index)
+    coptic = AbstractPPL.concretize_top_level(optic, pa.data)
     # check the top level Index
-    Base.haskey(pa, optic.ix...; optic.kw...) || return false
+    Base.haskey(pa, coptic.ix...; coptic.kw...) || return false
     # recurse if necessary
     return if optic.child isa AbstractPPL.Iden
         true
-    elseif _is_multiindex(pa, optic.ix...; optic.kw...)
-        _haskey_optic(_subset_partialarray(pa, optic.ix...; optic.kw...), optic.child)
+    elseif _is_multiindex(pa, coptic.ix...; coptic.kw...)
+        _haskey_optic(_subset_partialarray(pa, coptic.ix...; coptic.kw...), optic.child)
     else
-        _haskey_optic(getindex(pa, optic.ix...; optic.kw...), optic.child)
+        _haskey_optic(getindex(pa, coptic.ix...; coptic.kw...), optic.child)
     end
 end
 function _haskey_optic(arr::AbstractArray, optic::IndexWithoutChild)

--- a/src/varnamedtuple/getset.jl
+++ b/src/varnamedtuple/getset.jl
@@ -108,7 +108,8 @@ function _haskey_optic(arr::AbstractArray, optic::IndexWithoutChild)
     # checkbounds. For example, DimArray can error here:
     # https://github.com/rafaqz/DimensionalData.jl/issues/1156. But that is not our job to fix
     # -- it should be done upstream -- hence we just forward the indices.
-    return checkbounds(Bool, arr, optic.ix...; optic.kw...)
+    coptic = AbstractPPL.concretize_top_level(optic, arr)
+    return checkbounds(Bool, arr, coptic.ix...; coptic.kw...)
 end
 
 """

--- a/test/subsample.jl
+++ b/test/subsample.jl
@@ -57,6 +57,21 @@ function independent_problem(model, dataset_size; transform_strategy=UnlinkAll()
 end
 
 @testset "Subsampling" begin
+    @testset "shape membership" begin
+        for data in ([1.0, 2.0], view([1.0, 2.0, 3.0], 2:3))
+            shape = DynamicPPL.SubsamplingShape(data)
+            values = VarNamedTuple(; x=shape)
+            @test haskey(values, @varname(x[begin]))
+            @test haskey(values, @varname(x[end]))
+            @test haskey(values, @varname(x[begin:end]))
+            @test !haskey(values, @varname(x[begin - 1]))
+            @test !haskey(values, @varname(x[end + 1]))
+            for inspect in (size, axes, length)
+                @test_throws ArgumentError inspect(shape)
+            end
+        end
+    end
+
     @testset "full and batched densities" begin
         data = [-2.0, -1.0, 0.5, 3.0]
         model = normal_location() | (x=data,)

--- a/test/varnamedtuple.jl
+++ b/test/varnamedtuple.jl
@@ -180,6 +180,17 @@ function Base.similar(
 end
 
 @testset "VarNamedTuple" begin
+    @testset "dynamic indices into array leaves" begin
+        for x in ([1.0, 2.0], view([1.0, 2.0], :), OA.OffsetArray([1.0, 2.0], 3:4))
+            vnt = VarNamedTuple(; x)
+            @test haskey(vnt, @varname(x[begin]))
+            @test haskey(vnt, @varname(x[end]))
+            @test haskey(vnt, @varname(x[begin:end]))
+            @test !haskey(vnt, @varname(x[begin - 1]))
+            @test !haskey(vnt, @varname(x[end + 1]))
+        end
+    end
+
     @testset "Construction" begin
         vnt1 = VarNamedTuple()
         test_invariants(vnt1)

--- a/test/varnamedtuple.jl
+++ b/test/varnamedtuple.jl
@@ -189,6 +189,22 @@ end
             @test !haskey(vnt, @varname(x[begin - 1]))
             @test !haskey(vnt, @varname(x[end + 1]))
         end
+        @test haskey(VarNamedTuple(; x=[1.0 2.0; 3.0 4.0]), @varname(x[end, end]))
+    end
+
+    @testset "dynamic indices into partial array leaves" begin
+        template = [0.0, 0.0]
+        partial = DynamicPPL.templated_setindex!!(
+            VarNamedTuple(), 1.0, @varname(x[1]), template
+        )
+        # `x[2]` is still masked, so the last index is absent and retrieval throws.
+        @test haskey(partial, @varname(x[begin]))
+        @test !haskey(partial, @varname(x[end]))
+        @test_throws BoundsError partial[@varname(x[end])]
+
+        filled = DynamicPPL.templated_setindex!!(partial, 2.0, @varname(x[2]), template)
+        @test haskey(filled, @varname(x[end]))
+        @test filled[@varname(x[end])] == 2.0
     end
 
     @testset "Construction" begin


### PR DESCRIPTION
Resolve `begin` and `end` against the stored array before checking bounds. This currently throws; it should return `true`:

```julia
vnt = VarNamedTuple(; x=[1.0, 2.0])
haskey(vnt, @varname(x[end]))
```

Related history: #1259 covered incomplete-array membership; #61 covered compiler handling of `end`. This fixes a separate failure.

The regression fails on `main`. All 50,424 VarNamedTuple tests pass, including views, offset arrays, and out-of-bounds dynamic indices. Formatted with JuliaFormatter v1.
