### PR TITLE
componentarrays: preserve property indices in VarNamedTuple operations

### DIFF
--- a/ext/DynamicPPLComponentArraysExt.jl
+++ b/ext/DynamicPPLComponentArraysExt.jl
@@ -6,41 +6,23 @@ using DynamicPPL.VarNamedTuples:
     SetPermissions,
     _setindex_optic!!,
     _getindex_optic,
-    make_leaf,
-    make_leaf_singleindex,
-    _is_multiindex,
-    make_leaf_multiindex
-using ComponentArrays: ComponentArrays, ComponentArray, ComponentVector
+    _haskey_optic,
+    make_leaf
+using ComponentArrays: ComponentArrays, ComponentVector
 using AbstractPPL
 
-# Helper: convert a Property optic label S to an integer Index optic
+# Resolve properties through the component axes, including nested fields and slices.
 function _property_to_index(
     template::ComponentVector, optic::AbstractPPL.Property{S}
 ) where {S}
-    ax = ComponentArrays.getaxes(template)[1]
-    idx = first(ax[S].idx)
-    return AbstractPPL.Index((idx,), NamedTuple(), optic.child)
+    indices = ComponentVector(LinearIndices(template), ComponentArrays.getaxes(template))
+    return AbstractPPL.Index((optic(indices),), NamedTuple(), AbstractPPL.Iden())
 end
 
 function DynamicPPL.VarNamedTuples.make_leaf(
     value, optic::AbstractPPL.Property{S}, template::ComponentVector
 ) where {S}
