### PR TITLE
distributions: remove `NamedDist`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+Removed `NamedDist` and distribution-driven site renaming. Replace `x ~ NamedDist(dist, :y)` with `y ~ dist`, followed by `x = y` if a local alias is needed.
+
 # 0.42.12
 
 `check_model` now warns when a latent tilde statement overwrites a value computed from a model input.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -208,7 +208,6 @@ extract_priors
 filldist
 arraydist
 independent_distribution
-NamedDist
 ```
 
 ## Distributions

--- a/src/DynamicPPL.jl
+++ b/src/DynamicPPL.jl
@@ -190,7 +190,6 @@ export AbstractVarInfo,
     invlink,
     invlink!!,
     # Pseudo distributions
-    NamedDist,
     NoDist,
     filldist,
     arraydist,

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -187,60 +187,6 @@ function check_dot_tilde_rhs(::AbstractArray{<:Distribution})
 end
 check_dot_tilde_rhs(x::UnivariateDistribution) = x
 
-"""
-    unwrap_right_vn(right, vn)
-
-Return the unwrapped distribution on the right-hand side and variable name on the left-hand
-side of a `~` expression such as `x ~ Normal()`.
-
-This is used mainly to unwrap `NamedDist` distributions.
-"""
-unwrap_right_vn(right, vn) = right, vn
-unwrap_right_vn(right::NamedDist, vn) = unwrap_right_vn(right.dist, right.name)
-
-"""
-    unwrap_right_left_vns(right, left, vns)
-
-Return the unwrapped distributions on the right-hand side and values and variable names on the
-left-hand side of a `.~` expression such as `x .~ Normal()`.
-
-This is used mainly to unwrap `NamedDist` distributions and adjust the indices of the
-variables.
-
-# Example
-```jldoctest; setup=:(using Distributions, LinearAlgebra)
-julia> _, _, vns = DynamicPPL.unwrap_right_left_vns(Normal(), randn(1, 2), @varname(x)); vns[end]
-x[1, 2]
-
-julia> _, _, vns = DynamicPPL.unwrap_right_left_vns(Normal(), randn(1, 2), @varname(x[:])); vns[end]
-x[:][1, 2]
-
-julia> _, _, vns = DynamicPPL.unwrap_right_left_vns(Normal(), randn(3), @varname(x[1])); vns[end]
-x[1][3]
-```
-"""
-unwrap_right_left_vns(right, left, vns) = right, left, vns
-function unwrap_right_left_vns(right::NamedDist, left::AbstractArray, ::VarName)
-    return unwrap_right_left_vns(right.dist, left, right.name)
-end
-function unwrap_right_left_vns(right::NamedDist, left::AbstractMatrix, ::VarName)
-    return unwrap_right_left_vns(right.dist, left, right.name)
-end
-function unwrap_right_left_vns(
-    right::Union{Distribution,AbstractArray{<:Distribution}},
-    left::AbstractArray,
-    vn::VarName,
-)
-    vns = map(CartesianIndices(left)) do i
-        sym, optic = getsym(vn), getoptic(vn)
-        return VarName{sym}(AbstractPPL.Index(Tuple(i), (;), AbstractPPL.Iden()) ∘ optic)
-    end
-    return unwrap_right_left_vns(right, left, vns)
-end
-
-resolve_varnames(vn::VarName, _) = vn
-resolve_varnames(::VarName, dist::NamedDist) = dist.name
-
 #################
 # Main Compiler #
 #################
@@ -514,7 +460,7 @@ function generate_tilde(left, right)
 
     return quote
         $dist = $right
-        $vn = $(DynamicPPL.resolve_varnames)($(make_varname_expression(left)), $dist)
+        $vn = $(make_varname_expression(left))
         $isassumption = $(DynamicPPL.isassumption(left, vn))
         # TODO(penelopeysm): VERY HACKY WORKAROUND FOR SUBMODELS. See src/submodel.jl
         # tilde_observe!! for more details.
@@ -614,7 +560,8 @@ function generate_tilde_assume(left, right, vn)
     return quote
         $value, __varinfo__ = $(DynamicPPL.tilde_assume!!)(
             __model__.context,
-            $(DynamicPPL.unwrap_right_vn)($(DynamicPPL.check_tilde_rhs)($right), $vn)...,
+            $(DynamicPPL.check_tilde_rhs)($right),
+            $vn,
             $template,
             __varinfo__,
         )

--- a/src/distribution_wrappers.jl
+++ b/src/distribution_wrappers.jl
@@ -9,45 +9,10 @@ using Distributions:
     UnivariateDistribution
 using FillArrays: Fill
 
-"""
-    NamedDist(dist::Distribution, name::Symbol)
-
-A named distribution that carries the name of the random variable with it.
-
-# Fields
-
-$(TYPEDFIELDS)
-"""
-struct NamedDist{variate,support,Td<:Distribution{variate,support},Tv<:VarName} <:
-       Distribution{variate,support}
-    "the underlying distribution"
-    dist::Td
-    "the name of the random variable"
-    name::Tv
-end
-
-NamedDist(dist::Distribution, name::Symbol) = NamedDist(dist, VarName{name}())
-
-Distributions.logpdf(dist::NamedDist, x::Real) = Distributions.logpdf(dist.dist, x)
-function Distributions.logpdf(dist::NamedDist, x::AbstractArray{<:Real,0})
-    # extract the singleton value from 0-dimensional array
-    return Distributions.logpdf(dist.dist, first(x))
-end
-function Distributions.logpdf(dist::NamedDist, x::AbstractArray{<:Real})
-    return Distributions.logpdf(dist.dist, x)
-end
-function Distributions.loglikelihood(dist::NamedDist, x::Real)
-    return Distributions.loglikelihood(dist.dist, x)
-end
-function Distributions.loglikelihood(dist::NamedDist, x::AbstractArray{<:Real})
-    return Distributions.loglikelihood(dist.dist, x)
-end
-
 struct NoDist{variate,support,Td<:Distribution{variate,support}} <:
        Distribution{variate,support}
     dist::Td
 end
-NoDist(dist::NamedDist) = NamedDist(NoDist(dist.dist), dist.name)
 
 nodist(dist::Distribution) = NoDist(dist)
 nodist(dists::AbstractArray) = nodist.(dists)
@@ -86,7 +51,6 @@ for f in (
     :(Distributions.maximum),
 )
     @eval $f(d::NoDist) = $f(d.dist)
-    @eval $f(d::NamedDist) = $f(d.dist)
 end
 
 """

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -395,27 +395,16 @@ end
         @test getlogjoint(varinfo) == lp
     end
 
-    @testset "user-defined variable name" begin
-        @model f1() = x ~ NamedDist(Normal(), :y)
-        @model f2() = x ~ NamedDist(Normal(), @varname(z))
-        @model f3() = x ~ NamedDist(Normal(), @varname(w.x))
-        vi1 = VarInfo(f1())
-        vi2 = VarInfo(f2())
-        vi3 = VarInfo(f3())
-        @test only(Base.keys(vi1)) == @varname(y)
-        @test only(Base.keys(vi2)) == @varname(z)
-        @test only(Base.keys(vi3)) == @varname(w.x)
-
-        # Conditioning
-        f1_c = f1() | (y=1,)
-        f2_c = f2() | Dict(@varname(z) => 1)
-        f3_c = f3() | Dict(@varname(w.x) => 1)
-        @test f1_c() == 1
-        @test f2_c() == 1
-        @test f3_c() == 1
-        @test getlogjoint(VarInfo(f1_c)) ==
-            getlogjoint(VarInfo(f2_c)) ==
-            getlogjoint(VarInfo(f3_c))
+    @testset "tilde names follow the left-hand side" begin
+        @model function named_site()
+            y ~ Normal()
+            x = y
+            return x
+        end
+        @test only(keys(VarInfo(named_site()))) == @varname(y)
+        observed = condition(named_site(); y=2.0)
+        @test observed() == 2.0
+        @test loglikelihood(observed, VarNamedTuple()) == logpdf(Normal(), 2.0)
     end
 
     @testset "custom tilde" begin


### PR DESCRIPTION
Remove `NamedDist` and its compiler handling. Replace:

```julia
x ~ NamedDist(Normal(), :y)
```

with:

```julia
y ~ Normal()
x = y
```

This is a breaking change; the changelog documents migration. Addresses the removal proposed in #759 and #400, which was closed as a duplicate. Distribution-level `prefix` and a replacement for programmatically generated names remain outside this change.

All 355 compiler, distribution, and input-provenance checks pass with REPL loaded for the existing docstring test. Formatted with JuliaFormatter v1.