-    return if optic.child isa AbstractPPL.Iden
-        index_optic = _property_to_index(template, optic)
-        make_leaf(value, index_optic, template)
-    else
-        # This branch is needed to handle nested axes in ComponentArrays: the idea is that
-        # if x is e.g. ComponentArray(a=(b=1)) and we are trying to set `x.a.b`, then we
-        # first index into `x.a` to get the slice of the ComponentArray. The easiest way to
-        # handle this is to call the default method.
-        invoke(
-            make_leaf,
-            Tuple{Any,AbstractPPL.Property{S},AbstractArray},
-            value,
-            optic,
-            template,
-        )
-    end
+    return make_leaf(value, _property_to_index(template, optic), template)
 end
 
 function DynamicPPL.VarNamedTuples._setindex_optic!!(
@@ -59,6 +41,13 @@ function DynamicPPL.VarNamedTuples._getindex_optic(
 ) where {S}
     index_optic = _property_to_index(pa.data, optic)
     return _getindex_optic(pa, index_optic, orig_vn)
+end
+
+function DynamicPPL.VarNamedTuples._haskey_optic(
+    pa::PartialArray{<:Any,<:Any,<:ComponentVector}, optic::AbstractPPL.Property{S}
+) where {S}
+    AbstractPPL.canview(optic, pa.data) || return false
+    return _haskey_optic(pa, _property_to_index(pa.data, optic))
 end
 
 end

--- a/ext/DynamicPPLComponentArraysExt.jl
+++ b/ext/DynamicPPLComponentArraysExt.jl
@@ -15,20 +15,23 @@ using AbstractPPL
 function _property_to_index(
     template::ComponentVector, optic::AbstractPPL.Property{S}
 ) where {S}
-    indices = ComponentVector(LinearIndices(template), ComponentArrays.getaxes(template))
+    indices = ComponentVector(
+        LinearIndices(ComponentArrays.getdata(template)), ComponentArrays.getaxes(template)
+    )
     return AbstractPPL.Index(
         (_resolve_indices(optic, indices),), NamedTuple(), AbstractPPL.Iden()
     )
 end
 
-# Properties are looked up through the component axes, but anything below them is applied to
-# a plain array: indexing a ComponentVector with a range is ambiguous between
-# `ComponentArrays.getindex(::CombinedAxis, ::AbstractArray)` and Base's range indexing.
+# Resolve child indices against unwrapped storage to avoid ComponentArrays'
+# range-indexing ambiguity.
 _resolve_indices(::AbstractPPL.Iden, indices) = indices
 function _resolve_indices(optic::AbstractPPL.Property{S}, indices) where {S}
     return _resolve_indices(optic.child, getproperty(indices, S))
 end
-_resolve_indices(optic::AbstractPPL.AbstractOptic, indices) = optic(collect(indices))
+function _resolve_indices(optic::AbstractPPL.AbstractOptic, indices)
+    return optic(ComponentArrays.getdata(indices))
+end
 
 function DynamicPPL.VarNamedTuples.make_leaf(
     value, optic::AbstractPPL.Property{S}, template::ComponentVector
@@ -57,7 +60,10 @@ end
 function DynamicPPL.VarNamedTuples._haskey_optic(
     pa::PartialArray{<:Any,<:Any,<:ComponentVector}, optic::AbstractPPL.Property{S}
 ) where {S}
-    AbstractPPL.canview(optic, pa.data) || return false
+    indices = ComponentVector(
+        LinearIndices(ComponentArrays.getdata(pa.data)), ComponentArrays.getaxes(pa.data)
+    )
+    AbstractPPL.canview(optic, indices) || return false
     return _haskey_optic(pa, _property_to_index(pa.data, optic))
 end
 

--- a/ext/DynamicPPLComponentArraysExt.jl
+++ b/ext/DynamicPPLComponentArraysExt.jl
@@ -16,8 +16,19 @@ function _property_to_index(
     template::ComponentVector, optic::AbstractPPL.Property{S}
 ) where {S}
     indices = ComponentVector(LinearIndices(template), ComponentArrays.getaxes(template))
-    return AbstractPPL.Index((optic(indices),), NamedTuple(), AbstractPPL.Iden())
+    return AbstractPPL.Index(
+        (_resolve_indices(optic, indices),), NamedTuple(), AbstractPPL.Iden()
+    )
 end
+
+# Properties are looked up through the component axes, but anything below them is applied to
+# a plain array: indexing a ComponentVector with a range is ambiguous between
+# `ComponentArrays.getindex(::CombinedAxis, ::AbstractArray)` and Base's range indexing.
+_resolve_indices(::AbstractPPL.Iden, indices) = indices
+function _resolve_indices(optic::AbstractPPL.Property{S}, indices) where {S}
+    return _resolve_indices(optic.child, getproperty(indices, S))
+end
+_resolve_indices(optic::AbstractPPL.AbstractOptic, indices) = optic(collect(indices))
 
 function DynamicPPL.VarNamedTuples.make_leaf(
     value, optic::AbstractPPL.Property{S}, template::ComponentVector

--- a/test/varnamedtuple.jl
+++ b/test/varnamedtuple.jl
@@ -365,6 +365,48 @@ end
         end
 
         @testset "ComponentArray" begin
+            @testset "ComponentVector property membership and updates" begin
+                for (template, property, index, value) in (
+                    (
+                        CA.ComponentVector(; a=1.0, b=2.0),
+                        @varname(x.b),
+                        @varname(x[2]),
+                        3.0,
+                    ),
+                    (
+                        CA.ComponentVector(; a=[1.0, 2.0], b=3.0),
+                        @varname(x.a),
+                        @varname(x[1:2]),
+                        [4.0, 5.0],
+                    ),
+                    (
+                        CA.ComponentVector(; a=(; b=[1.0, 2.0]), c=3.0),
+                        @varname(x.a.b[2]),
+                        @varname(x[2]),
+                        4.0,
+                    ),
+                    (
+                        CA.ComponentVector(; a=(; b=[1.0, 2.0]), c=3.0),
+                        @varname(x.a.b),
+                        @varname(x[1:2]),
+                        [4.0, 5.0],
+                    ),
+                )
+                    for set_vn in (property, index)
+                        vnt = templated_setindex!!(VarNamedTuple(), value, set_vn, template)
+                        for get_vn in (property, index)
+                            @test haskey(vnt, get_vn)
+                            @test vnt[get_vn] == value
+                            updated = templated_setindex!!(
+                                copy(vnt), 2 .* value, get_vn, template
+                            )
+                            @test updated[property] == updated[index] == 2 .* value
+                        end
+                        @test !haskey(vnt, @varname(x.absent))
+                    end
+                end
+            end
+
             ca = CA.ComponentArray(; a=1.0, b=2.0)
             test_get_set(GetSetTestCase(@varname(x[1]), 1.0, ca, []))
             test_get_set(GetSetTestCase(@varname(x[2]), 2.0, ca, []))

--- a/test/varnamedtuple.jl
+++ b/test/varnamedtuple.jl
@@ -419,6 +419,21 @@ end
                 end
             end
 
+            @testset "Unset component properties" begin
+                for (template, unset) in (
+                    (CA.ComponentVector(; a="a", b="b"), @varname(x.b)),
+                    (CA.ComponentVector(; a="a", b=["b", "c"]), @varname(x.b[1])),
+                    (CA.ComponentVector(; a="a", b=(; c="c")), @varname(x.b.c)),
+                )
+                    vnt = templated_setindex!!(
+                        VarNamedTuple(), "set", @varname(x.a), template
+                    )
+                    @test haskey(vnt, @varname(x.a))
+                    @test !haskey(vnt, unset)
+                    @test !haskey(vnt, @varname(x[2]))
+                end
+            end
+
             ca = CA.ComponentArray(; a=1.0, b=2.0)
             test_get_set(GetSetTestCase(@varname(x[1]), 1.0, ca, []))
             test_get_set(GetSetTestCase(@varname(x[2]), 2.0, ca, []))

--- a/test/varnamedtuple.jl
+++ b/test/varnamedtuple.jl
@@ -391,6 +391,18 @@ end
                         @varname(x[1:2]),
                         [4.0, 5.0],
                     ),
+                    (
+                        CA.ComponentVector(; a=[1.0, 2.0, 3.0], b=4.0),
+                        @varname(x.a[1:2]),
+                        @varname(x[1:2]),
+                        [5.0, 6.0],
+                    ),
+                    (
+                        CA.ComponentVector(; a=(; b=[1.0, 2.0, 3.0]), c=4.0),
+                        @varname(x.a.b[2:3]),
+                        @varname(x[2:3]),
+                        [5.0, 6.0],
+                    ),
                 )
                     for set_vn in (property, index)
                         vnt = templated_setindex!!(VarNamedTuple(), value, set_vn, template)


### PR DESCRIPTION
Resolve ComponentVector properties through their axes, preserving nested fields and array-valued slices. Membership should agree with retrieval:

```julia
template = ComponentVector(a=[1.0, 2.0], b=3.0)
vn = @varname(x.a)
vnt = DynamicPPL.templated_setindex!!(
    VarNamedTuple(), [4.0, 5.0], vn, template
)
@assert haskey(vnt, vn)
```

Currently, retrieval succeeds but the assertion fails. Follows up on #1230.

Regressions fail on `main`; all 50,477 VarNamedTuple tests pass with the fix, including reads, updates, and membership through equivalent property and integer indices. Formatted with JuliaFormatter v1.
